### PR TITLE
fix: bind Codex sessions to exact child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.9.2 - 2026-07-13
+
+### Fixed
+
+- **Codex worker sessions stay bound to the child that created them.** Fresh
+  Codex runs now capture `thread.started.thread_id` directly from that child's
+  JSONL stdout and use that exact ID for transient resume and dependent-task
+  hot chaining. Yardlet no longer guesses from the most recently modified file
+  under the global `~/.codex/sessions` directory, which could attach a
+  concurrently active Codex Desktop conversation to an unrelated Yardlet run.
+  Missing or malformed child session events now fail closed by disabling retry
+  and hot chaining for that run instead of selecting another session.
+
 ## 0.9.1 - 2026-07-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,7 +1103,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yardlet"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yardlet"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.82"
 description = "Yardlet: a local AI workbench. Plan, queue, route, validate, and hand off long-running work using your already-installed Codex and Claude Code CLIs as hidden workers."

--- a/src/run.rs
+++ b/src/run.rs
@@ -550,7 +550,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     }
 
     // Session id for resume-on-transient: claude lets us set one up front; codex
-    // generates its own, captured from its rollout file after the run starts.
+    // generates its own, captured from that child's JSONL stdout.
     let log_path = run_dir.join("worker-output.log");
     let mut effective_chained = chained;
     let mut session_id: Option<String> = if chained {
@@ -567,7 +567,6 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     // are not attributed as worker deliverables.
     let run_excludes = vec![run_dir.clone()];
     let baseline_fp = evaluator::run_fingerprints(&ws.root, &run_excludes);
-    let started_sys = std::time::SystemTime::now();
     let run_started = std::time::Instant::now();
     let mut outcome = workers::spawn(
         &eff_profile,
@@ -583,7 +582,13 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         chained,
     )?;
     if active_worker_id == "codex" && session_id.is_none() {
-        session_id = find_codex_session(started_sys);
+        session_id = outcome.session_id.clone();
+        if session_id.is_none() {
+            lines.push(
+                "codex session id missing from child stdout; retry and hot-chain disabled"
+                    .to_string(),
+            );
+        }
     }
     // Resume on a transient failure (e.g. a dropped connection) instead of redoing
     // the task from scratch — unless the user stopped it (Esc writes a marker).
@@ -698,7 +703,6 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                     approved,
                 });
                 write_str(&workers::packet_path(&run_dir), &failover_packet)?;
-                let failover_started = SystemTime::now();
                 outcome = workers::spawn(
                     &eff_profile,
                     &active_bin,
@@ -713,7 +717,13 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                     false,
                 )?;
                 if active_worker_id == "codex" && session_id.is_none() {
-                    session_id = find_codex_session(failover_started);
+                    session_id = outcome.session_id.clone();
+                    if session_id.is_none() {
+                        lines.push(
+                            "codex session id missing from child stdout; retry and hot-chain disabled"
+                                .to_string(),
+                        );
+                    }
                 }
                 failover_note = Some(note);
             }
@@ -1409,52 +1419,6 @@ pub(crate) fn gen_session_uuid(seed: &str) -> String {
         &hex[16..20],
         &hex[20..32]
     )
-}
-
-/// Find the codex session id (UUID) for a run started at/after `after`, from its
-/// rollout file under ~/.codex/sessions (named `rollout-<ts>-<uuid>.jsonl`, so
-/// the trailing 36 chars are the id).
-fn find_codex_session(after: std::time::SystemTime) -> Option<String> {
-    fn walk(
-        dir: &std::path::Path,
-        after: std::time::SystemTime,
-        best: &mut Option<(std::time::SystemTime, String)>,
-    ) {
-        let Ok(rd) = std::fs::read_dir(dir) else {
-            return;
-        };
-        for e in rd.flatten() {
-            let p = e.path();
-            if p.is_dir() {
-                walk(&p, after, best);
-                continue;
-            }
-            let Some(stem) = p
-                .file_name()
-                .and_then(|n| n.to_str())
-                .and_then(|n| n.strip_suffix(".jsonl"))
-            else {
-                continue;
-            };
-            if !stem.starts_with("rollout-") || stem.len() < 36 {
-                continue;
-            }
-            let Ok(mt) = e.metadata().and_then(|m| m.modified()) else {
-                continue;
-            };
-            if mt + std::time::Duration::from_secs(3) < after {
-                continue;
-            }
-            if best.as_ref().map(|(t, _)| mt > *t).unwrap_or(true) {
-                *best = Some((mt, stem[stem.len() - 36..].to_string()));
-            }
-        }
-    }
-    let home = std::env::var_os("HOME")?;
-    let base = std::path::Path::new(&home).join(".codex/sessions");
-    let mut best = None;
-    walk(&base, after, &mut best);
-    best.map(|(_, id)| id)
 }
 
 /// A transient (likely network/infra) failure: the worker did not exit cleanly,
@@ -3870,6 +3834,102 @@ printf "# handoff\nattempt %s\n" "$n" > "$run_dir/handoff.md"
         let path = root.join(name);
         write_str(&path, body).unwrap();
         path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_report_session_comes_from_exact_fresh_codex_child() {
+        use std::os::unix::fs::PermissionsExt;
+
+        const EXPECTED_SESSION: &str = "11111111-2222-4333-8444-555555555555";
+        let source = std::env::temp_dir().join(format!(
+            "yard-codex-session-report-src-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&source);
+        std::fs::create_dir_all(&source).unwrap();
+        let fake_codex = write_worker_script(
+            &source,
+            "codex",
+            r#"#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' 'codex-test 0.0.0'
+  exit 0
+fi
+run_dir=
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--add-dir" ]; then
+    shift
+    run_dir=$1
+  fi
+  shift
+done
+if [ -z "$run_dir" ]; then
+  printf '%s\n' 'missing --add-dir' >&2
+  exit 2
+fi
+run_id=${run_dir##*/}
+printf '%s\n' '{"type":"thread.started","thread_id":"11111111-2222-4333-8444-555555555555"}'
+/bin/cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-SESSION",
+  "status": "done",
+  "intent_adherence": { "drift_detected": false, "notes": "" },
+  "changes": { "files_modified": [], "files_created": [], "files_deleted": [] },
+  "validation": { "commands_run": [], "passed": true, "failures": [] },
+  "question_for_user": null,
+  "compact_summary": "session captured",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+/bin/cat > "$run_dir/handoff.md" <<EOF
+# Worker handoff
+session captured
+EOF
+exit 0
+"#,
+        );
+        let mut permissions = std::fs::metadata(&fake_codex).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions).unwrap();
+
+        let worker_yaml = format!(
+            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    invocation:\n      command: {}\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            shell_literal(&fake_codex)
+        );
+        let ws = init_test_workspace("codex-session-report", &worker_yaml);
+        ws.save_queue(&queue(vec![task(
+            "YARD-SESSION",
+            TaskState::Queued,
+            10,
+            false,
+        )]))
+        .unwrap();
+
+        let report = run_next(
+            &ws,
+            &RunOptions {
+                execute: true,
+                target: Some("YARD-SESSION".into()),
+                ..opts()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(report.worker_id, "codex");
+        assert_eq!(report.result_state, Some(TaskState::Done));
+        assert_eq!(
+            report.session.as_deref(),
+            Some(EXPECTED_SESSION),
+            "RunReport must expose only the exact fresh child's stdout thread id"
+        );
+
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
     }
 
     #[test]

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -244,6 +244,55 @@ pub struct WorkerOutcome {
     pub exit_ok: bool,
     pub timed_out: bool,
     pub note: String,
+    /// Exact Codex thread created by this child process. Captured only from
+    /// that child's JSONL stdout; never inferred from global session files.
+    pub session_id: Option<String>,
+}
+
+fn valid_codex_thread_id(id: &str) -> bool {
+    id.len() == 36
+        && id.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            _ => byte.is_ascii_hexdigit(),
+        })
+}
+
+fn codex_thread_id_from_json_line(line: &[u8]) -> Option<String> {
+    let event: serde_json::Value = serde_json::from_slice(line).ok()?;
+    if event.get("type").and_then(|value| value.as_str()) != Some("thread.started") {
+        return None;
+    }
+    event
+        .get("thread_id")
+        .and_then(|value| value.as_str())
+        .filter(|id| valid_codex_thread_id(id))
+        .map(str::to_string)
+}
+
+fn capture_codex_thread_id(
+    pending: &mut Vec<u8>,
+    chunk: &[u8],
+    captured: &std::sync::Arc<std::sync::Mutex<Option<String>>>,
+) {
+    if captured.lock().is_ok_and(|guard| guard.is_some()) {
+        return;
+    }
+    pending.extend_from_slice(chunk);
+    while let Some(newline) = pending.iter().position(|byte| *byte == b'\n') {
+        let line: Vec<u8> = pending.drain(..=newline).collect();
+        if let Some(id) = codex_thread_id_from_json_line(&line) {
+            if let Ok(mut guard) = captured.lock() {
+                *guard = Some(id);
+            }
+            pending.clear();
+            return;
+        }
+    }
+    // `thread.started` is a small leading event. Fail closed instead of
+    // retaining unbounded non-JSON output while waiting for it.
+    if pending.len() > 64 * 1024 {
+        pending.clear();
+    }
 }
 
 /// Spawn a worker with a sanitized environment, feeding the packet on stdin and
@@ -340,23 +389,38 @@ pub fn spawn(
     let log_file = std::sync::Arc::new(std::sync::Mutex::new(
         std::fs::File::create(output_log).ok(),
     ));
-    let mut sources: Vec<Box<dyn Read + Send>> = Vec::new();
+    let captured_session = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let mut sources: Vec<(Box<dyn Read + Send>, bool)> = Vec::new();
     if let Some(o) = child.stdout.take() {
-        sources.push(Box::new(o));
+        sources.push((Box::new(o), profile.id == "codex" && !resume));
     }
     if let Some(e) = child.stderr.take() {
-        sources.push(Box::new(e));
+        sources.push((Box::new(e), false));
     }
     let readers: Vec<_> = sources
         .into_iter()
-        .map(|mut src| {
+        .map(|(mut src, capture_session)| {
             let log = std::sync::Arc::clone(&log_file);
+            let captured = std::sync::Arc::clone(&captured_session);
             thread::spawn(move || {
                 let mut buf = [0u8; 4096];
+                let mut pending = Vec::new();
                 loop {
                     match src.read(&mut buf) {
-                        Ok(0) | Err(_) => break,
+                        Ok(0) | Err(_) => {
+                            if capture_session && !pending.is_empty() {
+                                if let Some(id) = codex_thread_id_from_json_line(&pending) {
+                                    if let Ok(mut guard) = captured.lock() {
+                                        *guard = Some(id);
+                                    }
+                                }
+                            }
+                            break;
+                        }
                         Ok(n) => {
+                            if capture_session {
+                                capture_codex_thread_id(&mut pending, &buf[..n], &captured);
+                            }
                             if let Ok(mut guard) = log.lock() {
                                 if let Some(f) = guard.as_mut() {
                                     let _ = f.write_all(&buf[..n]);
@@ -387,10 +451,15 @@ pub fn spawn(
         let _ = r.join();
     }
     let _ = std::fs::remove_file(&pid_path);
+    let session_id = captured_session
+        .lock()
+        .ok()
+        .and_then(|captured| captured.clone());
 
     Ok(WorkerOutcome {
         exit_ok: status.success() && !timed_out,
         timed_out,
+        session_id,
         note: if timed_out {
             "worker exceeded wall-clock limit and was stopped".to_string()
         } else {
@@ -762,6 +831,104 @@ image_args: ["-i", "{image}"]
         ));
         assert!(cl.windows(2).any(|w| w[0] == "--resume" && w[1] == "SID"));
         assert!(cl.windows(2).any(|w| w[0] == "--model" && w[1] == "opus"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_codex_session_id_comes_from_that_childs_stdout() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root =
+            std::env::temp_dir().join(format!("yard-codex-session-capture-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let fake_codex = root.join("codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"11111111-2222-4333-8444-555555555555"}'
+printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"}' >&2
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&fake_codex).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions).unwrap();
+
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+        )
+        .unwrap();
+        let log = root.join("worker-output.log");
+        let outcome = spawn(
+            &profile,
+            &fake_codex,
+            "packet",
+            &root,
+            &[],
+            &log,
+            Duration::from_secs(5),
+            false,
+            &[],
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert!(outcome.exit_ok);
+        assert_eq!(
+            outcome.session_id.as_deref(),
+            Some("11111111-2222-4333-8444-555555555555"),
+            "only the exact fresh child's stdout may identify its session"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fresh_codex_without_stdout_thread_event_has_no_session_to_resume() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = std::env::temp_dir().join(format!(
+            "yard-codex-session-fail-closed-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let fake_codex = root.join("codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"}' >&2
+"#,
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&fake_codex).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions).unwrap();
+
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+        )
+        .unwrap();
+        let outcome = spawn(
+            &profile,
+            &fake_codex,
+            "packet",
+            &root,
+            &[],
+            &root.join("worker-output.log"),
+            Duration::from_secs(5),
+            false,
+            &[],
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert!(outcome.exit_ok);
+        assert_eq!(outcome.session_id, None);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- capture the exact fresh Codex thread ID from that child process stdout
- remove the global Codex session mtime scan
- fail closed when the child does not emit a valid thread ID
- release as Yardlet v0.9.2

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test
- cargo package --locked --allow-dirty
- cargo publish --dry-run --locked --allow-dirty