### PR TITLE
feat: add durable task channels and steering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Cargo.lock.orig
 # `yardlet init` regenerates it from templates::WORKERS, and untracking it
 # keeps the parallel-mode git preflight green while you tune it.
 /.agents/runs/
+/.agents/task-channels/
 /.agents/checkpoints/
 /.agents/handoffs/
 /.agents/telemetry/

--- a/docs/reviews/v010-003-dogfood.md
+++ b/docs/reviews/v010-003-dogfood.md
@@ -1,0 +1,113 @@
+# V010-003 process dogfood
+
+## 범위와 기준
+
+이 문서는 YARD-007의 제한 remediation 증거다. 규범 기준은
+`docs/v0.10-shared-session-state-contract.md`의 task channel, attempt,
+question/answer, redirect, replay 및 derived index 계약과 task packet의
+AC-001부터 AC-005, SEC-001, SEC-002다.
+
+현재 worktree에는 내부 문서인 `docs/yardlet-roadmap.md`와 run 시작 시점의
+`evidence/repo-summary.md`가 없었다. 따라서 task packet에 보존된 exact failed
+check와 공개 계약 문서를 기준으로 구현 및 검증 범위를 고정했다. 활성 intent,
+queue 및 기존 run history는 수정하거나 fixture 입력으로 사용하지 않았다.
+
+## Red
+
+선행 production red는 `93cf06b`의 parent에서 다음 상태였다.
+
+- `src/parallel.rs`가 `t.has_validation()` task를 ready set에서 제외했다.
+- 당시 `cargo test ready_set_excludes_all_validation_tasks`는 그 잘못된 동작을
+  고정했다.
+- `.agents/task-channels/`는 ignore되지 않았고 attempt raw file은 일반 umask에서
+  private mode를 보장하지 않았다.
+
+`93cf06b`가 이 세 production red를 먼저 보수한 뒤, YARD-007은 누락된 실제-process
+story를 테스트로 추가했다. fixture 구현 전 실행 명령은 다음과 같다.
+
+```bash
+cargo test --test v010_003_task_channels_process -- --nocapture
+```
+
+관찰 결과는 4 pass, 3 fail이었다.
+
+- `native_resume_preserves_session_ref_and_answer_causality`: native session-bearing
+  attempt를 만들지 못해 task가 `partial`이었다.
+- `running_redirect_records_stop_checkpoint_guidance_and_restart_dedupe`: stop 이후
+  continuation이 하나로 수렴하지 않고 attempt가 3개였다.
+- `deleted_derived_index_rebuilds_from_canonical_facts_with_bounded_tail`: fixture가
+  128개를 넘는 canonical event를 만들지 못했다.
+
+이 red는 compile 또는 파일 부재 오류가 아니라 fake worker를 통과한 실제 Yardlet
+subprocess state가 acceptance story를 충족하지 못한 결과였다.
+
+## Fix
+
+선행 `93cf06b`의 최소 production 수정은 현재 source에 다음과 같이 남아 있다.
+
+- `src/parallel.rs`는 validation-bearing runnable task를 parallel ready set에
+  포함한다.
+- `src/run.rs`의 공통 finalization은 parallel worktree에서 validation을 실행하고
+  `validation.started`, `validation.completed`를 attempt에 연결한다.
+- `src/workers/mod.rs`는 attempt별 stdout/stderr를 create-new로 열고 existing path를
+  거절하며 private file helper를 사용한다.
+- `.gitignore`는 `/.agents/task-channels/`를 operational state로 제외한다.
+
+YARD-007은 production schema나 state writer를 넓히지 않고 다음 fixture와 assertion만
+추가했다.
+
+- generic worker identity 두 개로 question task와 validation task를 분리했다.
+- 같은 fake binary가 Codex built-in adapter 인자를 받아 stable
+  `worker_session_ref`를 공개하고 resume invocation을 기록한다.
+- long-running worker가 checkpoint를 쓴 뒤 실제 signal stop을 받고 redirect
+  continuation을 실행한다.
+- index task가 140개 public progress line을 내고 answer subprocess 전에 derived
+  index를 삭제한다.
+- exact `asked_event_id`, `asked_seq`, bounded prior position, action/event causality,
+  raw stream identity 및 restart 뒤 attempt count를 직접 읽어 확인한다.
+
+## Green 관찰 state
+
+`tests/v010_003_task_channels_process.rs`의 7개 Unix subprocess test가 다음 상태를
+확인한다.
+
+1. `YARD-ASK`와 `YARD-DRAIN`이 같은 parallel batch에서 서로 다른 worker identity로
+   시작한다. `YARD-ASK`는 `question.asked` 뒤 `needs_user`, `YARD-DRAIN`은
+   `worker.started`, `validation.started`, `validation.completed`,
+   `completion.recorded` 뒤 `done`이다.
+2. text-only answer는 exact question event를 지목하고 `explicit_packet` attempt를
+   만든다. 첫 stdout/stderr는 새 attempt가 생긴 뒤에도 byte 동일하다.
+3. native worker의 첫 `worker.completed`가
+   `11111111-1111-4111-8111-111111111111` session ref를 보존한다. answer가 만든 새
+   `native_resume` attempt는 같은 ref, exact `user.answered` causation 및
+   `act-native-answer`를 가진다. 실제 invocation도 `exec resume`과 exact ref를
+   포함한다.
+4. running redirect는 기존 attempt를 `cancelled`로 관찰하고 checkpoint, reason,
+   guidance, `live_message_delivered: false`를 기록한 뒤 정확히 한 `redirect` attempt를
+   만든다. 같은 action을 새 CLI process에서 다시 요청해도 새 attempt가 실행되지
+   않는다.
+5. 128개를 넘는 event의 index를 삭제한 뒤 answer CLI process가 canonical event와
+   raw bytes를 덮어쓰지 않고 index를 재생성한다. `tail_events <= 128`,
+   `event_count == canonical event count`, `highest_applied_seq == max(seq)`다.
+6. `git check-ignore`는 task-channel 및 raw evidence를 ignore하지만
+   `.agents/skills/fixture-probe/SKILL.md`는 ignore하지 않는다.
+7. umask 022에서도 stdout, stderr, combined log가 모두 0600이다. 미리 존재하는
+   다음 attempt stdout path는 `attempt raw stream already exists`로 거절되고 sentinel
+   bytes가 유지된다.
+
+Targeted green 명령은 다음과 같다.
+
+```bash
+cargo test --test v010_003_task_channels_process -- --nocapture
+cargo test ready_set_includes_validation_tasks -- --nocapture
+cargo test attempt_capture_separates_stdout_stderr_and_refuses_overwrite -- --nocapture
+cargo test channel_replay_recovers_a_deleted_or_malformed_bounded_index -- --nocapture
+cargo test redirect_requires_observed_terminal_state_before_new_guidance_attempt -- --nocapture
+```
+
+관찰 결과는 process test 7/7 pass, 관련 unit test 각 1/1 pass다. 이어서 실행한
+`cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
+`cargo build`, `cargo test`도 모두 exit 0이었다. 전체 test의 실제 관찰치는 unit
+409/409, builtin bundle 3/3, Git finish process 1/1, state architecture 2/2,
+V010-001 replay 8/8, serial Git finish process 1/1, V010-002 process 37/37,
+V010-003 process 7/7 pass다. 명령별 결과는 현재 run의 `validation.log`에도 보존했다.

--- a/docs/reviews/v010-003-dogfood.md
+++ b/docs/reviews/v010-003-dogfood.md
@@ -111,3 +111,66 @@ cargo test redirect_requires_observed_terminal_state_before_new_guidance_attempt
 409/409, builtin bundle 3/3, Git finish process 1/1, state architecture 2/2,
 V010-001 replay 8/8, serial Git finish process 1/1, V010-002 process 37/37,
 V010-003 process 7/7 pass다. 명령별 결과는 현재 run의 `validation.log`에도 보존했다.
+
+## YARD-008 security remediation
+
+### HIGH-001 action-id receipt escape
+
+Red 명령은 다음과 같다.
+
+```bash
+cargo test answer_action_rejects_unsafe_action_id_before_writing_a_receipt -- --nocapture
+cargo test --test v010_003_task_channels_process action_id_rejects_absolute_and_parent_paths_without_receipt_escape -- --nocapture
+```
+
+수정 전 state 단위 test는 임시 workspace 안의 절대경로 action id를 정상
+`AnswerActionOutcome`으로 받아들였다. 실제 CLI process도 같은 절대경로
+`--action-id`로 answer continuation을 완료했다. 원인은 `cli_action_id`가 사용자 입력을
+검증하지 않고, `channel_action_path`가 action id를 receipt filename에 그대로 보간한
+것이다. 절대경로는 `PathBuf::join`의 channel action root를 대체했고 `..` 성분도
+actions directory를 벗어날 수 있었다.
+
+Remediation은 다음 경계를 추가했다.
+
+- action id는 최대 128 byte의 단일 portable identifier만 허용한다. 첫 문자는 ASCII
+  영숫자이고 나머지는 ASCII 영숫자, `.`, `_`, `-`만 허용한다.
+- CLI answer, redirect, planning action은 사용자 제공 id를 mutation 전에 검증한다.
+  특히 redirect는 invalid id를 worker stop 전에 거절한다.
+- state writer는 CLI를 우회한 호출도 다시 검증한다. planning 및 task-channel receipt
+  path의 parent가 canonical actions directory와 정확히 같은지 확인한 뒤에만 쓴다.
+- process test는 절대경로와 `../` 입력이 non-zero로 끝나고 channel action receipt와
+  예상 escape 위치 모두에 파일이 생기지 않는지 확인한다.
+
+수정 뒤 위 두 명령은 각각 1/1 pass다.
+
+### HIGH-002 redirect decoy PID signal
+
+Red 명령은 다음과 같다.
+
+```bash
+cargo test --test v010_003_task_channels_process redirect_ignores_decoy_pid_and_signals_verified_worker -- --nocapture
+```
+
+수정 전 fixture는 long-running worker의 실제 PID를 읽은 뒤 별도 `sleep` decoy를
+시작하고 `worker.pid`만 decoy PID로 바꿨다. Redirect는 decoy를 종료했고 실제 worker는
+계속 살아 있었다. 10초 뒤 CLI는 `no observed terminal event yet`로 실패했다. 원인은
+`live_worker_pid`가 mutable `worker.pid` 숫자와 `kill -0`만 신뢰한 것이다.
+
+Remediation은 spawn 직후 private 0600 `worker-process.yaml`을 create-new로 기록한다.
+Receipt는 `run_id`, `attempt_id`, `worker_id`, 실제 PID 및 OS process start marker를
+담는다. Redirect는 signal 전에 다음을 모두 대조한다.
+
+1. canonical `run.yaml`의 run id, task id, running state 및 미완료 상태
+2. receipt의 run, attempt, worker identity와 현재 redirect 대상
+3. receipt PID의 현재 OS process start marker와 spawn 시 marker
+
+`worker.pid`는 기존 monitor 및 legacy recovery를 위한 projection으로만 남고 redirect
+signal source로 사용하지 않는다. Process test는 receipt identity와 0600 mode를 읽고,
+`worker.pid` 변조 뒤 decoy 생존, 실제 worker 종료, redirect continuation의 `done` 수렴을
+확인한다. 수정 뒤 위 명령은 1/1 pass이며 전체 V010-003 process suite는 9/9 pass다.
+
+YARD-008 최종 gate는 `cargo fmt --all -- --check`,
+`cargo clippy --all-targets --all-features -- -D warnings`, `cargo build`가 모두 exit 0이다.
+새 전체 `cargo test --quiet` 관찰치는 unit 410/410, builtin bundle 3/3,
+Git finish process 1/1, state architecture 2/2, V010-001 replay 8/8,
+serial Git finish process 1/1, V010-002 process 37/37, V010-003 process 9/9 pass다.

--- a/docs/reviews/v010-003-independent-review.md
+++ b/docs/reviews/v010-003-independent-review.md
@@ -1,0 +1,117 @@
+# V010-003 remediation 최종 독립 재검토
+
+## 최종 판정
+
+**PASS.** AC-001부터 AC-008까지 모두 통과했다. 1차 review의 HIGH-001부터
+HIGH-004와 MEDIUM-001은 현재 fixture를 remediation parent production에 얹었을 때
+각각 원 증상으로 실패했고, 현재 HEAD의 동일 fixture와 14개 실제-process suite에서는
+모두 통과했다. 미해결 critical, major, high, medium failed check는 없다.
+
+검토 HEAD는 `9a6ece91ad3cc22e7d94ba72eef75ddac8f5b0bd`, YARD-009 production
+commit은 `7a41942db42f161301b4b314b04937194a877193`, 그 remediation parent는
+`8dae92c6724a1e0f02873e47446a233eba6bf56e`다.
+
+## 기준과 evidence provenance
+
+- 현재 checkout의 tracked 계약 `docs/v0.10-shared-session-state-contract.md` 전체를
+  읽었고 SHA-256은
+  `8dabe01c969fca5bd9c7a28ed4a0da0114503526309990afa6770a8175cca8f4`다.
+- roadmap의 V010-003 요구는 root checkout의 ignored 내부 문서
+  `/Users/zzunkie/Desktop/workspace/yard/docs/yardlet-roadmap.md:696-752`에서
+  읽었다. SHA-256은
+  `cf4d16bac80f735ae58c8a2c410631dddbb35e6e3a140a18af1067b42cd8025b`다.
+- 1차 review는 독립 review worktree의
+  `/Users/zzunkie/Desktop/workspace/yard/.agents/worktrees/run-20260714-190212/docs/reviews/v010-003-independent-review-round-1.md`
+  에서 읽었다. SHA-256은
+  `759d2b6fd06ce42eefd519a2563594245972bc587a3fd48fedf8810c1fae3e74`다.
+- 현재 branch에는 위 roadmap과 1차 review가 없고, task packet이 지정한
+  `.agents/runs/run-20260714-195009/evidence/repo-summary.md`도 시작부터 없었다.
+  `git check-ignore -v docs/yardlet-roadmap.md`는 `.gitignore:50`을 반환했다.
+  이 portability 결함은 아래 MINOR-001에 기록한다. 활성 intent, queue 또는 기존
+  `.agents/runs` history는 fixture 입력으로 읽거나 수정하지 않았다.
+- 현재 branch에 있는 `docs/reviews/v010-003-dogfood.md`와
+  `docs/reviews/v010-003-remediation.md`의 SHA-256은 각각
+  `34ed2aa8e5aa7f5bcaa0841c340fb61370df0c35b528771cff4a7eb4b00b0cd2`,
+  `6a679d4fd956670c7852b58a0081baeca71e6ba6ef01b7c65722b53a97856869`다.
+
+YARD-009 diff는 `src/run.rs`, `src/schemas.rs`, `src/state.rs`,
+`src/workers/mod.rs`, V010-003 process test와 fixture, remediation 문서의 7개
+파일뿐이다. `git diff --check 8dae92c..7a41942`는 exit 0이었다. V010-004
+resource runtime, V010-002A/B skill lifecycle, V010-005/008 UI redesign,
+auth, payment, deploy, release, publication 또는 broad cleanup은 없었다.
+
+## 원 failed check의 독립 red-green
+
+Red는 tracked source를 바꾸지 않고 `git archive 8dae92c`로 만든
+`target/v010003-red-snapshot.vD3XmE`에 현재 HEAD의
+`tests/v010_003_task_channels_process.rs`와 worker fixture만 overlay해 실행했다.
+따라서 같은 assertion이 remediation 전 production과 현재 production을 직접
+구분한다.
+
+| finding | remediation 전 red | 현재 HEAD green과 source evidence |
+|---|---|---|
+| HIGH-001 live normalized progress와 artifact event | `provider_progress_is_canonical_while_worker_lives_and_artifacts_keep_attempt_provenance` exit 101, `normalized events were not visible while the worker lived`. `git grep`도 parent의 `artifact.created`를 `src/schemas.rs` enum/serde 4곳에서만 찾았다. | 같은 process test가 pass했다. `src/workers/mod.rs:292-317, 934-978`이 raw flush 뒤 complete public line을 live sink로 보내고, `src/run.rs:660-710`이 exact raw span을 canonical event로 쓴다. `src/run.rs:4497-4652`는 result/evaluation/checkpoint/handoff/worker-declared artifact에 exact attempt, worker, digest를 기록한다. |
+| HIGH-002 redirect-superseded question과 stale answer | `redirect_closes_superseded_question_and_stale_answer_fails_without_mutation` exit 101, `redirect did not record a question.closed event`. | 같은 test가 pass했다. `src/state.rs:2503-2524`가 close event를 projection하고, `src/state.rs:3076-3113`이 stopped attempt의 open question을 redirect action causality로 닫는다. `src/run.rs:1183-1194`는 actionable open question이 없으면 fail closed한다. |
+| HIGH-003 unavailable producer fallback | `unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet` exit 101, `prepared attempt does not match invocation`. | 같은 test가 pass했다. `src/run.rs:1212-1230`이 answer 기록 전에 actual ready worker를 resolve하고, worker가 바뀌면 selected worker 소유 explicit packet attempt를 만든다. |
+| HIGH-004 redirect receipt 뒤 spawn 전 crash | `redirect_receipt_crash_retries_same_action_and_runs_stored_attempt_once` exit 101, `redirect did not stop after the terminal receipt`. Parent에는 stable crash boundary가 없었다. | 같은 test가 pass했다. `src/run.rs:1391-1431`은 stored prepared redirect attempt를 restart에서 찾고 receipt 뒤 failpoint를 제공한다. `src/state.rs:3227-3238`은 cancelled queue state를 pending continuation으로 복구한다. Test는 같은 action retry 뒤 attempt 2개 유지, redirect `worker.started` 정확히 1개, task Done을 확인한다. |
+| MEDIUM-001 question/completion ordering | `needs_user_question_precedes_worker_completed_and_is_its_cause` exit 101, `asked.seq < completed.seq` assertion 실패. | 같은 test가 pass했다. `src/run.rs:934-972`는 needs_user result의 question을 먼저 기록하고 `worker.completed`가 exact asked event를 causation으로 참조하게 한다. |
+
+현재 green 명령 `cargo test --test v010_003_task_channels_process -- --nocapture`는
+14 passed, 0 failed, exit 0이었다. 위 다섯 test 외에도 native resume, text-only
+explicit packet, raw overwrite 방어, verified PID redirect, decoy PID 방어,
+independent drain, bounded index rebuild를 같은 실제 binary subprocess에서 실행했다.
+
+## 필수 반례 직접 점검
+
+| 반례 | 판정과 독립 evidence |
+|---|---|
+| attempt/raw overwrite | PASS. `tests/v010_003_task_channels_process.rs:943-991`이 0600 stdout/stderr/combined log와 sentinel create-new overwrite 거절을 확인했다. `attempt_capture_separates_stdout_stderr_and_refuses_overwrite`도 fresh exit 0이다. |
+| stale answer | PASS. `tests/v010_003_task_channels_process.rs:1116-1178`이 redirect action의 exact `question.closed`, stale answer non-zero, attempt/event bytes 불변, receipt 부재를 확인했다. |
+| false live redirect | PASS. `tests/v010_003_task_channels_process.rs:550-647`이 stop/checkpoint/reason/guidance와 `live_message_delivered: false`를, `tests/v010_003_task_channels_process.rs:710-832`가 mutable decoy PID 생존과 verified real worker 종료를 확인했다. `redirect_requires_observed_terminal_state_before_new_guidance_attempt`도 exit 0이다. |
+| seq gap | PASS. `src/state.rs:2324-2366`은 session gap/conflict 뒤 mutation을 fail closed한다. `sequence_gap_and_collision_are_fail_closed` fresh exit 0이다. |
+| index corruption | PASS. `src/state.rs:2614-2644`는 canonical projection에서 최대 128 event tail index를 다시 만든다. malformed-index unit test와 `tests/v010_003_task_channels_process.rs:833-895`의 deleted-index restart가 모두 exit 0이다. |
+| duplicate action | PASS. `src/state.rs:2688-2950`은 answer의 stable id, digest, terminal receipt를 replay하고 다른 digest를 conflict로 거절한다. answer idempotency unit test와 redirect receipt crash process test가 모두 exit 0이다. |
+| independent drain | PASS. `tests/v010_003_task_channels_process.rs:397-470`이 YARD-ASK NeedsUser 중 YARD-DRAIN의 worker, validation, completion과 Done을 확인하고 두 worker의 raw stream 비혼합 및 restart question 복원을 확인했다. |
+
+## AC-001부터 AC-008 최종 판정
+
+| AC | 판정 | exact source 또는 command evidence와 contradiction |
+|---|---|---|
+| AC-001 | **PASS** | `src/state.rs:2445-2611`은 `(intent_id, task_id)`당 하나의 deterministic channel을 session seq로 replay하고 attempt를 `attempt.prepared` 순서로 정렬한다. text continuation `tests/v010_003_task_channels_process.rs:246-395`, independent two-worker restart `tests/v010_003_task_channels_process.rs:397-470`, fallback worker `tests/v010_003_task_channels_process.rs:1182-1230`이 distinct attempt, worker identity, raw stream과 answer causality를 확인했다. |
+| AC-002 | **PASS** | live sink는 `src/workers/mod.rs:292-317, 934-978`, canonical writer는 `src/run.rs:660-710`, artifact writer는 `src/run.rs:4497-4652`다. Process suite는 live worker 중 message/tool event의 exact stdout span, private reasoning 배제, 다섯 artifact role과 attempt provenance, text-only fallback, raw overwrite 거절을 확인했다. |
+| AC-003 | **PASS** | `src/run.rs:1019-1090`은 question id, asked event/seq, attempt와 prior context를 기록한다. `src/state.rs:2688-2950`은 answer, action receipt와 새 attempt를 exact causality로 기록한다. stale close process test와 ordering test가 모두 green이다. |
+| AC-004 | **PASS** | `src/run.rs:1212-1230`은 actual selected worker와 producer/session capability를 대조하고, `src/state.rs:2851-2880`은 exact session ref가 있을 때만 native resume를 선택한다. Native process test `tests/v010_003_task_channels_process.rs:474-549`, text-only test `tests/v010_003_task_channels_process.rs:246-395`, unavailable producer fallback test `tests/v010_003_task_channels_process.rs:1182-1230`이 모두 pass했다. |
+| AC-005 | **PASS** | `src/cli.rs:1401-1464`가 run-owned process provenance를 검증하고 terminal observation 뒤에만 redirect action을 기록한다. `src/state.rs:2959-3240`은 reason, `live_message_delivered: false`, close/checkpoint, guidance와 새 attempt를 감사 가능하게 잇는다. stop, decoy PID, duplicate redirect, receipt crash tests가 모두 pass했다. |
+| AC-006 | **PASS** | `tests/v010_003_task_channels_process.rs:397-470`의 actual parallel batch가 NeedsUser와 independent validation task를 함께 시작하고 후자를 Done까지 drain했다. `ready_set_includes_validation_tasks`와 dependency 관련 full-suite regressions도 exit 0이다. |
+| AC-007 | **PASS** | session seq gap fail-closed `src/state.rs:2290-2393`, canonical replay와 attempt ordering `src/state.rs:2445-2611`, bounded index rebuild `src/state.rs:2614-2644`를 확인했다. Deleted/malformed index, 140-line compaction, raw/event bytes 보존, restart recovery가 unit/process에서 pass했다. |
+| AC-008 | **PASS** | `docs/reviews/v010-003-dogfood.md`, `docs/reviews/v010-003-remediation.md`, 14개 actual-process fixture, 위 parent-red/HEAD-green, 그리고 이 별도 final review가 concurrency, contextual answer, native/explicit continuation, redirect, compaction, restart와 원 finding 폐쇄를 재검증했다. 현재 branch의 roadmap/round-1/repo-summary 부재는 MINOR-001 portability contradiction으로 남기되 behavior와 final 판정을 막는 high/medium 결함은 아니다. |
+
+## Validation
+
+2026-07-14 KST에 이 review run에서 fresh하게 실행했다.
+
+| command | exit | 관찰 결과 |
+|---|---:|---|
+| parent production + current fixture의 finding별 5개 `cargo test` | 각 101 | 원 finding별 기대 red 5개 재현 |
+| `cargo test --test v010_003_task_channels_process -- --nocapture` | 0 | 14 passed, 0 failed |
+| 6개 반례 filter test | 각 0 | seq gap, malformed index, answer idempotency, redirect terminal gate, validation ready-set, raw overwrite 각각 1 passed |
+| `cargo fmt --check` | 0 | output 없음 |
+| `cargo clippy --all-targets --all-features -- -D warnings` | 0 | dev profile 완료, warning error 없음 |
+| `cargo build` | 0 | dev profile 완료 |
+| `cargo test` | 0 | unit 410, integration 3 + 1 + 2 + 8 + 1 + 37 + 14, 총 476 passed |
+
+명령별 결과와 red 증상은
+`.agents/runs/run-20260714-195009/validation.log`에 보존했다.
+
+## Findings와 잔여 failed checks
+
+Critical, major, high, medium finding과 failed check는 없다.
+
+### MINOR-001 - evidence anchor portability
+
+현재 feature branch는 ignored root roadmap, 다른 worktree의 1차 review, 존재하지 않는
+`repo-summary.md`에 의존한다. 동일 checkout만 보존하면 최초 normative/review artifact의
+원문 접근성이 떨어진다. 구체적 개선은 후속 evidence 정리 시 V010-003 normative excerpt와
+1차 review를 tracked stable path에 보존하고, 생성되지 않은 repo-summary 링크는 실제
+Yardlet 생성 artifact로 대체하는 것이다. 이 final review는 exact path, digest, finding,
+red-green 결과를 함께 기록해 현재 판정의 재현성을 보완한다.

--- a/docs/reviews/v010-003-remediation.md
+++ b/docs/reviews/v010-003-remediation.md
@@ -1,0 +1,247 @@
+# V010-003 1차 review failed checks 제한 remediation
+
+## 기준과 범위
+
+이 문서는 YARD-009가 `docs/reviews/v010-003-independent-review-round-1.md`의
+HIGH-001부터 HIGH-004와 MEDIUM-001만 재현하고 보수한 증거다. 규범 기준은
+`docs/v0.10-shared-session-state-contract.md`의 event, action, ordering,
+persistence, replay 계약과 root checkout의 내부 roadmap
+`docs/yardlet-roadmap.md:696-752`다.
+
+현재 remediation worktree의 HEAD에는 1차 review 문서와 roadmap 문서가 없었다.
+1차 review 문서는 같은 저장소의 독립 review worktree에서, roadmap은 root
+checkout에서 읽기 전용으로 확인했다. task packet이 지정한
+`.agents/runs/run-20260714-192013/evidence/repo-summary.md`도 run 시작 시 존재하지
+않았다. 활성 intent, queue 또는 기존 run history는 수정하거나 fixture 입력으로
+사용하지 않았다.
+
+Production 변경은 `src/workers/mod.rs`, `src/run.rs`, `src/state.rs`와 additive
+`src/schemas.rs`에 한정했다. Process 증거는
+`tests/v010_003_task_channels_process.rs`와
+`tests/fixtures/v010_003_task_channels/worker.sh`만 확장했다.
+
+## HIGH-001: live normalized progress와 artifact event
+
+### Red
+
+실제 Codex adapter-shaped fixture가 공개 message와 tool JSON line을 쓴 뒤 3초간
+살아 있도록 만들고 다음 명령을 실행했다.
+
+```bash
+cargo test --test v010_003_task_channels_process \
+  provider_progress_is_canonical_while_worker_lives_and_artifacts_keep_attempt_provenance \
+  -- --nocapture
+```
+
+수정 전 strict worker PID 생존 조건에서 다음과 같이 실패했다.
+
+```text
+normalized events were not visible while the worker lived
+test result: FAILED. 0 passed; 1 failed
+```
+
+별도 artifact assertion까지 진행한 선행 실행은 다음 결함도 직접 확인했다.
+
+```text
+missing artifact role worker_result: {}
+```
+
+### Fix
+
+- `src/workers/mod.rs:292-327`은 reader별 complete line을 raw file flush 뒤
+  normalize하고 누적 byte offset을 exact `raw_ref`에 반영한다.
+- `src/workers/mod.rs:672-702`는 기존 `spawn_attempt` compatibility를 유지하면서
+  canonical sink를 받는 additive `spawn_attempt_with_sink`를 제공한다.
+- `src/run.rs:660-712`는 worker 공개 event를 `src/state.rs` writer를 통해 즉시
+  append한다. 같은 raw span의 duplicate는 payload가 같을 때만 idempotent하다.
+- Codex 및 Claude normalizer의 reasoning, thinking, analysis 배제 규칙은 유지했다.
+- `src/run.rs:4497-4663`은 `result.json`, `evaluation.json`, `checkpoint.md`,
+  `handoff.md`와 result가 명시한 실제 created/modified file을 content digest,
+  role, producer worker와 exact attempt를 가진 `artifact.created`로 기록한다.
+  worker-declared path는 producer root 밖으로 해석되거나 실제 file이 아니면
+  등록하지 않는다.
+
+### Green
+
+동일 process test는 worker PID가 살아 있는 동안 `worker.message`, `tool.started`,
+`tool.completed`를 읽었고, 각 raw span을 stdout bytes에 다시 대조했다. 종료 뒤에는
+`worker_result`, `evaluation`, `checkpoint`, `handoff`, `worker_declared` 다섯 role이
+같은 attempt provenance와 non-empty digest를 가짐을 확인했다. Private reasoning은
+normalized payload에 없었다.
+
+## HIGH-002: redirect-superseded question과 stale answer
+
+### Red
+
+```bash
+cargo test --test v010_003_task_channels_process \
+  redirect_closes_superseded_question_and_stale_answer_fails_without_mutation \
+  -- --nocapture
+```
+
+수정 전 결과는 다음과 같았다.
+
+```text
+redirect did not record a question.closed event
+test result: FAILED. 0 passed; 1 failed
+```
+
+### Fix
+
+- `src/schemas.rs:1681-1763`에 additive `question.closed` event vocabulary를
+  추가했다.
+- `src/state.rs:2503-2522`는 canonical close event를 replay해 answer가 없는
+  question만 `Closed`로 projection한다.
+- `src/state.rs:3076-3140`은 redirect 대상 attempt의 모든 unanswered open
+  question을 같은 `action_id`와 연속 causation으로 먼저 닫고, checkpoint 및 새
+  attempt가 그 close fact 뒤를 잇게 한다.
+- `src/run.rs:1173-1233`은 channel에 question history가 있지만 actionable open
+  question이 없으면 legacy fresh run으로 떨어지지 않고 `question_closed`로
+  fail closed한다.
+
+### Green
+
+같은 actual-process test는 q1 redirect, q2 answer, task Done 뒤 q1 stale answer를
+실행했다. q1 close event의 action은 exact redirect action이었고 stale answer는
+non-zero로 끝났다. Attempt, event, terminal receipt bytes는 호출 전후 동일했다.
+
+## HIGH-003: unavailable producer의 fallback continuation
+
+### Red
+
+```bash
+cargo test --test v010_003_task_channels_process \
+  unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet \
+  -- --nocapture
+```
+
+Worker A가 question을 만든 뒤 A command를 unavailable하게 하고 ready worker B를
+fallback으로 둔 수정 전 결과는 다음과 같았다.
+
+```text
+yardlet: prepared attempt does not match invocation
+test result: FAILED. 0 passed; 1 failed
+```
+
+### Fix
+
+`src/run.rs:1173-1233`의 answer preparation이 현재 worker readiness와 fallback
+policy를 먼저 resolve한다. 선택 worker가 producer와 같고 exact session ref와 native
+capability가 있을 때만 native resume를 유지한다. Worker가 바뀌면 selected worker
+소유 `explicit_packet` attempt를 answer event와 action causality로 기록한다.
+
+### Green
+
+같은 process test에서 B 소유 `explicit_packet` attempt가 exact
+`act-fallback-answer` causality로 실행돼 task가 Done이 됐다. 기존
+`native_resume_preserves_session_ref_and_answer_causality`도 함께 통과해 same-worker
+native path가 유지됨을 확인했다.
+
+## HIGH-004: redirect receipt 이후 spawn 이전 crash recovery
+
+### Red
+
+```bash
+cargo test --test v010_003_task_channels_process \
+  redirect_receipt_crash_retries_same_action_and_runs_stored_attempt_once \
+  -- --nocapture
+```
+
+수정 전에는 stable crash injection 경계가 없어 redirect가 그대로 완료됐고 다음
+assertion에서 실패했다.
+
+```text
+redirect did not stop after the terminal receipt
+test result: FAILED. 0 passed; 1 failed
+```
+
+### Fix
+
+- `src/run.rs:1391-1412`는 모든 prepared answer/redirect continuation을 restart에서
+  찾는다. Debug fixture 환경의 `YARDLET_TEST_CRASH_AFTER_REDIRECT_RECEIPT=1`은
+  terminal receipt와 prepared attempt 확인 뒤 새 run directory 또는 worker spawn
+  전에만 failpoint를 연다.
+- `src/state.rs:3224-3240`은 cancelled run이 Queued로 돌아온 경우 terminal redirect
+  receipt를 반환하기 전에 task를 pending continuation 상태로 두어 same action CLI
+  retry가 기존 precondition을 통과하게 한다.
+- Retry는 `redirect_task` terminal receipt를 먼저 replay하고 `run_next`가 stored
+  attempt id를 그대로 사용한다. 새 attempt id를 만들지 않는다.
+
+### Green
+
+Process test는 live worker를 실제 signal로 취소하고 terminal receipt 뒤 crash를
+주입했다. Restart한 새 CLI process가 같은 action id를 재요청한 뒤 attempt 수 2개를
+유지했고, redirect attempt의 `worker.started`는 정확히 1개였으며 task는 Done으로
+수렴했다. 기존 verified PID, decoy PID, `live_message_delivered: false` tests도 함께
+유지됐다.
+
+## MEDIUM-001: question.asked와 worker.completed ordering
+
+### Red
+
+```bash
+cargo test --test v010_003_task_channels_process \
+  needs_user_question_precedes_worker_completed_and_is_its_cause \
+  -- --nocapture
+```
+
+수정 전 결과는 다음과 같았다.
+
+```text
+assertion failed: number(asked, "seq") < number(completed, "seq")
+test result: FAILED. 0 passed; 1 failed
+```
+
+### Fix
+
+`src/run.rs:931-952`는 imported `result.json`의 needs_user question을 terminal event
+전에 해석한다. `record_result_question`은 exact asked event를 반환하고
+`worker.completed(needs_user)`는 그 event id를 직접 causation으로 사용한다.
+Finalization의 기존 호출은 같은 attempt와 text를 idempotently 재사용한다.
+
+### Green
+
+같은 process test가 `question.asked.seq < worker.completed.seq`, completed result
+`needs_user`, completed causation이 exact asked event id임을 모두 확인했다.
+
+## 전체 반례와 AC trace
+
+| 항목 | 구현자 확인 근거 |
+|---|---|
+| AC-001 | fallback B actual-process test가 distinct B attempt, answer action/event causality와 completion을 확인했다. |
+| AC-002 | live PID test가 exact raw spans와 공개 message/tool event를, 종료 뒤 artifact role과 attempt provenance를 확인했다. Raw overwrite 및 0600 process test도 유지됐다. |
+| AC-003 | q1 close와 stale no-mutation test, needs_user ordering test가 exact question/action/channel position을 확인했다. |
+| AC-004 | 기존 native resume, same-worker explicit packet과 새 unavailable producer fallback test가 모두 통과했다. |
+| AC-005 | 기존 verified stop/redirect audit와 새 receipt crash/same action retry가 exactly-once stored attempt를 확인했다. |
+| AC-006 | `parallel_independent_task_records_validation_completion`이 NeedsUser와 독립 validation task drain을 확인했다. |
+| AC-007 | 기존 seq gap fail-closed unit test와 deleted/malformed index replay, bounded tail process test가 유지됐다. |
+| AC-008 | 이 remediation과 14개 actual-process fixture까지는 작성됐다. 최종 AC-001부터 AC-008 판정은 remediation 작성과 분리된 read-only review run의 책임이다. |
+
+Attempt/raw overwrite, false live redirect, seq gap, index corruption, duplicate action과
+independent drain의 기존 반례는 전체 regression suite에 남아 있다. 이번 diff에는
+V010-004 resource runtime, V010-002A/B skill lifecycle, V010-005/008 UI redesign,
+provider-private reasoning 수집, auth, payment, deploy, publication 또는 broad cleanup이
+없다.
+
+## Green gate
+
+Finding별 narrow 명령 5개는 각각 1 passed, 0 failed였다. 확장된 process suite는
+다음 명령에서 14 passed, 0 failed였다.
+
+```bash
+cargo test --test v010_003_task_channels_process -- --nocapture
+```
+
+2026-07-14 최종 fresh gate 결과는 다음과 같다.
+
+| 명령 | 결과 |
+|---|---|
+| `cargo fmt --check` | exit 0 |
+| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
+| `cargo build` | exit 0 |
+| `cargo test --test v010_003_task_channels_process -- --nocapture` | exit 0, 14 passed |
+| `cargo test --quiet` | exit 0, 476 passed across 8 test binaries |
+| `git diff --check` | exit 0 |
+
+명령별 실제 출력과 장기 process test의 count는 이 run의 `validation.log`에 함께
+보존한다.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,8 @@ pub enum Command {
     Run(RunArgs),
     /// Answer a task that is waiting on you, and resume it.
     Answer(AnswerArgs),
+    /// Stop or checkpoint a task, record the redirect, and start new guidance.
+    Redirect(RedirectArgs),
     /// Grant single-use approval to a gated task.
     Approve(ApproveArgs),
     /// Set a task aside by decision (Deferred: not pending, not done).
@@ -216,6 +218,26 @@ pub struct AnswerArgs {
     #[arg(long)]
     task: Option<String>,
     /// Drop the worker sandbox when resuming (e.g. to grant the access asked for).
+    #[arg(long)]
+    full_access: bool,
+    /// Stable idempotency key for retrying the same answer action.
+    #[arg(long)]
+    action_id: Option<String>,
+}
+
+#[derive(Args)]
+pub struct RedirectArgs {
+    /// The task whose current attempt should be redirected.
+    task: String,
+    /// New guidance for the next attempt.
+    guidance: Vec<String>,
+    /// Auditable reason for stopping the old attempt.
+    #[arg(long, default_value = "user redirect")]
+    reason: String,
+    /// Stable idempotency key for retrying the same redirect action.
+    #[arg(long)]
+    action_id: Option<String>,
+    /// Drop the worker sandbox for the new attempt.
     #[arg(long)]
     full_access: bool,
 }
@@ -513,6 +535,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Packet(a)) => cmd_packet(&cwd, a),
         Some(Command::Run(a)) => cmd_run(&cwd, a),
         Some(Command::Answer(a)) => cmd_answer(&cwd, a),
+        Some(Command::Redirect(a)) => cmd_redirect(&cwd, a),
         Some(Command::Approve(a)) => cmd_approve(&cwd, a),
         Some(Command::Defer(a)) => cmd_defer(&cwd, a),
         Some(Command::Revive(a)) => cmd_revive(&cwd, a),
@@ -1294,6 +1317,8 @@ fn cmd_answer(cwd: &std::path::Path, args: AnswerArgs) -> Result<()> {
         return Ok(());
     }
 
+    run::prepare_answer_action(&ws, &task_id, &reply, args.action_id)?;
+
     println!("You: {reply}\n");
     let report = run::run_next(
         &ws,
@@ -1319,6 +1344,133 @@ fn cmd_answer(cwd: &std::path::Path, args: AnswerArgs) -> Result<()> {
         }
     } else if !report.run_id.is_empty() {
         println!("\nrun {} resumed", report.run_id);
+    }
+    Ok(())
+}
+
+fn cmd_redirect(cwd: &std::path::Path, args: RedirectArgs) -> Result<()> {
+    let ws = init::ensure_initialized(cwd)?.0;
+    let guidance = args.guidance.join(" ");
+    if guidance.trim().is_empty() {
+        anyhow::bail!("redirect guidance must not be empty");
+    }
+    let queue = ws.load_queue()?;
+    let task = queue
+        .tasks
+        .iter()
+        .find(|task| task.id == args.task)
+        .ok_or_else(|| anyhow::anyhow!("task '{}' not found in the queue", args.task))?;
+    if !matches!(
+        task.state,
+        crate::schemas::TaskState::Running | crate::schemas::TaskState::NeedsUser
+    ) {
+        anyhow::bail!(
+            "task '{}' must be Running or NeedsUser to redirect (currently {:?})",
+            args.task,
+            task.state
+        );
+    }
+
+    let mut channel = ws.load_task_channel(&queue.intent_id, &args.task)?;
+    let latest_attempt_id = run::latest_run_for(&ws, &args.task)
+        .and_then(|(_, dir)| std::fs::read_to_string(dir.join("latest-attempt")).ok())
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty())
+        .or_else(|| {
+            channel
+                .attempts
+                .last()
+                .map(|attempt| attempt.attempt_id.clone())
+        })
+        .ok_or_else(|| anyhow::anyhow!("task '{}' has no durable attempt", args.task))?;
+
+    let mut run_dir = run::latest_run_for(&ws, &args.task).map(|(_, dir)| dir);
+    let mut stopped = channel
+        .attempts
+        .iter()
+        .find(|attempt| attempt.attempt_id == latest_attempt_id)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("latest attempt '{}' is missing", latest_attempt_id))?;
+    if !stopped.state.is_terminal() {
+        let active_dir = run_dir
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("running task has no run directory"))?;
+        let pid = run::live_worker_pid(active_dir).ok_or_else(|| {
+            anyhow::anyhow!(
+                "attempt '{}' is non-terminal but has no live worker; run `yardlet recover` first",
+                latest_attempt_id
+            )
+        })?;
+        crate::state::write_str_atomic(&active_dir.join("cancelled"), "redirect\n")?;
+        let status = std::process::Command::new("kill")
+            .arg(pid.to_string())
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("failed to stop worker pid {pid}; redirect was not recorded");
+        }
+
+        let mut observed = None;
+        for _ in 0..100 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            channel = ws.load_task_channel(&queue.intent_id, &args.task)?;
+            observed = channel
+                .attempts
+                .iter()
+                .find(|attempt| attempt.attempt_id == latest_attempt_id)
+                .filter(|attempt| attempt.state.is_terminal())
+                .cloned();
+            let no_longer_running = ws.load_queue().ok().is_some_and(|latest| {
+                latest.tasks.iter().any(|task| {
+                    task.id == args.task && task.state != crate::schemas::TaskState::Running
+                })
+            });
+            if observed.is_some() && no_longer_running {
+                break;
+            }
+        }
+        stopped = observed.ok_or_else(|| {
+            anyhow::anyhow!(
+                "worker stop was requested but attempt '{}' has no observed terminal event yet",
+                latest_attempt_id
+            )
+        })?;
+    }
+
+    let action_id = cli_action_id("redirect", args.action_id);
+    let checkpoint_ref = run_dir.take().and_then(|dir| {
+        [dir.join("checkpoint.md"), dir.join("handoff.md")]
+            .into_iter()
+            .find(|path| path.is_file())
+            .map(|path| path.display().to_string())
+    });
+    ws.redirect_task(&crate::schemas::RedirectActionRequest {
+        continuation_attempt_id: run::action_attempt_id(&action_id),
+        action_id,
+        session_id: channel.session_id,
+        intent_id: queue.intent_id,
+        task_id: args.task.clone(),
+        stopped_attempt_id: stopped.attempt_id,
+        observed_terminal_state: stopped.state,
+        reason: args.reason,
+        guidance: guidance.clone(),
+        worker_id: stopped.worker_id,
+        checkpoint_ref,
+    })?;
+
+    let report = run::run_next(
+        &ws,
+        &RunOptions {
+            execute: true,
+            worker_override: None,
+            target: Some(args.task),
+            answer: Some(guidance),
+            full_access: args.full_access,
+            accept_ambiguity: false,
+            chain: None,
+        },
+    )?;
+    for line in report.lines {
+        println!("{line}");
     }
     Ok(())
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1038,14 +1038,16 @@ fn parse_expected_head(value: &str) -> Option<&str> {
     (!value.eq_ignore_ascii_case("none")).then_some(value)
 }
 
-fn cli_action_id(prefix: &str, provided: Option<String>) -> String {
-    provided.unwrap_or_else(|| {
+fn cli_action_id(prefix: &str, provided: Option<String>) -> Result<String> {
+    let action_id = provided.unwrap_or_else(|| {
         format!(
             "act-{prefix}-{}-{}",
             chrono::Utc::now().format("%Y%m%d%H%M%S%6f"),
             std::process::id()
         )
-    })
+    });
+    crate::state::validate_action_id(&action_id)?;
+    Ok(action_id)
 }
 
 fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
@@ -1057,7 +1059,7 @@ fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
             expected_head,
             action_id,
         } => {
-            let action_id = cli_action_id("accept", action_id);
+            let action_id = cli_action_id("accept", action_id)?;
             let revision = crate::planning::accept_proposal(
                 &ws,
                 &proposal,
@@ -1076,7 +1078,7 @@ fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
             expected_head,
             action_id,
         } => {
-            let action_id = cli_action_id("reject", action_id);
+            let action_id = cli_action_id("reject", action_id)?;
             crate::planning::reject_proposal(
                 &ws,
                 &proposal,
@@ -1090,7 +1092,7 @@ fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
             expected_head,
             action_id,
         } => {
-            let action_id = cli_action_id("undo", action_id);
+            let action_id = cli_action_id("undo", action_id)?;
             let restored = crate::planning::undo(&ws, &expected_head, &action_id)?;
             println!(
                 "Undo complete. Visible head: {}",
@@ -1105,7 +1107,7 @@ fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
             worker,
         } => {
             let message = message.join(" ");
-            let action_id = cli_action_id("answer", action_id);
+            let action_id = cli_action_id("answer", action_id)?;
             let (session, turn) = crate::planning::record_answer_exact(
                 &ws,
                 &message,
@@ -1129,7 +1131,7 @@ fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
             expected_head,
             action_id,
         } => {
-            let action_id = cli_action_id("confirm", action_id);
+            let action_id = cli_action_id("confirm", action_id)?;
             let activation = crate::planning::confirm(&ws, &expected_head, &action_id)?;
             println!(
                 "Confirmed {} with activation {}. The exact visible draft is now active.",
@@ -1285,6 +1287,10 @@ fn cmd_tidy(cwd: &std::path::Path) -> Result<()> {
 fn cmd_answer(cwd: &std::path::Path, args: AnswerArgs) -> Result<()> {
     let ws = init::ensure_initialized(cwd)?.0;
     let reply = args.reply.join(" ");
+    let action_id = args
+        .action_id
+        .map(|action_id| cli_action_id("answer", Some(action_id)))
+        .transpose()?;
     let queue = ws.load_queue()?;
     let task_id = match &args.task {
         Some(t) => t.clone(),
@@ -1317,7 +1323,7 @@ fn cmd_answer(cwd: &std::path::Path, args: AnswerArgs) -> Result<()> {
         return Ok(());
     }
 
-    run::prepare_answer_action(&ws, &task_id, &reply, args.action_id)?;
+    run::prepare_answer_action(&ws, &task_id, &reply, action_id)?;
 
     println!("You: {reply}\n");
     let report = run::run_next(
@@ -1354,6 +1360,7 @@ fn cmd_redirect(cwd: &std::path::Path, args: RedirectArgs) -> Result<()> {
     if guidance.trim().is_empty() {
         anyhow::bail!("redirect guidance must not be empty");
     }
+    let action_id = cli_action_id("redirect", args.action_id)?;
     let queue = ws.load_queue()?;
     let task = queue
         .tasks
@@ -1395,12 +1402,12 @@ fn cmd_redirect(cwd: &std::path::Path, args: RedirectArgs) -> Result<()> {
         let active_dir = run_dir
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("running task has no run directory"))?;
-        let pid = run::live_worker_pid(active_dir).ok_or_else(|| {
-            anyhow::anyhow!(
-                "attempt '{}' is non-terminal but has no live worker; run `yardlet recover` first",
-                latest_attempt_id
-            )
-        })?;
+        let pid = run::verified_worker_pid_for_redirect(
+            active_dir,
+            &args.task,
+            &latest_attempt_id,
+            &stopped.worker_id,
+        )?;
         crate::state::write_str_atomic(&active_dir.join("cancelled"), "redirect\n")?;
         let status = std::process::Command::new("kill")
             .arg(pid.to_string())
@@ -1436,7 +1443,6 @@ fn cmd_redirect(cwd: &std::path::Path, args: RedirectArgs) -> Result<()> {
         })?;
     }
 
-    let action_id = cli_action_id("redirect", args.action_id);
     let checkpoint_ref = run_dir.take().and_then(|dir| {
         [dir.join("checkpoint.md"), dir.join("handoff.md")]
             .into_iter()

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -438,6 +438,25 @@ pub fn run_batch<F: FnMut(&str)>(
             .join(", ")
     ));
 
+    let attempt_runtime = preps
+        .iter()
+        .map(|prep| {
+            let context = run::channel_run_context(ws, &queue.intent_id, &prep.task.id);
+            let (attempt, capture) = run::begin_worker_attempt(
+                ws,
+                None,
+                &context,
+                &prep.run_dir,
+                &prep.run_id,
+                &prep.worker_id,
+                prep.session.clone(),
+                crate::schemas::ContinuationMode::Fresh,
+                None,
+            )?;
+            Ok((context, attempt, capture))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
     let (tx, rx) = mpsc::channel::<Finished>();
     let mut handles = Vec::new();
     for (i, p) in preps.iter().enumerate() {
@@ -451,20 +470,20 @@ pub fn run_batch<F: FnMut(&str)>(
         let packet_text = p.packet_text.clone();
         let cwd = p.wt_path.clone();
         let worker_run_dir = p.run_dir.clone();
-        let log_path = p.run_dir.join("worker-output.log");
+        let capture = attempt_runtime[i].2.clone();
         let timeout = Duration::from_secs(p.profile.limits.max_wall_minutes as u64 * 60);
         let images = images.clone();
         let session = p.session.clone();
         handles.push(std::thread::spawn(move || {
             let started = std::time::Instant::now();
-            let outcome = workers::spawn(
+            let outcome = workers::spawn_attempt(
                 &profile,
                 &bin,
                 &packet_text,
                 &worker_run_dir,
                 &cwd,
                 &env,
-                &log_path,
+                &capture,
                 timeout,
                 full_access,
                 &images,
@@ -491,12 +510,39 @@ pub fn run_batch<F: FnMut(&str)>(
         let mut wall_seconds = fin.wall_seconds;
         let mut failover_note: Option<String> = None;
 
+        if let Ok(completed) = &outcome {
+            let runtime = &attempt_runtime[fin.prep_idx];
+            run::finish_worker_attempt(
+                ws, None, &runtime.0, &p.run_dir, &runtime.1, &runtime.2, completed,
+            )?;
+        } else if let Err(error) = &outcome {
+            let runtime = &attempt_runtime[fin.prep_idx];
+            run::finish_worker_attempt_error(ws, &runtime.0, &runtime.1, error)?;
+        }
+
         match &outcome {
             Ok(o) => on_event(&format!(
                 "{}: worker finished ({}); integrating",
                 p.task.id, o.note
             )),
             Err(e) => on_event(&format!("{}: worker error: {e}", p.task.id)),
+        }
+
+        if p.run_dir.join("cancelled").is_file() {
+            let _ = std::fs::remove_file(p.run_dir.join("cancelled"));
+            run::save_task_state_on_latest_queue(
+                ws,
+                &mut queue,
+                &p.task.id,
+                TaskState::Queued,
+                crate::schemas::TransitionCause::RunOutcome,
+                "stopped by user; task requeued",
+                crate::schemas::TransitionActor::System,
+            )?;
+            remove_worktree(&ws.root, &p.wt_path, &p.branch);
+            on_event(&format!("{}: stopped by user; requeued", p.task.id));
+            states.push((p.task.id.clone(), TaskState::Queued));
+            continue;
         }
 
         if !p.run_dir.join("result.json").exists() {
@@ -555,20 +601,43 @@ pub fn run_batch<F: FnMut(&str)>(
                         write_str(&workers::packet_path(&p.run_dir), &failover_packet)?;
                         let session = (worker_id == "claude-code")
                             .then(|| run::gen_session_uuid(&format!("{}-{worker_id}", p.run_id)));
-                        workers::spawn(
+                        let context = run::channel_run_context(ws, &queue.intent_id, &p.task.id);
+                        let attempt_id = run::attempt_id_for_ordinal(&p.run_id, 2);
+                        let (attempt, capture) = run::begin_worker_attempt(
+                            ws,
+                            None,
+                            &context,
+                            &p.run_dir,
+                            &attempt_id,
+                            &worker_id,
+                            session.clone(),
+                            crate::schemas::ContinuationMode::Fallback,
+                            None,
+                        )?;
+                        let completed = match workers::spawn_attempt(
                             &eff_profile,
                             &alt.bin,
                             &failover_packet,
                             &p.run_dir,
                             &p.wt_path,
                             &env,
-                            &p.run_dir.join("worker-output.log"),
+                            &capture,
                             timeout,
                             full_access,
                             &images,
                             session.as_deref(),
                             false,
-                        )
+                        ) {
+                            Ok(completed) => completed,
+                            Err(error) => {
+                                run::finish_worker_attempt_error(ws, &context, &attempt, &error)?;
+                                return Err(error);
+                            }
+                        };
+                        run::finish_worker_attempt(
+                            ws, None, &context, &p.run_dir, &attempt, &capture, &completed,
+                        )?;
+                        Ok(completed)
                     })();
                     wall_seconds += failover_started.elapsed().as_secs();
                     match &outcome {

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -64,11 +64,8 @@ pub fn ready_independent(queue: &WorkQueue, max: usize) -> Vec<usize> {
             if is_verifier(t) && (work_pending || queue.has_active_remediation_for(&t.id)) {
                 return false;
             }
-            // Any validation-bearing task is excluded: parallel skips validation,
-            // so it must run serially where failed checks can enter feedback.
             queue.runnable_class(t, false, &caps) == RunnableClass::Runnable
                 && !t.approval_required()
-                && !t.has_validation()
         })
         .map(|(i, _)| i)
         .collect();
@@ -175,18 +172,6 @@ pub fn assess_parallelism(queue: &WorkQueue, max_parallel: usize) -> ParallelAss
     if !approval_required.is_empty() {
         reasons.push(SequentialReason::ApprovalRequired {
             tasks: approval_required,
-        });
-    }
-
-    let validation_required = queue
-        .tasks
-        .iter()
-        .filter(|t| t.state == TaskState::Queued && t.has_validation() && queue.deps_met(t))
-        .map(|t| t.id.clone())
-        .collect::<Vec<_>>();
-    if !validation_required.is_empty() {
-        reasons.push(SequentialReason::ValidationRequired {
-            tasks: validation_required,
         });
     }
 
@@ -1793,14 +1778,13 @@ mod tests {
     }
 
     #[test]
-    fn ready_set_excludes_all_validation_tasks() {
-        // Validation-bearing tasks are held back from parallel batches (parallel
-        // skips validation), so they run serially where failure enters feedback.
+    fn ready_set_includes_validation_tasks() {
+        // Validation-bearing tasks use the same pre-merge gate in their isolated
+        // worktree and therefore remain eligible for parallel batches.
         let mut needs_val = task("V", TaskState::Queued, 5, vec![]);
         needs_val.validation = Some(crate::yaml::from_str("commands: [cargo test]").unwrap());
         let q = queue(vec![task("A", TaskState::Queued, 10, vec![]), needs_val]);
-        // Only A is parallel-ready; V is excluded despite its lower priority.
-        assert_eq!(ready_independent(&q, 10), vec![0]);
+        assert_eq!(ready_independent(&q, 10), vec![1, 0]);
     }
 
     #[test]
@@ -1829,9 +1813,9 @@ mod tests {
         serial_builder.validation = Some(crate::yaml::from_str("required: true").unwrap());
         let mut q = queue(vec![review, serial_builder]);
 
-        // The serial-only builder still holds the review out of a parallel
-        // batch; run_auto will fall through and select it sequentially.
-        assert!(ready_independent(&q, 4).is_empty());
+        // The validation-bearing builder holds the review out of the batch and
+        // itself remains runnable through the parallel validation path.
+        assert_eq!(ready_independent(&q, 4), vec![1]);
 
         q.tasks[1].validation = None;
         q.tasks[1].approval = Some(crate::yaml::from_str("required: true").unwrap());
@@ -1917,7 +1901,7 @@ mod tests {
 
         let assessment = assess_parallelism(&q, 4);
 
-        assert_eq!(assessment.runnable, vec!["A"]);
+        assert_eq!(assessment.runnable, vec!["VALIDATE", "A"]);
         assert!(assessment
             .reasons
             .contains(&SequentialReason::DependencyChain {
@@ -1928,14 +1912,10 @@ mod tests {
             .contains(&SequentialReason::ApprovalRequired {
                 tasks: vec!["APPROVE".to_string()]
             }));
-        assert!(assessment
+        assert!(!assessment
             .reasons
-            .contains(&SequentialReason::ValidationRequired {
-                tasks: vec!["VALIDATE".to_string()]
-            }));
-        assert!(assessment
-            .reasons
-            .contains(&SequentialReason::RunnableTaskCount { runnable: 1 }));
+            .iter()
+            .any(|reason| matches!(reason, SequentialReason::ValidationRequired { .. })));
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -2633,9 +2633,13 @@ fn is_transient_failure(outcome: &workers::WorkerOutcome, run_dir: &std::path::P
 /// or a bare sequence. Yardlet runs these itself (a worker's self-reported
 /// validation is advisory, not the gate).
 fn validation_commands(task: &crate::schemas::Task) -> Vec<String> {
-    let Some(v) = &task.validation else {
+    if !task.has_validation() {
         return Vec::new();
-    };
+    }
+    let v = task
+        .validation
+        .as_ref()
+        .expect("has_validation guarantees validation is present");
     let seq = v
         .get("commands")
         .and_then(|c| c.as_sequence())
@@ -4024,18 +4028,15 @@ impl FinalizeFlags {
         }
     }
 
-    /// The parallel path runs in an isolated worktree, so the in-tree gates that
-    /// need the real workspace are deferred: validation is OFF (the pre-merge
-    /// worktree lacks gitignored build deps like node_modules/target, so running
-    /// it there spuriously fails self-contained-looking tasks — a post-merge gate
-    /// is the proper future design), and post-run hooks are OFF for the same
-    /// reason. The evaluator's forbidden-path gate still runs on the worktree
-    /// diff, so the safety floor holds. Conversation/learned are skipped (batches
-    /// only pick Queued tasks). Artifacts, telemetry, and follow-up ingestion land.
+    /// The parallel path runs validation in the isolated worktree before merge,
+    /// preserving the same fatal gate and channel events as serial execution.
+    /// Post-run hooks remain deferred because they may rely on workspace-local
+    /// dependencies. Conversation/learned are skipped (batches only pick Queued
+    /// tasks). Artifacts, telemetry, and follow-up ingestion land.
     pub fn parallel() -> Self {
         Self {
             post_hooks: false,
-            validation: false,
+            validation: true,
             conversation: false,
             learned: false,
             artifacts: true,

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
 
@@ -332,10 +332,11 @@ fn serial_worktree_evidence(
     })
 }
 
-const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 17] = [
+const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 18] = [
     "run.yaml",
     "task-packet.md",
     "worker.pid",
+    "worker-process.yaml",
     "worker-output.log",
     "git-finish.json",
     "git-integration.json",
@@ -2818,6 +2819,46 @@ pub(crate) fn live_worker_pid(run_dir: &std::path::Path) -> Option<u32> {
         .ok()?
         .success()
         .then_some(pid)
+}
+
+pub(crate) fn verified_worker_pid_for_redirect(
+    run_dir: &std::path::Path,
+    expected_task_id: &str,
+    expected_attempt_id: &str,
+    expected_worker_id: &str,
+) -> Result<u32> {
+    let record: RunRecord =
+        state::load_yaml(&run_dir.join("run.yaml")).context("loading redirect run identity")?;
+    let path_run_id = run_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| anyhow!("redirect run directory has no valid identity"))?;
+    if record.run_id != path_run_id
+        || record.task_id != expected_task_id
+        || record.completed_at.is_some()
+        || record.state != "running"
+    {
+        bail!("redirect run identity/provenance mismatch; refusing to signal a process");
+    }
+
+    let provenance = workers::load_worker_process_provenance(run_dir)
+        .context("worker process provenance is missing or invalid; refusing redirect signal")?;
+    if provenance.schema_version != 1
+        || provenance.run_id != record.run_id
+        || provenance.attempt_id != expected_attempt_id
+        || provenance.worker_id != expected_worker_id
+        || provenance.pid == 0
+    {
+        bail!(
+            "worker process provenance does not match the active attempt; refusing redirect signal"
+        );
+    }
+    let observed_start = workers::process_start_marker(provenance.pid)
+        .ok_or_else(|| anyhow!("verified worker process is no longer alive"))?;
+    if observed_start != provenance.process_start_marker {
+        bail!("worker process identity changed since spawn; refusing redirect signal");
+    }
+    Ok(provenance.pid)
 }
 
 /// A run Yardlet never finalized: its `worker.pid` is still on disk (a finalized

--- a/src/run.rs
+++ b/src/run.rs
@@ -657,6 +657,59 @@ fn record_channel_event(
     }
 }
 
+fn live_worker_event_sink(
+    ws: &Workspace,
+    context: &ChannelRunContext,
+    attempt: &WorkerAttempt,
+) -> workers::AttemptEventSink {
+    let ws = ws.clone();
+    let context = context.clone();
+    let attempt_id = attempt.attempt_id.clone();
+    let worker_id = attempt.worker_id.clone();
+    std::sync::Arc::new(move |normalized| {
+        let channel = ws
+            .load_task_channel(&context.intent_id, &context.task_id)
+            .map_err(|error| error.to_string())?;
+        if let Some(existing) = channel.events.iter().find(|event| {
+            event.attempt_id.as_deref() == Some(&attempt_id)
+                && event.event_type == normalized.event_type
+                && event.raw_ref.as_ref() == Some(&normalized.raw_ref)
+        }) {
+            if existing.payload == normalized.payload {
+                return Ok(());
+            }
+            return Err(format!(
+                "normalized raw event changed for {} at {}..{}",
+                normalized.raw_ref.artifact_id,
+                normalized.raw_ref.byte_start,
+                normalized.raw_ref.byte_end
+            ));
+        }
+        let causation_id = channel
+            .events
+            .iter()
+            .rev()
+            .find(|event| event.attempt_id.as_deref() == Some(&attempt_id))
+            .map(|event| event.event_id.clone());
+        record_channel_event(
+            &ws,
+            None,
+            &context,
+            normalized.event_type,
+            EventActor {
+                kind: EventActorKind::Worker,
+                id: worker_id.clone(),
+            },
+            Some(&attempt_id),
+            causation_id,
+            normalized.payload,
+            Some(normalized.raw_ref),
+        )
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+    })
+}
+
 fn raw_attempt_path(ws: &Workspace, reference: &str) -> PathBuf {
     let path = std::path::Path::new(reference);
     if path.is_absolute() {
@@ -878,6 +931,22 @@ pub(crate) fn finish_worker_attempt(
             causation_id = Some(recorded.event_id);
         }
     }
+    if worker_attempt_result(run_dir, outcome) == "needs_user" {
+        if let Ok(result) = std::fs::read_to_string(run_dir.join("result.json")) {
+            if let Ok(result) = serde_json::from_str::<RunResult>(&result) {
+                if let Some(question) = result
+                    .question_for_user
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|question| !question.is_empty())
+                {
+                    if let Some(asked) = record_result_question(ws, context, run_dir, question)? {
+                        causation_id = Some(asked.event_id);
+                    }
+                }
+            }
+        }
+    }
     if !channel.events.iter().any(|event| {
         event.event_type == ChannelEventType::WorkerCompleted
             && event.attempt_id.as_deref() == Some(&attempt.attempt_id)
@@ -952,7 +1021,7 @@ fn record_result_question(
     context: &ChannelRunContext,
     run_dir: &std::path::Path,
     question_text: &str,
-) -> Result<()> {
+) -> Result<Option<ChannelEvent>> {
     let attempt_id = std::fs::read_to_string(run_dir.join("latest-attempt"))
         .with_context(|| format!("reading latest attempt for {}", context.task_id))?;
     let attempt_id = attempt_id.trim();
@@ -962,7 +1031,15 @@ fn record_result_question(
         .iter()
         .any(|question| question.attempt_id == attempt_id && question.text == question_text)
     {
-        return Ok(());
+        return Ok(channel
+            .events
+            .iter()
+            .find(|event| {
+                event.event_type == ChannelEventType::QuestionAsked
+                    && event.attempt_id.as_deref() == Some(attempt_id)
+                    && event.payload["text"] == question_text
+            })
+            .cloned());
     }
     let question_id = format!("qst_{attempt_id}");
     let asked = if let Some(existing) = channel.events.iter().find(|event| {
@@ -1002,7 +1079,7 @@ fn record_result_question(
         session_id: context.session_id.clone(),
         task_id: context.task_id.clone(),
         attempt_id: attempt_id.to_string(),
-        asked_event_id: asked.event_id,
+        asked_event_id: asked.event_id.clone(),
         asked_seq: asked.seq,
         context_start_seq,
         text: question_text.to_string(),
@@ -1010,7 +1087,7 @@ fn record_result_question(
         answer_id: None,
     })?;
     ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
-    Ok(())
+    Ok(Some(asked))
 }
 
 pub(crate) fn action_attempt_id(action_id: &str) -> String {
@@ -1110,7 +1187,10 @@ pub(crate) fn prepare_answer_action(
         .rev()
         .find(|question| question.state == QuestionState::Open)
     else {
-        return Ok(false);
+        if channel.questions.is_empty() {
+            return Ok(false);
+        }
+        bail!("question_closed: task {task_id} has no actionable open question");
     };
     let producer = channel
         .attempts
@@ -1124,6 +1204,15 @@ pub(crate) fn prepare_answer_action(
             std::process::id()
         )
     });
+    let task = queue
+        .tasks
+        .iter()
+        .find(|task| task.id == task_id)
+        .ok_or_else(|| anyhow!("task {task_id} not found in queue"))?;
+    let workers_file = ws.load_workers()?;
+    let billing = ws.load_billing()?;
+    let selected = routing::resolve_worker_for_task(ws, &workers_file, &billing, None, task)?;
+    let same_worker = selected.worker_id == producer.worker_id;
     ws.answer_question(&AnswerActionRequest {
         continuation_attempt_id: action_attempt_id(&action_id),
         answer_id: format!("ans-{}", action_attempt_id(&action_id)),
@@ -1133,9 +1222,11 @@ pub(crate) fn prepare_answer_action(
         task_id: task_id.to_string(),
         question_id: question.question_id.clone(),
         text: reply.to_string(),
-        worker_id: producer.worker_id.clone(),
-        worker_session_ref: producer.worker_session_ref.clone(),
-        supports_native_resume: workers::supports_native_resume(&producer.worker_id),
+        worker_id: selected.worker_id.clone(),
+        worker_session_ref: same_worker
+            .then(|| producer.worker_session_ref.clone())
+            .flatten(),
+        supports_native_resume: same_worker && workers::supports_native_resume(&selected.worker_id),
     })?;
     Ok(true)
 }
@@ -1297,23 +1388,28 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     } else {
         Vec::new()
     };
-    let prepared_answer_attempt = if opts.answer.is_some() {
-        ws.load_task_channel(&queue.intent_id, &task.id)
-            .ok()
-            .and_then(|channel| {
-                channel.attempts.into_iter().rev().find(|attempt| {
-                    attempt.state == AttemptState::Prepared
-                        && matches!(
-                            attempt.continuation,
-                            ContinuationMode::NativeResume
-                                | ContinuationMode::ExplicitPacket
-                                | ContinuationMode::Redirect
-                        )
-                })
+    let prepared_answer_attempt = ws
+        .load_task_channel(&queue.intent_id, &task.id)
+        .ok()
+        .and_then(|channel| {
+            channel.attempts.into_iter().rev().find(|attempt| {
+                attempt.state == AttemptState::Prepared
+                    && matches!(
+                        attempt.continuation,
+                        ContinuationMode::NativeResume
+                            | ContinuationMode::ExplicitPacket
+                            | ContinuationMode::Redirect
+                    )
             })
-    } else {
-        None
-    };
+        });
+    #[cfg(debug_assertions)]
+    if prepared_answer_attempt
+        .as_ref()
+        .is_some_and(|attempt| attempt.continuation == ContinuationMode::Redirect)
+        && std::env::var("YARDLET_TEST_CRASH_AFTER_REDIRECT_RECEIPT").as_deref() == Ok("1")
+    {
+        bail!("injected crash after redirect receipt and before continuation spawn");
+    }
     // Re-running a Partial task uses its checkpoint. An answer/redirect that
     // cannot honestly resume a native provider session receives a bounded,
     // causally explicit packet instead of an unbounded transcript.
@@ -1667,7 +1763,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         first_continuation,
         None,
     )?;
-    let mut outcome = match workers::spawn_attempt(
+    let mut outcome = match workers::spawn_attempt_with_sink(
         &eff_profile,
         &active_bin,
         &packet_text,
@@ -1675,6 +1771,11 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         worker_cwd,
         &env,
         &current_capture,
+        Some(live_worker_event_sink(
+            ws,
+            &channel_context,
+            &current_attempt,
+        )),
         timeout,
         full_access,
         &images,
@@ -1742,7 +1843,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         )?;
         current_attempt = begun.0;
         current_capture = begun.1;
-        outcome = match workers::spawn_attempt(
+        outcome = match workers::spawn_attempt_with_sink(
             &eff_profile,
             &active_bin,
             cont,
@@ -1750,6 +1851,11 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             worker_cwd,
             &env,
             &current_capture,
+            Some(live_worker_event_sink(
+                ws,
+                &channel_context,
+                &current_attempt,
+            )),
             timeout,
             full_access,
             &images,
@@ -1871,7 +1977,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 )?;
                 current_attempt = begun.0;
                 current_capture = begun.1;
-                outcome = match workers::spawn_attempt(
+                outcome = match workers::spawn_attempt_with_sink(
                     &eff_profile,
                     &active_bin,
                     &failover_packet,
@@ -1879,6 +1985,11 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                     worker_cwd,
                     &env,
                     &current_capture,
+                    Some(live_worker_event_sink(
+                        ws,
+                        &channel_context,
+                        &current_attempt,
+                    )),
                     timeout,
                     full_access,
                     &images,
@@ -4365,6 +4476,182 @@ pub(crate) fn feedback_next_state(feedback: &FeedbackRecord) -> TaskState {
     }
 }
 
+fn artifact_content_digest(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+fn artifact_media_type(path: &std::path::Path) -> &'static str {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("json") => "application/json",
+        Some("yaml" | "yml") => "application/yaml",
+        Some("md") => "text/markdown",
+        _ => "application/octet-stream",
+    }
+}
+
+fn record_artifact_created(
+    ws: &Workspace,
+    context: &ChannelRunContext,
+    attempt_id: &str,
+    path: &std::path::Path,
+    recorded_path: &str,
+    role: &str,
+    worker_authored: bool,
+) -> Result<()> {
+    if !path.is_file() {
+        return Ok(());
+    }
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("reading artifact for channel event {}", path.display()))?;
+    let content_digest = artifact_content_digest(&bytes);
+    let seed = format!("{attempt_id}\0{role}\0{recorded_path}\0{content_digest}");
+    let artifact_id = format!(
+        "art_{}",
+        artifact_content_digest(seed.as_bytes()).trim_start_matches("fnv1a64:")
+    );
+    let channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
+    if let Some(existing) = channel.events.iter().find(|event| {
+        event.event_type == ChannelEventType::ArtifactCreated
+            && event.payload["artifact_id"] == artifact_id
+    }) {
+        if existing.payload["content_digest"] == content_digest
+            && existing.attempt_id.as_deref() == Some(attempt_id)
+        {
+            return Ok(());
+        }
+        bail!("artifact event conflict for {artifact_id}");
+    }
+    let worker_id = channel
+        .attempts
+        .iter()
+        .find(|attempt| attempt.attempt_id == attempt_id)
+        .map(|attempt| attempt.worker_id.clone())
+        .ok_or_else(|| anyhow!("artifact producer attempt missing: {attempt_id}"))?;
+    let causation_id = channel.events.last().map(|event| event.event_id.clone());
+    record_channel_event(
+        ws,
+        None,
+        context,
+        ChannelEventType::ArtifactCreated,
+        if worker_authored {
+            EventActor {
+                kind: EventActorKind::Worker,
+                id: worker_id.clone(),
+            }
+        } else {
+            EventActor {
+                kind: EventActorKind::System,
+                id: String::new(),
+            }
+        },
+        Some(attempt_id),
+        causation_id,
+        serde_json::json!({
+            "artifact_id": artifact_id,
+            "path": recorded_path,
+            "content_digest": content_digest,
+            "media_type": artifact_media_type(path),
+            "role": role,
+            "producer_attempt_id": attempt_id,
+            "producer_worker_id": worker_id
+        }),
+        None,
+    )?;
+    Ok(())
+}
+
+fn record_finalization_artifacts(
+    ws: &Workspace,
+    context: &ChannelRunContext,
+    run_dir: &std::path::Path,
+    worker_root: &std::path::Path,
+    result: Option<&RunResult>,
+) -> Result<()> {
+    let Some(attempt_id) = std::fs::read_to_string(run_dir.join("latest-attempt"))
+        .ok()
+        .map(|attempt| attempt.trim().to_string())
+        .filter(|attempt| !attempt.is_empty())
+    else {
+        return Ok(());
+    };
+    for (name, role, worker_authored) in [
+        ("result.json", "worker_result", true),
+        ("evaluation.json", "evaluation", false),
+        ("checkpoint.md", "checkpoint", false),
+        ("handoff.md", "handoff", false),
+    ] {
+        let path = run_dir.join(name);
+        let recorded_path = path
+            .strip_prefix(&ws.root)
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        record_artifact_created(
+            ws,
+            context,
+            &attempt_id,
+            &path,
+            &recorded_path,
+            role,
+            worker_authored,
+        )?;
+    }
+
+    let Some(result) = result else {
+        ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
+        return Ok(());
+    };
+    let Ok(canonical_root) = std::fs::canonicalize(worker_root) else {
+        return Ok(());
+    };
+    let mut declared = result
+        .changes
+        .files_created
+        .iter()
+        .chain(&result.changes.files_modified)
+        .collect::<Vec<_>>();
+    declared.sort();
+    declared.dedup();
+    for recorded_path in declared {
+        let relative = std::path::Path::new(recorded_path);
+        if relative.is_absolute()
+            || relative.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            })
+        {
+            continue;
+        }
+        let path = worker_root.join(relative);
+        let Ok(canonical_path) = std::fs::canonicalize(&path) else {
+            continue;
+        };
+        if canonical_path.strip_prefix(&canonical_root).is_err() || !canonical_path.is_file() {
+            continue;
+        }
+        record_artifact_created(
+            ws,
+            context,
+            &attempt_id,
+            &canonical_path,
+            recorded_path,
+            "worker_declared",
+            true,
+        )?;
+    }
+    ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
+    Ok(())
+}
+
 /// The single finalization pipeline shared by the run paths (Slice 1: serial
 /// only). Evaluate -> gates -> artifacts -> conversation -> learned -> queue
 /// state + follow-up ingestion -> telemetry. Behavior is identical to the
@@ -4567,6 +4854,12 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             append_nonblocking_follow_up_notes(run_dir, r)?;
         }
     }
+    let artifact_context = channel_run_context(ws, &intent_id, &task.id);
+    let worker_root = merge
+        .as_ref()
+        .map(|merge| merge.wt_path)
+        .unwrap_or(ws.root.as_path());
+    record_finalization_artifacts(ws, &artifact_context, run_dir, worker_root, result.as_ref())?;
 
     // Harness learning loop (S3): record skills/rules the worker proposed. The
     // worker authored the content; Yardlet (the core) does the writing.

--- a/src/run.rs
+++ b/src/run.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
 
@@ -18,8 +18,10 @@ use crate::guard;
 use crate::inspect;
 use crate::packet::{self, PacketInputs};
 use crate::schemas::{
-    ConversationTurn, RunResult, TaskState, TransitionActor, TransitionCause, TurnRole, WorkQueue,
-    WorkerProfile, WorkersFile,
+    AnswerActionRequest, AttemptState, ChannelEvent, ChannelEventType, ContinuationMode,
+    ConversationTurn, EventActor, EventActorKind, Question, QuestionState, RunResult, TaskState,
+    TransitionActor, TransitionCause, TurnRole, WorkQueue, WorkerAttempt, WorkerProfile,
+    WorkersFile,
 };
 use crate::state::{self, append_str, write_str, PlanningLock, Workspace};
 use crate::ui::i18n::{self, Lang};
@@ -330,7 +332,7 @@ fn serial_worktree_evidence(
     })
 }
 
-const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 15] = [
+const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 17] = [
     "run.yaml",
     "task-packet.md",
     "worker.pid",
@@ -346,6 +348,8 @@ const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 15] = [
     "validation.json",
     "evidence",
     "hooks",
+    "attempts",
+    "latest-attempt",
 ];
 
 fn is_main_owned_validation_log_name(name: &str) -> bool {
@@ -551,6 +555,590 @@ pub(crate) struct RunFailover {
     pub at: String,
 }
 
+pub(crate) fn attempt_id_for_ordinal(run_id: &str, ordinal: u32) -> String {
+    if ordinal <= 1 {
+        run_id.to_string()
+    } else {
+        format!("{run_id}-attempt-{ordinal}")
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct ChannelRunContext {
+    session_id: String,
+    intent_id: String,
+    task_id: String,
+    correlation_id: String,
+}
+
+pub(crate) fn channel_run_context(
+    ws: &Workspace,
+    intent_id: &str,
+    task_id: &str,
+) -> ChannelRunContext {
+    // Pre-activation/legacy queues had no intent id. Keep that execution path
+    // additive while still giving the durable envelope a non-empty identity.
+    let channel_intent_id = if intent_id.trim().is_empty() {
+        "legacy-intent"
+    } else {
+        intent_id
+    };
+    if let Ok(existing) = ws.load_task_channel(channel_intent_id, task_id) {
+        if !existing.session_id.is_empty() {
+            return ChannelRunContext {
+                correlation_id: existing
+                    .events
+                    .first()
+                    .map(|event| event.correlation_id.clone())
+                    .filter(|id| !id.is_empty())
+                    .unwrap_or_else(|| format!("cor_{}", existing.channel_id)),
+                session_id: existing.session_id,
+                intent_id: channel_intent_id.to_string(),
+                task_id: task_id.to_string(),
+            };
+        }
+    }
+    let session_id = ws
+        .load_activated_intent()
+        .ok()
+        .flatten()
+        .filter(|intent| intent.intent.id == channel_intent_id)
+        .map(|intent| intent.planning_session_id)
+        .filter(|session| !session.is_empty())
+        .unwrap_or_else(|| {
+            format!(
+                "ses_{}",
+                gen_session_uuid(channel_intent_id).replace('-', "")
+            )
+        });
+    ChannelRunContext {
+        correlation_id: format!(
+            "cor_{}",
+            gen_session_uuid(channel_intent_id).replace('-', "")
+        ),
+        session_id,
+        intent_id: channel_intent_id.to_string(),
+        task_id: task_id.to_string(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_channel_event(
+    ws: &Workspace,
+    lock: Option<&PlanningLock>,
+    context: &ChannelRunContext,
+    event_type: ChannelEventType,
+    actor: EventActor,
+    attempt_id: Option<&str>,
+    causation_id: Option<String>,
+    payload: serde_json::Value,
+    raw_ref: Option<crate::schemas::RawEventRef>,
+) -> Result<ChannelEvent> {
+    let event = ChannelEvent {
+        schema_version: 1,
+        event_id: String::new(),
+        session_id: context.session_id.clone(),
+        seq: 0,
+        event_type,
+        recorded_at: Local::now().to_rfc3339(),
+        actor,
+        action_id: None,
+        causation_id,
+        correlation_id: context.correlation_id.clone(),
+        task_id: context.task_id.clone(),
+        attempt_id: attempt_id.map(str::to_string),
+        payload,
+        raw_ref,
+    };
+    match lock {
+        Some(lock) => ws.record_task_event_with_lock(lock, &context.intent_id, event),
+        None => ws.record_task_event(&context.intent_id, event),
+    }
+}
+
+fn raw_attempt_path(ws: &Workspace, reference: &str) -> PathBuf {
+    let path = std::path::Path::new(reference);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else if let Ok(relative) = path.strip_prefix(".agents") {
+        ws.agents_dir().join(relative)
+    } else if reference.starts_with("task-channels/") {
+        ws.agents_dir().join(path)
+    } else {
+        ws.root.join(path)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn begin_worker_attempt(
+    ws: &Workspace,
+    lock: Option<&PlanningLock>,
+    context: &ChannelRunContext,
+    run_dir: &std::path::Path,
+    attempt_id: &str,
+    worker_id: &str,
+    worker_session_ref: Option<String>,
+    continuation: ContinuationMode,
+    caused_by_event_id: Option<String>,
+) -> Result<(WorkerAttempt, workers::AttemptCapture)> {
+    let channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
+    let attempt = if let Some(existing) = channel
+        .attempts
+        .into_iter()
+        .find(|attempt| attempt.attempt_id == attempt_id)
+    {
+        if existing.state != AttemptState::Prepared
+            || existing.worker_id != worker_id
+            || existing.continuation != continuation
+        {
+            return Err(anyhow!("prepared attempt does not match invocation"));
+        }
+        existing
+    } else {
+        let attempt_dir = run_dir.join("attempts").join(attempt_id);
+        let attempt = WorkerAttempt {
+            schema_version: 1,
+            attempt_id: attempt_id.to_string(),
+            session_id: context.session_id.clone(),
+            intent_id: context.intent_id.clone(),
+            task_id: context.task_id.clone(),
+            worker_id: worker_id.to_string(),
+            worker_session_ref,
+            state: AttemptState::Prepared,
+            continuation,
+            caused_by_event_id,
+            caused_by_action_id: None,
+            raw_stdout_ref: attempt_dir.join("stdout.log").display().to_string(),
+            raw_stderr_ref: attempt_dir.join("stderr.log").display().to_string(),
+        };
+        ws.record_worker_attempt(&attempt)?;
+        attempt
+    };
+    let prepared_exists = ws
+        .load_task_channel(&context.intent_id, &context.task_id)?
+        .events
+        .iter()
+        .any(|event| {
+            event.event_type == ChannelEventType::AttemptPrepared
+                && event.attempt_id.as_deref() == Some(attempt_id)
+        });
+    let prepared_event = if prepared_exists {
+        ws.load_task_channel(&context.intent_id, &context.task_id)?
+            .events
+            .into_iter()
+            .find(|event| {
+                event.event_type == ChannelEventType::AttemptPrepared
+                    && event.attempt_id.as_deref() == Some(attempt_id)
+            })
+            .expect("prepared event checked above")
+    } else {
+        record_channel_event(
+            ws,
+            lock,
+            context,
+            ChannelEventType::AttemptPrepared,
+            EventActor {
+                kind: EventActorKind::System,
+                id: String::new(),
+            },
+            Some(attempt_id),
+            attempt.caused_by_event_id.clone(),
+            serde_json::json!({
+                "worker_id": worker_id,
+                "worker_session_ref": attempt.worker_session_ref,
+                "continuation": continuation
+            }),
+            None,
+        )?
+    };
+    let started_exists = ws
+        .load_task_channel(&context.intent_id, &context.task_id)?
+        .events
+        .iter()
+        .any(|event| {
+            event.event_type == ChannelEventType::WorkerStarted
+                && event.attempt_id.as_deref() == Some(attempt_id)
+        });
+    if !started_exists {
+        record_channel_event(
+            ws,
+            lock,
+            context,
+            ChannelEventType::WorkerStarted,
+            EventActor {
+                kind: EventActorKind::Worker,
+                id: worker_id.to_string(),
+            },
+            Some(attempt_id),
+            Some(prepared_event.event_id),
+            serde_json::json!({"worker_id": worker_id}),
+            None,
+        )?;
+    }
+    state::write_str_atomic(&run_dir.join("latest-attempt"), &format!("{attempt_id}\n"))?;
+    let capture = workers::AttemptCapture {
+        combined_log: run_dir.join("worker-output.log"),
+        stdout_log: raw_attempt_path(ws, &attempt.raw_stdout_ref),
+        stderr_log: raw_attempt_path(ws, &attempt.raw_stderr_ref),
+    };
+    Ok((attempt, capture))
+}
+
+fn worker_attempt_result(
+    run_dir: &std::path::Path,
+    outcome: &workers::WorkerOutcome,
+) -> &'static str {
+    if run_dir.join("cancelled").is_file() {
+        return "cancelled";
+    }
+    if outcome.timed_out {
+        return "timed_out";
+    }
+    if let Ok(raw) = std::fs::read_to_string(run_dir.join("result.json")) {
+        if let Ok(result) = serde_json::from_str::<RunResult>(&raw) {
+            return match result.status.as_str() {
+                "needs_user" => "needs_user",
+                "failed" => "failed",
+                _ => "succeeded",
+            };
+        }
+    }
+    "failed"
+}
+
+pub(crate) fn finish_worker_attempt(
+    ws: &Workspace,
+    lock: Option<&PlanningLock>,
+    context: &ChannelRunContext,
+    run_dir: &std::path::Path,
+    attempt: &WorkerAttempt,
+    capture: &workers::AttemptCapture,
+    outcome: &workers::WorkerOutcome,
+) -> Result<()> {
+    let mut channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
+    let mut causation_id = channel
+        .events
+        .iter()
+        .find(|event| {
+            event.event_type == ChannelEventType::WorkerStarted
+                && event.attempt_id.as_deref() == Some(&attempt.attempt_id)
+        })
+        .map(|event| event.event_id.clone());
+    for (stream, path, artifact_id) in [
+        (
+            workers::RawStreamKind::Stdout,
+            &capture.stdout_log,
+            format!("raw_{}_stdout", attempt.attempt_id),
+        ),
+        (
+            workers::RawStreamKind::Stderr,
+            &capture.stderr_log,
+            format!("raw_{}_stderr", attempt.attempt_id),
+        ),
+    ] {
+        let raw = std::fs::read(path)
+            .with_context(|| format!("reading attempt raw stream {}", path.display()))?;
+        for normalized in
+            workers::normalize_worker_output(&attempt.worker_id, stream, &raw, &artifact_id)
+        {
+            let existing = channel.events.iter().find(|event| {
+                event.attempt_id.as_deref() == Some(&attempt.attempt_id)
+                    && event.event_type == normalized.event_type
+                    && event.raw_ref.as_ref() == Some(&normalized.raw_ref)
+            });
+            let recorded = if let Some(existing) = existing {
+                if existing.payload != normalized.payload {
+                    return Err(anyhow!(
+                        "normalized raw event changed for {} at {}..{}",
+                        normalized.raw_ref.artifact_id,
+                        normalized.raw_ref.byte_start,
+                        normalized.raw_ref.byte_end
+                    ));
+                }
+                existing.clone()
+            } else {
+                let recorded = record_channel_event(
+                    ws,
+                    lock,
+                    context,
+                    normalized.event_type,
+                    EventActor {
+                        kind: EventActorKind::Worker,
+                        id: attempt.worker_id.clone(),
+                    },
+                    Some(&attempt.attempt_id),
+                    causation_id,
+                    normalized.payload,
+                    Some(normalized.raw_ref),
+                )?;
+                channel.events.push(recorded.clone());
+                recorded
+            };
+            causation_id = Some(recorded.event_id);
+        }
+    }
+    if !channel.events.iter().any(|event| {
+        event.event_type == ChannelEventType::WorkerCompleted
+            && event.attempt_id.as_deref() == Some(&attempt.attempt_id)
+    }) {
+        record_channel_event(
+            ws,
+            lock,
+            context,
+            ChannelEventType::WorkerCompleted,
+            EventActor {
+                kind: EventActorKind::System,
+                id: String::new(),
+            },
+            Some(&attempt.attempt_id),
+            causation_id,
+            serde_json::json!({
+                "result": worker_attempt_result(run_dir, outcome),
+                "exit_ok": outcome.exit_ok,
+                "timed_out": outcome.timed_out,
+                "worker_session_ref": outcome.session_id
+            }),
+            None,
+        )?;
+    }
+    ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
+    Ok(())
+}
+
+pub(crate) fn finish_worker_attempt_error(
+    ws: &Workspace,
+    context: &ChannelRunContext,
+    attempt: &WorkerAttempt,
+    error: &anyhow::Error,
+) -> Result<()> {
+    let channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
+    if channel.events.iter().any(|event| {
+        event.event_type == ChannelEventType::WorkerCompleted
+            && event.attempt_id.as_deref() == Some(&attempt.attempt_id)
+    }) {
+        return Ok(());
+    }
+    let causation_id = channel
+        .events
+        .into_iter()
+        .rev()
+        .find(|event| event.attempt_id.as_deref() == Some(&attempt.attempt_id))
+        .map(|event| event.event_id);
+    record_channel_event(
+        ws,
+        None,
+        context,
+        ChannelEventType::WorkerCompleted,
+        EventActor {
+            kind: EventActorKind::System,
+            id: String::new(),
+        },
+        Some(&attempt.attempt_id),
+        causation_id,
+        serde_json::json!({
+            "result": "failed",
+            "spawn_error": error.to_string(),
+            "worker_session_ref": attempt.worker_session_ref
+        }),
+        None,
+    )?;
+    ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
+    Ok(())
+}
+
+fn record_result_question(
+    ws: &Workspace,
+    context: &ChannelRunContext,
+    run_dir: &std::path::Path,
+    question_text: &str,
+) -> Result<()> {
+    let attempt_id = std::fs::read_to_string(run_dir.join("latest-attempt"))
+        .with_context(|| format!("reading latest attempt for {}", context.task_id))?;
+    let attempt_id = attempt_id.trim();
+    let channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
+    if channel
+        .questions
+        .iter()
+        .any(|question| question.attempt_id == attempt_id && question.text == question_text)
+    {
+        return Ok(());
+    }
+    let question_id = format!("qst_{attempt_id}");
+    let asked = if let Some(existing) = channel.events.iter().find(|event| {
+        event.event_type == ChannelEventType::QuestionAsked
+            && event.attempt_id.as_deref() == Some(attempt_id)
+            && event.payload["question_id"] == question_id
+    }) {
+        if existing.payload["text"] != question_text {
+            return Err(anyhow!("question event payload changed after persistence"));
+        }
+        existing.clone()
+    } else {
+        record_channel_event(
+            ws,
+            None,
+            context,
+            ChannelEventType::QuestionAsked,
+            EventActor {
+                kind: EventActorKind::Worker,
+                id: channel
+                    .attempts
+                    .iter()
+                    .find(|attempt| attempt.attempt_id == attempt_id)
+                    .map(|attempt| attempt.worker_id.clone())
+                    .unwrap_or_else(|| "unknown".to_string()),
+            },
+            Some(attempt_id),
+            channel.events.last().map(|event| event.event_id.clone()),
+            serde_json::json!({"question_id": question_id, "text": question_text}),
+            None,
+        )?
+    };
+    let context_start_seq = asked.seq.saturating_sub(20).max(1);
+    ws.record_question(&Question {
+        schema_version: 1,
+        question_id,
+        session_id: context.session_id.clone(),
+        task_id: context.task_id.clone(),
+        attempt_id: attempt_id.to_string(),
+        asked_event_id: asked.event_id,
+        asked_seq: asked.seq,
+        context_start_seq,
+        text: question_text.to_string(),
+        state: QuestionState::Open,
+        answer_id: None,
+    })?;
+    ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
+    Ok(())
+}
+
+pub(crate) fn action_attempt_id(action_id: &str) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in action_id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("att-action-{hash:016x}")
+}
+
+fn explicit_continuation_packet(
+    attempt_id: &str,
+    caused_by_event_id: Option<&str>,
+    caused_by_action_id: Option<&str>,
+    public_context: &[(u64, String)],
+    checkpoint: Option<&str>,
+) -> String {
+    const CONTEXT_LIMIT: usize = 20;
+    let retained = public_context.len().saturating_sub(CONTEXT_LIMIT);
+    let mut packet = format!(
+        "Explicit continuation packet\n\
+         continuation_attempt_id: {attempt_id}\n\
+         caused_by_event_id: {}\n\
+         caused_by_action_id: {}\n",
+        caused_by_event_id.unwrap_or("none"),
+        caused_by_action_id.unwrap_or("none")
+    );
+    if let Some(checkpoint) = checkpoint.filter(|value| !value.trim().is_empty()) {
+        packet.push_str("\nCheckpoint:\n");
+        packet.push_str(checkpoint.trim());
+        packet.push('\n');
+    }
+    packet.push_str("\nBounded public channel context:\n");
+    for (seq, text) in &public_context[retained..] {
+        packet.push_str(&format!("[{seq}] {}\n", text.trim()));
+    }
+    packet
+}
+
+fn public_channel_context(channel: &crate::schemas::TaskChannel) -> Vec<(u64, String)> {
+    channel
+        .events
+        .iter()
+        .filter_map(|event| {
+            let text = match event.event_type {
+                ChannelEventType::WorkerMessage
+                | ChannelEventType::QuestionAsked
+                | ChannelEventType::UserAnswered => event
+                    .payload
+                    .get("text")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_string),
+                ChannelEventType::ToolStarted | ChannelEventType::ToolCompleted => Some(format!(
+                    "{}: {}",
+                    event.event_type.as_str(),
+                    event
+                        .payload
+                        .get("name")
+                        .or_else(|| event.payload.get("command"))
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("tool")
+                )),
+                ChannelEventType::WorkerCheckpoint => Some("worker.checkpoint".to_string()),
+                ChannelEventType::WorkerCompleted => Some(format!(
+                    "worker.completed: {}",
+                    event
+                        .payload
+                        .get("result")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("unknown")
+                )),
+                _ => None,
+            }?;
+            (!text.trim().is_empty()).then_some((event.seq, text))
+        })
+        .collect()
+}
+
+/// Bind a UI or CLI reply to the exact open channel question before `run_next`
+/// appends the legacy conversation turn. Legacy channels remain additive and
+/// simply return `false`.
+pub(crate) fn prepare_answer_action(
+    ws: &Workspace,
+    task_id: &str,
+    reply: &str,
+    requested_action_id: Option<String>,
+) -> Result<bool> {
+    let queue = ws.load_queue()?;
+    if queue.intent_id.is_empty() {
+        return Ok(false);
+    }
+    let channel = ws.load_task_channel(&queue.intent_id, task_id)?;
+    let Some(question) = channel
+        .questions
+        .iter()
+        .rev()
+        .find(|question| question.state == QuestionState::Open)
+    else {
+        return Ok(false);
+    };
+    let producer = channel
+        .attempts
+        .iter()
+        .find(|attempt| attempt.attempt_id == question.attempt_id)
+        .ok_or_else(|| anyhow!("question producer attempt is missing"))?;
+    let action_id = requested_action_id.unwrap_or_else(|| {
+        format!(
+            "act-answer-{}-{}",
+            chrono::Utc::now().format("%Y%m%d%H%M%S%6f"),
+            std::process::id()
+        )
+    });
+    ws.answer_question(&AnswerActionRequest {
+        continuation_attempt_id: action_attempt_id(&action_id),
+        answer_id: format!("ans-{}", action_attempt_id(&action_id)),
+        action_id,
+        session_id: channel.session_id.clone(),
+        intent_id: queue.intent_id,
+        task_id: task_id.to_string(),
+        question_id: question.question_id.clone(),
+        text: reply.to_string(),
+        worker_id: producer.worker_id.clone(),
+        worker_session_ref: producer.worker_session_ref.clone(),
+        supports_native_resume: workers::supports_native_resume(&producer.worker_id),
+    })?;
+    Ok(true)
+}
+
 pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     // Serialize queue selection and the first runtime transition against a
     // planning confirmation. Once Running is canonical, confirm observes it
@@ -708,9 +1296,42 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     } else {
         Vec::new()
     };
-    // Re-running a Partial task: continue from the previous run's checkpoint
-    // instead of redoing the work from scratch.
-    let continuation = if task.state == TaskState::Partial {
+    let prepared_answer_attempt = if opts.answer.is_some() {
+        ws.load_task_channel(&queue.intent_id, &task.id)
+            .ok()
+            .and_then(|channel| {
+                channel.attempts.into_iter().rev().find(|attempt| {
+                    attempt.state == AttemptState::Prepared
+                        && matches!(
+                            attempt.continuation,
+                            ContinuationMode::NativeResume
+                                | ContinuationMode::ExplicitPacket
+                                | ContinuationMode::Redirect
+                        )
+                })
+            })
+    } else {
+        None
+    };
+    // Re-running a Partial task uses its checkpoint. An answer/redirect that
+    // cannot honestly resume a native provider session receives a bounded,
+    // causally explicit packet instead of an unbounded transcript.
+    let continuation = if let Some(attempt) = prepared_answer_attempt.as_ref().filter(|attempt| {
+        matches!(
+            attempt.continuation,
+            ContinuationMode::ExplicitPacket | ContinuationMode::Redirect
+        )
+    }) {
+        let channel = ws.load_task_channel(&queue.intent_id, &task.id)?;
+        let context = public_channel_context(&channel);
+        Some(explicit_continuation_packet(
+            &attempt.attempt_id,
+            attempt.caused_by_event_id.as_deref(),
+            attempt.caused_by_action_id.as_deref(),
+            &context,
+            continuation_context(ws, &task.id).as_deref(),
+        ))
+    } else if task.state == TaskState::Partial {
         continuation_context(ws, &task.id)
     } else {
         None
@@ -990,7 +1611,6 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
 
     // Session id for resume-on-transient: claude lets us set one up front; codex
     // generates its own, captured from that child's JSONL stdout.
-    let log_path = run_dir.join("worker-output.log");
     let mut effective_chained = chained;
     let mut session_id: Option<String> = if chained {
         opts.chain.as_ref().map(|c| c.session.clone())
@@ -999,6 +1619,15 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     } else {
         None
     };
+    let channel_context = channel_run_context(ws, &queue.intent_id, &task.id);
+    if let Some(attempt) = &prepared_answer_attempt {
+        if attempt.continuation == ContinuationMode::NativeResume {
+            session_id = attempt.worker_session_ref.clone();
+            effective_chained = true;
+        } else {
+            effective_chained = false;
+        }
+    }
     // Snapshot the workspace before the worker runs so the evaluator can diff
     // against ACTUAL on-disk changes, not the worker's self-report. Git
     // workspaces use `git status`; non-git workspaces use a bounded folder scan.
@@ -1011,25 +1640,66 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         .map(|owned| owned.path.as_path())
         .unwrap_or(ws.root.as_path());
     let run_started = std::time::Instant::now();
-    let mut outcome = workers::spawn(
+    let mut attempt_ordinal = 1_u32;
+    let first_attempt_id = prepared_answer_attempt
+        .as_ref()
+        .map(|attempt| attempt.attempt_id.clone())
+        .unwrap_or_else(|| attempt_id_for_ordinal(&run_id, attempt_ordinal));
+    let first_continuation = prepared_answer_attempt
+        .as_ref()
+        .map(|attempt| attempt.continuation)
+        .unwrap_or_else(|| {
+            if chained {
+                ContinuationMode::NativeResume
+            } else {
+                ContinuationMode::Fresh
+            }
+        });
+    let (mut current_attempt, mut current_capture) = begin_worker_attempt(
+        ws,
+        None,
+        &channel_context,
+        &run_dir,
+        &first_attempt_id,
+        &active_worker_id,
+        session_id.clone(),
+        first_continuation,
+        None,
+    )?;
+    let mut outcome = match workers::spawn_attempt(
         &eff_profile,
         &active_bin,
         &packet_text,
         worker_run_dir,
         worker_cwd,
         &env,
-        &log_path,
+        &current_capture,
         timeout,
         full_access,
         &images,
         session_id.as_deref(),
-        chained,
-    )?;
+        effective_chained,
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            finish_worker_attempt_error(ws, &channel_context, &current_attempt, &error)?;
+            return Err(error);
+        }
+    };
     // From this point the worktree may contain completed or partially completed
     // worker work. Any import/finalization error must retain it for recovery;
     // the guard is only for failures before a worker actually ran.
     serial_cleanup.disarm();
     import_worker_run_artifacts(worker_run_dir, &run_dir)?;
+    finish_worker_attempt(
+        ws,
+        None,
+        &channel_context,
+        &run_dir,
+        &current_attempt,
+        &current_capture,
+        &outcome,
+    )?;
     if active_worker_id == "codex" && session_id.is_none() {
         session_id = outcome.session_id.clone();
         if session_id.is_none() {
@@ -1056,21 +1726,51 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         let cont = "The previous run was interrupted by a connection error before it finished. \
                     Continue from where you left off, complete the task, and write the result file \
                     exactly as specified in the original task packet.";
-        outcome = workers::spawn(
+        attempt_ordinal += 1;
+        let attempt_id = attempt_id_for_ordinal(&run_id, attempt_ordinal);
+        let begun = begin_worker_attempt(
+            ws,
+            None,
+            &channel_context,
+            &run_dir,
+            &attempt_id,
+            &active_worker_id,
+            session_id.clone(),
+            ContinuationMode::NativeResume,
+            None,
+        )?;
+        current_attempt = begun.0;
+        current_capture = begun.1;
+        outcome = match workers::spawn_attempt(
             &eff_profile,
             &active_bin,
             cont,
             worker_run_dir,
             worker_cwd,
             &env,
-            &log_path,
+            &current_capture,
             timeout,
             full_access,
             &images,
             session_id.as_deref(),
             true,
-        )?;
+        ) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                finish_worker_attempt_error(ws, &channel_context, &current_attempt, &error)?;
+                return Err(error);
+            }
+        };
         import_worker_run_artifacts(worker_run_dir, &run_dir)?;
+        finish_worker_attempt(
+            ws,
+            None,
+            &channel_context,
+            &run_dir,
+            &current_attempt,
+            &current_capture,
+            &outcome,
+        )?;
     }
 
     // User stopped it (Esc): requeue rather than evaluate as a real failure.
@@ -1155,21 +1855,56 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                     approved,
                 });
                 write_str(&workers::packet_path(&run_dir), &failover_packet)?;
-                outcome = workers::spawn(
+                attempt_ordinal += 1;
+                let attempt_id = attempt_id_for_ordinal(&run_id, attempt_ordinal);
+                let begun = begin_worker_attempt(
+                    ws,
+                    None,
+                    &channel_context,
+                    &run_dir,
+                    &attempt_id,
+                    &active_worker_id,
+                    session_id.clone(),
+                    ContinuationMode::Fallback,
+                    None,
+                )?;
+                current_attempt = begun.0;
+                current_capture = begun.1;
+                outcome = match workers::spawn_attempt(
                     &eff_profile,
                     &active_bin,
                     &failover_packet,
                     worker_run_dir,
                     worker_cwd,
                     &env,
-                    &log_path,
+                    &current_capture,
                     timeout,
                     full_access,
                     &images,
                     session_id.as_deref(),
                     false,
-                )?;
+                ) {
+                    Ok(outcome) => outcome,
+                    Err(error) => {
+                        finish_worker_attempt_error(
+                            ws,
+                            &channel_context,
+                            &current_attempt,
+                            &error,
+                        )?;
+                        return Err(error);
+                    }
+                };
                 import_worker_run_artifacts(worker_run_dir, &run_dir)?;
+                finish_worker_attempt(
+                    ws,
+                    None,
+                    &channel_context,
+                    &run_dir,
+                    &current_attempt,
+                    &current_capture,
+                    &outcome,
+                )?;
                 if active_worker_id == "codex" && session_id.is_none() {
                     session_id = outcome.session_id.clone();
                     if session_id.is_none() {
@@ -1368,6 +2103,13 @@ pub(crate) mod gate_msg {
 /// coming back partial, including across restarts. `bypass` drops the worker sandbox for the whole run
 /// (workers still self-gate dangerous actions per the packet).
 #[allow(clippy::too_many_arguments)]
+/// A held decision is local to its dependency branch. Auto-drain may keep
+/// selecting other ready work; only a hard block or an actually running task
+/// ends the current drain loop.
+fn continues_auto_drain(state: TaskState) -> bool {
+    !matches!(state, TaskState::Blocked | TaskState::Running)
+}
+
 pub fn run_auto<F: FnMut(&str)>(
     ws: &Workspace,
     bypass: bool,
@@ -1694,6 +2436,9 @@ pub fn run_auto<F: FnMut(&str)>(
             }
             TaskState::NeedsUser => {
                 emit(gate_msg::needs_user(&report.task_id));
+                if continues_auto_drain(state) {
+                    continue;
+                }
                 break;
             }
             TaskState::Partial => {
@@ -2960,7 +3705,7 @@ pub(crate) fn find_worker<'a>(workers: &'a [WorkerProfile], id: &str) -> Result<
         .ok_or_else(|| anyhow!("worker '{id}' is not defined in .agents/workers.yaml"))
 }
 
-fn save_task_state_on_latest_queue(
+pub(crate) fn save_task_state_on_latest_queue(
     ws: &Workspace,
     fallback_queue: &mut WorkQueue,
     task_id: &str,
@@ -3642,8 +4387,48 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             .map(|m| m.wt_path)
             .unwrap_or(ws.root.as_path());
         let validation_cmds = validation_commands(task);
+        let validation_attempt = std::fs::read_to_string(run_dir.join("latest-attempt"))
+            .ok()
+            .map(|attempt| attempt.trim().to_string())
+            .filter(|attempt| !attempt.is_empty());
+        let validation_context = channel_run_context(ws, &intent_id, &task.id);
+        let validation_started = if let Some(attempt_id) = validation_attempt.as_deref() {
+            Some(record_channel_event(
+                ws,
+                None,
+                &validation_context,
+                ChannelEventType::ValidationStarted,
+                EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                Some(attempt_id),
+                None,
+                serde_json::json!({"commands": validation_cmds.clone()}),
+                None,
+            )?)
+        } else {
+            None
+        };
         let (validation_ran, validation_passed) =
             run_validation_commands(&validation_cmds, validation_cwd, run_dir, billing);
+        if let Some(attempt_id) = validation_attempt.as_deref() {
+            record_channel_event(
+                ws,
+                None,
+                &validation_context,
+                ChannelEventType::ValidationCompleted,
+                EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                Some(attempt_id),
+                validation_started.map(|event| event.event_id),
+                serde_json::json!({"ran": validation_ran, "passed": validation_passed}),
+                None,
+            )?;
+            ws.load_or_rebuild_task_channel(&validation_context.intent_id, &task.id)?;
+        }
         if (validation_ran && !validation_passed) || (validation_required(task) && !validation_ran)
         {
             lines.push("validation failed (blocks Done)".to_string());
@@ -3693,6 +4478,17 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             next_state = TaskState::NeedsUser;
             lines.push(format!("feedback stopped: {}", f.terminal_reason));
         }
+    }
+
+    if let Some(question) = result
+        .as_ref()
+        .filter(|result| result.status == "needs_user")
+        .and_then(|result| result.question_for_user.as_deref())
+        .map(str::trim)
+        .filter(|question| !question.is_empty())
+    {
+        let channel_context = channel_run_context(ws, &intent_id, &task.id);
+        record_result_question(ws, &channel_context, run_dir, question)?;
     }
 
     // Record the worker's user-facing message into the conversation transcript
@@ -4121,6 +4917,40 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     }
 
     drop(queue_lock);
+
+    if let Some(attempt_id) = std::fs::read_to_string(run_dir.join("latest-attempt"))
+        .ok()
+        .map(|attempt| attempt.trim().to_string())
+        .filter(|attempt| !attempt.is_empty())
+    {
+        let context = channel_run_context(ws, &intent_id, &task.id);
+        let channel = ws.load_task_channel(&context.intent_id, &task.id)?;
+        let completion_id = format!("cmp_{run_id}");
+        if !channel.events.iter().any(|event| {
+            event.event_type == ChannelEventType::CompletionRecorded
+                && event.payload["completion_id"] == completion_id
+        }) {
+            record_channel_event(
+                ws,
+                None,
+                &context,
+                ChannelEventType::CompletionRecorded,
+                EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                Some(&attempt_id),
+                channel.events.last().map(|event| event.event_id.clone()),
+                serde_json::json!({
+                    "completion_id": completion_id,
+                    "run_id": run_id,
+                    "task_state": run_outcome_label(evaluated_state)
+                }),
+                None,
+            )?;
+            ws.load_or_rebuild_task_channel(&context.intent_id, &task.id)?;
+        }
+    }
 
     if flags.telemetry {
         let _ = telemetry::append_run(
@@ -4590,6 +5420,18 @@ pub fn latest_question_for(ws: &Workspace, task_id: &str) -> Option<String> {
         .as_ref()
         .map(|q| q.intent_id.clone())
         .filter(|s| !s.is_empty());
+    if let Some(intent_id) = current_intent.as_deref() {
+        if let Ok(channel) = ws.load_task_channel(intent_id, task_id) {
+            if let Some(question) = channel
+                .questions
+                .iter()
+                .rev()
+                .find(|question| question.state == QuestionState::Open)
+            {
+                return Some(question.text.clone());
+            }
+        }
+    }
     let mut best: Option<(SystemTime, String)> = None;
     if let Ok(entries) = std::fs::read_dir(ws.runs_dir()) {
         for entry in entries.flatten() {
@@ -4680,6 +5522,17 @@ pub fn latest_question_for(ws: &Workspace, task_id: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn every_invocation_ordinal_gets_a_distinct_attempt_identity() {
+        assert_eq!(attempt_id_for_ordinal("run-1", 1), "run-1");
+        assert_eq!(attempt_id_for_ordinal("run-1", 2), "run-1-attempt-2");
+        assert_eq!(attempt_id_for_ordinal("run-1", 3), "run-1-attempt-3");
+        assert_ne!(
+            attempt_id_for_ordinal("run-1", 2),
+            attempt_id_for_ordinal("run-1", 3)
+        );
+    }
     use crate::schemas::{SelectionPolicy, Task, WorkQueue};
 
     #[test]
@@ -7985,6 +8838,34 @@ exit 1
             dependent,
         ]);
         assert_eq!(select_next(&q, &opts()).unwrap(), None);
+    }
+
+    #[test]
+    fn a_new_needs_user_result_does_not_stop_the_independent_drain() {
+        assert!(continues_auto_drain(TaskState::NeedsUser));
+        assert!(continues_auto_drain(TaskState::Done));
+        assert!(!continues_auto_drain(TaskState::Blocked));
+        assert!(!continues_auto_drain(TaskState::Running));
+    }
+
+    #[test]
+    fn explicit_continuation_packet_is_bounded_and_causally_exact() {
+        let context = (1..=25)
+            .map(|seq| (seq, format!("message-{seq}")))
+            .collect::<Vec<_>>();
+        let packet = explicit_continuation_packet(
+            "att-next",
+            Some("evt-answer"),
+            Some("act-answer"),
+            &context,
+            Some("checkpoint text"),
+        );
+        assert!(!packet.contains("message-5\n"));
+        assert!(packet.contains("message-6"));
+        assert!(packet.contains("message-25"));
+        assert!(packet.contains("caused_by_event_id: evt-answer"));
+        assert!(packet.contains("caused_by_action_id: act-answer"));
+        assert!(packet.contains("checkpoint text"));
     }
 
     #[test]

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1661,6 +1661,463 @@ pub struct Conversation {
     pub turns: Vec<ConversationTurn>,
 }
 
+// ---------------------------------------------------------------------------
+// .agents/task-channels/** — V010-003 durable task channel facts/projection
+// ---------------------------------------------------------------------------
+
+/// Stable normalized event vocabulary shared by CLI/TUI projections. Unknown
+/// strings are retained so additive provider events stay displayable without
+/// being mistaken for scheduler evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelEventType {
+    TaskStateChanged,
+    AttemptPrepared,
+    WorkerStarted,
+    WorkerMessage,
+    ToolStarted,
+    ToolCompleted,
+    WorkerCheckpoint,
+    QuestionAsked,
+    UserAnswered,
+    ArtifactCreated,
+    ValidationStarted,
+    ValidationCompleted,
+    WorkerCompleted,
+    CompletionRecorded,
+    ActionRequested,
+    ActionCompleted,
+    ActionRejected,
+    Unknown(String),
+}
+
+impl ChannelEventType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::TaskStateChanged => "task.state.changed",
+            Self::AttemptPrepared => "attempt.prepared",
+            Self::WorkerStarted => "worker.started",
+            Self::WorkerMessage => "worker.message",
+            Self::ToolStarted => "tool.started",
+            Self::ToolCompleted => "tool.completed",
+            Self::WorkerCheckpoint => "worker.checkpoint",
+            Self::QuestionAsked => "question.asked",
+            Self::UserAnswered => "user.answered",
+            Self::ArtifactCreated => "artifact.created",
+            Self::ValidationStarted => "validation.started",
+            Self::ValidationCompleted => "validation.completed",
+            Self::WorkerCompleted => "worker.completed",
+            Self::CompletionRecorded => "completion.recorded",
+            Self::ActionRequested => "action.requested",
+            Self::ActionCompleted => "action.completed",
+            Self::ActionRejected => "action.rejected",
+            Self::Unknown(value) => value,
+        }
+    }
+
+    pub fn requires_attempt(&self) -> bool {
+        matches!(
+            self,
+            Self::AttemptPrepared
+                | Self::WorkerStarted
+                | Self::WorkerMessage
+                | Self::ToolStarted
+                | Self::ToolCompleted
+                | Self::WorkerCheckpoint
+                | Self::QuestionAsked
+                | Self::ArtifactCreated
+                | Self::ValidationStarted
+                | Self::ValidationCompleted
+                | Self::WorkerCompleted
+                | Self::CompletionRecorded
+        )
+    }
+}
+
+impl Serialize for ChannelEventType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ChannelEventType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "task.state.changed" => Self::TaskStateChanged,
+            "attempt.prepared" => Self::AttemptPrepared,
+            "worker.started" => Self::WorkerStarted,
+            "worker.message" => Self::WorkerMessage,
+            "tool.started" => Self::ToolStarted,
+            "tool.completed" => Self::ToolCompleted,
+            "worker.checkpoint" => Self::WorkerCheckpoint,
+            "question.asked" => Self::QuestionAsked,
+            "user.answered" => Self::UserAnswered,
+            "artifact.created" => Self::ArtifactCreated,
+            "validation.started" => Self::ValidationStarted,
+            "validation.completed" => Self::ValidationCompleted,
+            "worker.completed" => Self::WorkerCompleted,
+            "completion.recorded" => Self::CompletionRecorded,
+            "action.requested" => Self::ActionRequested,
+            "action.completed" => Self::ActionCompleted,
+            "action.rejected" => Self::ActionRejected,
+            _ => Self::Unknown(value),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventActorKind {
+    System,
+    User,
+    Worker,
+    Surface,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventActor {
+    pub kind: EventActorKind,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawEventRef {
+    pub artifact_id: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub stream: String,
+    pub byte_start: u64,
+    pub byte_end: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChannelEvent {
+    pub schema_version: u32,
+    pub event_id: String,
+    pub session_id: String,
+    pub seq: u64,
+    #[serde(rename = "type")]
+    pub event_type: ChannelEventType,
+    pub recorded_at: String,
+    pub actor: EventActor,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    pub correlation_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt_id: Option<String>,
+    #[serde(default)]
+    pub payload: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_ref: Option<RawEventRef>,
+}
+
+impl ChannelEvent {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != 1 {
+            return Err("unsupported channel event schema_version".into());
+        }
+        if self.event_id.is_empty()
+            || self.session_id.is_empty()
+            || self.seq == 0
+            || self.recorded_at.is_empty()
+            || self.correlation_id.is_empty()
+            || self.task_id.is_empty()
+        {
+            return Err("channel event is missing required envelope linkage".into());
+        }
+        if matches!(
+            self.actor.kind,
+            EventActorKind::Worker | EventActorKind::Surface
+        ) && self.actor.id.is_empty()
+        {
+            return Err("worker/surface actor id is required".into());
+        }
+        if self.event_type.requires_attempt()
+            && self.attempt_id.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(format!(
+                "attempt_id is required for {}",
+                self.event_type.as_str()
+            ));
+        }
+        if let Some(raw) = &self.raw_ref {
+            if raw.artifact_id.is_empty() || raw.byte_end <= raw.byte_start {
+                return Err("raw_ref must name a non-empty exact byte span".into());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttemptState {
+    Prepared,
+    Running,
+    NeedsUser,
+    Succeeded,
+    Failed,
+    TimedOut,
+    Cancelled,
+    Abandoned,
+}
+
+impl AttemptState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::NeedsUser
+                | Self::Succeeded
+                | Self::Failed
+                | Self::TimedOut
+                | Self::Cancelled
+                | Self::Abandoned
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContinuationMode {
+    Fresh,
+    NativeResume,
+    ExplicitPacket,
+    Retry,
+    Fallback,
+    Redirect,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkerAttempt {
+    pub schema_version: u32,
+    pub attempt_id: String,
+    pub session_id: String,
+    pub intent_id: String,
+    pub task_id: String,
+    pub worker_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_session_ref: Option<String>,
+    pub state: AttemptState,
+    pub continuation: ContinuationMode,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caused_by_event_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caused_by_action_id: Option<String>,
+    pub raw_stdout_ref: String,
+    pub raw_stderr_ref: String,
+}
+
+impl WorkerAttempt {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != 1
+            || self.attempt_id.is_empty()
+            || self.session_id.is_empty()
+            || self.intent_id.is_empty()
+            || self.task_id.is_empty()
+            || self.worker_id.is_empty()
+            || self.raw_stdout_ref.is_empty()
+            || self.raw_stderr_ref.is_empty()
+        {
+            return Err("attempt is missing required identity or raw evidence linkage".into());
+        }
+        if self.continuation == ContinuationMode::NativeResume
+            && self.worker_session_ref.as_deref().is_none_or(str::is_empty)
+        {
+            return Err("native resume requires exact worker_session_ref".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QuestionState {
+    Open,
+    Answered,
+    Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Question {
+    pub schema_version: u32,
+    pub question_id: String,
+    pub session_id: String,
+    pub task_id: String,
+    pub attempt_id: String,
+    pub asked_event_id: String,
+    pub asked_seq: u64,
+    pub context_start_seq: u64,
+    pub text: String,
+    pub state: QuestionState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub answer_id: Option<String>,
+}
+
+impl Question {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != 1
+            || self.question_id.is_empty()
+            || self.session_id.is_empty()
+            || self.task_id.is_empty()
+            || self.attempt_id.is_empty()
+            || self.asked_event_id.is_empty()
+            || self.asked_seq == 0
+            || self.context_start_seq == 0
+            || self.context_start_seq > self.asked_seq
+            || self.text.trim().is_empty()
+        {
+            return Err("question is missing exact channel position linkage".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Answer {
+    pub schema_version: u32,
+    pub answer_id: String,
+    pub question_id: String,
+    pub action_id: String,
+    pub answered_event_id: String,
+    pub text: String,
+}
+
+impl Answer {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != 1
+            || self.answer_id.is_empty()
+            || self.question_id.is_empty()
+            || self.action_id.is_empty()
+            || self.answered_event_id.is_empty()
+            || self.text.trim().is_empty()
+        {
+            return Err("answer is missing exact question/action/event linkage".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelActionKind {
+    Answer,
+    Redirect,
+    Retry,
+    Stop,
+    Resume,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelActionStatus {
+    Prepared,
+    Completed,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionReceipt {
+    pub schema_version: u32,
+    pub action_id: String,
+    pub session_id: String,
+    pub task_id: String,
+    pub action: ChannelActionKind,
+    pub request_digest: String,
+    pub status: ChannelActionStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub result_event_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_attempt_id: Option<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub error: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnswerActionRequest {
+    pub action_id: String,
+    pub answer_id: String,
+    pub continuation_attempt_id: String,
+    pub session_id: String,
+    pub intent_id: String,
+    pub task_id: String,
+    pub question_id: String,
+    pub text: String,
+    pub worker_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worker_session_ref: Option<String>,
+    #[serde(default)]
+    pub supports_native_resume: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnswerActionOutcome {
+    pub receipt: ActionReceipt,
+    pub answer: Answer,
+    pub attempt: WorkerAttempt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedirectActionRequest {
+    pub action_id: String,
+    pub continuation_attempt_id: String,
+    pub session_id: String,
+    pub intent_id: String,
+    pub task_id: String,
+    pub stopped_attempt_id: String,
+    pub observed_terminal_state: AttemptState,
+    pub reason: String,
+    pub guidance: String,
+    pub worker_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RedirectActionOutcome {
+    pub receipt: ActionReceipt,
+    pub attempt: WorkerAttempt,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskChannel {
+    pub schema_version: u32,
+    pub channel_id: String,
+    pub session_id: String,
+    pub intent_id: String,
+    pub task_id: String,
+    pub highest_seq: u64,
+    #[serde(default)]
+    pub attempts: Vec<WorkerAttempt>,
+    #[serde(default)]
+    pub questions: Vec<Question>,
+    #[serde(default)]
+    pub answers: Vec<Answer>,
+    #[serde(default)]
+    pub events: Vec<ChannelEvent>,
+    #[serde(default)]
+    pub replay_errors: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TaskChannelIndex {
+    pub schema_version: u32,
+    pub channel_id: String,
+    pub highest_applied_seq: u64,
+    pub retained_from_seq: u64,
+    pub event_count: usize,
+    #[serde(default)]
+    pub tail_events: Vec<ChannelEvent>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Verdict {
     /// The acceptance-criterion id being judged (e.g. "AC-004").
@@ -2131,5 +2588,93 @@ tasks:
         let encoded = yaml::to_string(&queue).unwrap();
         assert!(encoded.contains("condition: all checks pass"));
         assert!(encoded.contains("max_feedback_cycles: 3"));
+    }
+
+    #[test]
+    fn channel_event_enforces_attempt_and_raw_linkage_additively() {
+        let event: ChannelEvent = serde_json::from_str(
+            r#"{
+                "schema_version": 1,
+                "event_id": "evt_1",
+                "session_id": "ses_1",
+                "seq": 1,
+                "type": "worker.message",
+                "recorded_at": "2026-07-14T00:00:00Z",
+                "actor": { "kind": "worker", "id": "codex" },
+                "correlation_id": "cor_1",
+                "task_id": "YARD-001",
+                "attempt_id": "att_1",
+                "payload": { "text": "visible progress" },
+                "raw_ref": {
+                    "artifact_id": "raw_att_1_stdout",
+                    "stream": "stdout",
+                    "byte_start": 0,
+                    "byte_end": 17
+                },
+                "future_additive_field": true
+            }"#,
+        )
+        .unwrap();
+
+        event.validate().unwrap();
+        assert_eq!(event.event_type, ChannelEventType::WorkerMessage);
+        assert_eq!(event.attempt_id.as_deref(), Some("att_1"));
+
+        let mut missing_attempt = event.clone();
+        missing_attempt.attempt_id = None;
+        assert!(missing_attempt
+            .validate()
+            .unwrap_err()
+            .contains("attempt_id"));
+
+        let mut invalid_raw = event;
+        invalid_raw.raw_ref.as_mut().unwrap().byte_end = 0;
+        assert!(invalid_raw.validate().unwrap_err().contains("raw_ref"));
+    }
+
+    #[test]
+    fn durable_channel_types_preserve_attempt_and_exact_question_causality() {
+        let attempt = WorkerAttempt {
+            schema_version: 1,
+            attempt_id: "att_2".into(),
+            session_id: "ses_1".into(),
+            intent_id: "intent_1".into(),
+            task_id: "YARD-001".into(),
+            worker_id: "codex".into(),
+            worker_session_ref: Some("thread-1".into()),
+            state: AttemptState::Prepared,
+            continuation: ContinuationMode::NativeResume,
+            caused_by_event_id: Some("evt_answer".into()),
+            caused_by_action_id: Some("act_answer".into()),
+            raw_stdout_ref: "attempts/att_2/stdout.log".into(),
+            raw_stderr_ref: "attempts/att_2/stderr.log".into(),
+        };
+        let question = Question {
+            schema_version: 1,
+            question_id: "qst_1".into(),
+            session_id: "ses_1".into(),
+            task_id: "YARD-001".into(),
+            attempt_id: "att_1".into(),
+            asked_event_id: "evt_question".into(),
+            asked_seq: 9,
+            context_start_seq: 4,
+            text: "Which path?".into(),
+            state: QuestionState::Open,
+            answer_id: None,
+        };
+        let answer = Answer {
+            schema_version: 1,
+            answer_id: "ans_1".into(),
+            question_id: question.question_id.clone(),
+            action_id: "act_answer".into(),
+            answered_event_id: "evt_answer".into(),
+            text: "Path A".into(),
+        };
+
+        attempt.validate().unwrap();
+        question.validate().unwrap();
+        answer.validate().unwrap();
+        assert_eq!(attempt.continuation, ContinuationMode::NativeResume);
+        assert_eq!(answer.question_id, question.question_id);
     }
 }

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1678,6 +1678,7 @@ pub enum ChannelEventType {
     ToolCompleted,
     WorkerCheckpoint,
     QuestionAsked,
+    QuestionClosed,
     UserAnswered,
     ArtifactCreated,
     ValidationStarted,
@@ -1701,6 +1702,7 @@ impl ChannelEventType {
             Self::ToolCompleted => "tool.completed",
             Self::WorkerCheckpoint => "worker.checkpoint",
             Self::QuestionAsked => "question.asked",
+            Self::QuestionClosed => "question.closed",
             Self::UserAnswered => "user.answered",
             Self::ArtifactCreated => "artifact.created",
             Self::ValidationStarted => "validation.started",
@@ -1724,6 +1726,7 @@ impl ChannelEventType {
                 | Self::ToolCompleted
                 | Self::WorkerCheckpoint
                 | Self::QuestionAsked
+                | Self::QuestionClosed
                 | Self::ArtifactCreated
                 | Self::ValidationStarted
                 | Self::ValidationCompleted
@@ -1757,6 +1760,7 @@ impl<'de> Deserialize<'de> for ChannelEventType {
             "tool.completed" => Self::ToolCompleted,
             "worker.checkpoint" => Self::WorkerCheckpoint,
             "question.asked" => Self::QuestionAsked,
+            "question.closed" => Self::QuestionClosed,
             "user.answered" => Self::UserAnswered,
             "artifact.created" => Self::ArtifactCreated,
             "validation.started" => Self::ValidationStarted,

--- a/src/state.rs
+++ b/src/state.rs
@@ -198,6 +198,31 @@ fn task_channel_id(intent_id: &str, task_id: &str) -> String {
     format!("chn_{}", stable_digest_bytes(input.as_bytes()))
 }
 
+pub(crate) fn validate_action_id(action_id: &str) -> Result<()> {
+    let mut chars = action_id.chars();
+    let safe = action_id.len() <= 128
+        && chars.next().is_some_and(|ch| ch.is_ascii_alphanumeric())
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+        && Path::new(action_id).components().count() == 1
+        && Path::new(action_id)
+            .components()
+            .all(|component| matches!(component, std::path::Component::Normal(_)));
+    if !safe {
+        bail!(
+            "invalid action id '{action_id}': expected one portable identifier using letters, digits, '.', '_' or '-'"
+        );
+    }
+    Ok(())
+}
+
+fn contained_action_path(actions_dir: &Path, filename: &str) -> Result<PathBuf> {
+    let path = actions_dir.join(filename);
+    if path.parent() != Some(actions_dir) {
+        bail!("action receipt path escapes its canonical actions directory");
+    }
+    Ok(path)
+}
+
 fn channel_action_digest<T: Serialize>(value: &T) -> Result<String> {
     let bytes = serde_json::to_vec(value)?;
     Ok(format!("fnv1a64:{}", stable_digest_bytes(&bytes)))
@@ -328,6 +353,16 @@ impl Workspace {
         self.planning_session_dir(session_id)
             .join("actions")
             .join(format!("{action_id}.yaml"))
+    }
+
+    fn checked_planning_action_path(&self, session_id: &str, action_id: &str) -> Result<PathBuf> {
+        validate_action_id(action_id)?;
+        let actions_dir = self.planning_session_dir(session_id).join("actions");
+        let path = self.planning_action_path(session_id, action_id);
+        if path.parent() != Some(actions_dir.as_path()) {
+            bail!("action receipt path escapes its canonical actions directory");
+        }
+        Ok(path)
     }
 
     pub fn activation_path(&self, confirmation_id: &str) -> PathBuf {
@@ -674,7 +709,7 @@ impl Workspace {
     }
 
     pub fn create_planning_action(&self, receipt: &PlanningActionReceipt) -> Result<()> {
-        let path = self.planning_action_path(&receipt.session_id, &receipt.action_id);
+        let path = self.checked_planning_action_path(&receipt.session_id, &receipt.action_id)?;
         save_immutable_yaml(&path, receipt)
     }
 
@@ -686,7 +721,7 @@ impl Workspace {
         if expected.session_id != receipt.session_id || expected.action_id != receipt.action_id {
             bail!("planning action CAS identity mismatch");
         }
-        let path = self.planning_action_path(&receipt.session_id, &receipt.action_id);
+        let path = self.checked_planning_action_path(&receipt.session_id, &receipt.action_id)?;
         write_str_atomic_cas(
             &path,
             Some(&yaml::to_string(expected)?),
@@ -699,7 +734,7 @@ impl Workspace {
         session_id: &str,
         action_id: &str,
     ) -> Result<Option<PlanningActionReceipt>> {
-        let path = self.planning_action_path(session_id, action_id);
+        let path = self.checked_planning_action_path(session_id, action_id)?;
         if !path.is_file() {
             return Ok(None);
         }
@@ -2592,13 +2627,16 @@ impl Workspace {
         task_id: &str,
         action_id: &str,
         terminal: bool,
-    ) -> PathBuf {
-        self.task_channel_dir(intent_id, task_id)
-            .join("actions")
-            .join(format!(
+    ) -> Result<PathBuf> {
+        validate_action_id(action_id)?;
+        let actions_dir = self.task_channel_dir(intent_id, task_id).join("actions");
+        contained_action_path(
+            &actions_dir,
+            &format!(
                 "{action_id}.{}.yaml",
                 if terminal { "terminal" } else { "prepared" }
-            ))
+            ),
+        )
     }
 
     fn load_answer_action_outcome(
@@ -2637,6 +2675,7 @@ impl Workspace {
         {
             bail!("invalid answer action request");
         }
+        validate_action_id(&request.action_id)?;
         let digest = channel_action_digest(request)?;
         let _lock = self.acquire_planning_lock()?;
         let terminal_path = self.channel_action_path(
@@ -2644,7 +2683,7 @@ impl Workspace {
             &request.task_id,
             &request.action_id,
             true,
-        );
+        )?;
         if terminal_path.is_file() {
             let receipt: ActionReceipt = load_yaml(&terminal_path)?;
             if receipt.request_digest != digest {
@@ -2658,7 +2697,7 @@ impl Workspace {
             &request.task_id,
             &request.action_id,
             false,
-        );
+        )?;
         let recovering = if prepared_path.is_file() {
             let existing: ActionReceipt = load_yaml(&prepared_path)?;
             if existing.request_digest != digest {
@@ -2907,6 +2946,7 @@ impl Workspace {
         {
             bail!("invalid redirect action request");
         }
+        validate_action_id(&request.action_id)?;
         if !request.observed_terminal_state.is_terminal() {
             bail!("redirect_requires_observed_terminal");
         }
@@ -2917,7 +2957,7 @@ impl Workspace {
             &request.task_id,
             &request.action_id,
             true,
-        );
+        )?;
         if terminal_path.is_file() {
             let receipt: ActionReceipt = load_yaml(&terminal_path)?;
             if receipt.request_digest != digest {
@@ -2951,7 +2991,7 @@ impl Workspace {
             &request.task_id,
             &request.action_id,
             false,
-        );
+        )?;
         if prepared_path.is_file() {
             let existing: ActionReceipt = load_yaml(&prepared_path)?;
             if existing.request_digest != digest {
@@ -4913,6 +4953,69 @@ routing:
     }
 
     #[test]
+    fn answer_action_rejects_unsafe_action_id_before_writing_a_receipt() {
+        for label in ["absolute", "parent"] {
+            let dir = temp_root(&format!("channel-unsafe-action-{label}"));
+            let _ = fs::remove_dir_all(&dir);
+            let ws = Workspace::at(&dir);
+            let action_id = if label == "absolute" {
+                dir.join("escaped-action-receipt").display().to_string()
+            } else {
+                "../escaped-action-receipt".to_string()
+            };
+            ws.record_worker_attempt(&prepared_attempt("att_1"))
+                .unwrap();
+            let asked = ws
+                .record_task_event(
+                    "intent_channel",
+                    channel_event(ChannelEventType::QuestionAsked, Some("att_1")),
+                )
+                .unwrap();
+            ws.record_question(&Question {
+                schema_version: 1,
+                question_id: "qst_unsafe".into(),
+                session_id: "ses_channel".into(),
+                task_id: "YARD-001".into(),
+                attempt_id: "att_1".into(),
+                asked_event_id: asked.event_id,
+                asked_seq: asked.seq,
+                context_start_seq: 1,
+                text: "Continue?".into(),
+                state: QuestionState::Open,
+                answer_id: None,
+            })
+            .unwrap();
+            let request = AnswerActionRequest {
+                action_id,
+                answer_id: "ans_unsafe".into(),
+                continuation_attempt_id: "att_unsafe".into(),
+                session_id: "ses_channel".into(),
+                intent_id: "intent_channel".into(),
+                task_id: "YARD-001".into(),
+                question_id: "qst_unsafe".into(),
+                text: "Continue".into(),
+                worker_id: "generic-text".into(),
+                worker_session_ref: None,
+                supports_native_resume: false,
+            };
+
+            let error = ws.answer_question(&request).unwrap_err();
+            assert!(
+                error.to_string().contains("invalid action id"),
+                "unexpected error for {label}: {error}"
+            );
+            assert!(
+                ws.task_channel_dir("intent_channel", "YARD-001")
+                    .join("actions")
+                    .read_dir()
+                    .is_err(),
+                "unsafe {label} action id created an action receipt"
+            );
+            let _ = fs::remove_dir_all(&dir);
+        }
+    }
+
+    #[test]
     fn answer_action_recovers_after_restart_from_a_prepared_receipt() {
         let dir = temp_root("channel-answer-restart");
         let _ = fs::remove_dir_all(&dir);
@@ -4954,7 +5057,8 @@ routing:
         };
         let digest = channel_action_digest(&request).unwrap();
         save_immutable_yaml(
-            &ws.channel_action_path("intent_channel", "YARD-001", &request.action_id, false),
+            &ws.channel_action_path("intent_channel", "YARD-001", &request.action_id, false)
+                .unwrap(),
             &ActionReceipt {
                 schema_version: 1,
                 action_id: request.action_id.clone(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -17,12 +17,16 @@ use chrono::Local;
 use serde::{Deserialize, Serialize};
 
 use crate::schemas::{
-    ActivatedIntent, ActivatedQueue, ActivatedTask, ActivationReceipt, ActivationRequirement,
-    BillingPolicy, Conversation, ConversationTurn, DraftRevision, FollowUpTask, IntentContract,
-    PlanningActionReceipt, PlanningEvent, PlanningProposal, PlanningSession, PreservedFollowUps,
-    RuntimeCapabilityCommit, RuntimeCapabilityReceipt, RuntimeTaskCommit, RuntimeTaskReceipt,
-    SelectionPolicy, Task, TaskState, TransitionActor, TransitionCause, TransitionLog,
-    TransitionRecord, TurnRole, WorkQueue, WorkersFile, YardConfig,
+    ActionReceipt, ActivatedIntent, ActivatedQueue, ActivatedTask, ActivationReceipt,
+    ActivationRequirement, Answer, AnswerActionOutcome, AnswerActionRequest, AttemptState,
+    BillingPolicy, ChannelActionKind, ChannelActionStatus, ChannelEvent, ChannelEventType,
+    ContinuationMode, Conversation, ConversationTurn, DraftRevision, EventActor, EventActorKind,
+    FollowUpTask, IntentContract, PlanningActionReceipt, PlanningEvent, PlanningProposal,
+    PlanningSession, PreservedFollowUps, Question, QuestionState, RedirectActionOutcome,
+    RedirectActionRequest, RuntimeCapabilityCommit, RuntimeCapabilityReceipt, RuntimeTaskCommit,
+    RuntimeTaskReceipt, SelectionPolicy, Task, TaskChannel, TaskChannelIndex, TaskState,
+    TransitionActor, TransitionCause, TransitionLog, TransitionRecord, TurnRole, WorkQueue,
+    WorkerAttempt, WorkersFile, YardConfig,
 };
 use crate::yaml;
 
@@ -31,6 +35,16 @@ pub const STATE_DIR: &str = ".agents";
 /// (and written in place) for back-compat so existing workspaces keep working.
 pub const CONFIG_FILE: &str = "yardlet.yaml";
 pub const LEGACY_CONFIG_FILE: &str = "yard.yaml";
+pub const CHANNEL_INDEX_EVENT_LIMIT: usize = 128;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TaskChannelIdentity {
+    schema_version: u32,
+    channel_id: String,
+    session_id: String,
+    intent_id: String,
+    task_id: String,
+}
 
 /// A located Yardlet workspace: the directory that owns `.agents/`.
 #[derive(Debug, Clone)]
@@ -170,6 +184,25 @@ fn default_auto() -> String {
     "auto".to_string()
 }
 
+fn stable_digest_bytes(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn task_channel_id(intent_id: &str, task_id: &str) -> String {
+    let input = format!("{intent_id}\0{task_id}");
+    format!("chn_{}", stable_digest_bytes(input.as_bytes()))
+}
+
+fn channel_action_digest<T: Serialize>(value: &T) -> Result<String> {
+    let bytes = serde_json::to_vec(value)?;
+    Ok(format!("fnv1a64:{}", stable_digest_bytes(&bytes)))
+}
+
 impl Workspace {
     /// Walk up from `start` looking for an existing config file (the canonical
     /// `.agents/yardlet.yaml` or the legacy `.agents/yard.yaml`).
@@ -196,6 +229,19 @@ impl Workspace {
 
     pub fn agents_dir(&self) -> PathBuf {
         self.root.join(STATE_DIR)
+    }
+
+    pub fn task_channels_dir(&self) -> PathBuf {
+        self.agents_dir().join("task-channels")
+    }
+
+    pub fn task_channel_dir(&self, intent_id: &str, task_id: &str) -> PathBuf {
+        self.task_channels_dir()
+            .join(task_channel_id(intent_id, task_id))
+    }
+
+    pub fn task_channel_index_path(&self, intent_id: &str, task_id: &str) -> PathBuf {
+        self.task_channel_dir(intent_id, task_id).join("index.yaml")
     }
 
     pub fn is_initialized(&self) -> bool {
@@ -2125,6 +2171,963 @@ impl Workspace {
         })
     }
 
+    fn ensure_task_channel_identity(
+        &self,
+        intent_id: &str,
+        task_id: &str,
+        session_id: &str,
+    ) -> Result<TaskChannelIdentity> {
+        if intent_id.is_empty() || task_id.is_empty() || session_id.is_empty() {
+            bail!("task channel identity requires session, intent, and task ids");
+        }
+        let identity = TaskChannelIdentity {
+            schema_version: 1,
+            channel_id: task_channel_id(intent_id, task_id),
+            session_id: session_id.to_string(),
+            intent_id: intent_id.to_string(),
+            task_id: task_id.to_string(),
+        };
+        save_immutable_yaml(
+            &self
+                .task_channel_dir(intent_id, task_id)
+                .join("channel.yaml"),
+            &identity,
+        )?;
+        Ok(identity)
+    }
+
+    fn find_worker_attempt(
+        &self,
+        attempt_id: &str,
+    ) -> Result<Option<(TaskChannelIdentity, WorkerAttempt)>> {
+        let mut channel_dirs = if self.task_channels_dir().is_dir() {
+            fs::read_dir(self.task_channels_dir())?
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.is_dir())
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        channel_dirs.sort();
+        let mut found = None;
+        for directory in channel_dirs {
+            let path = directory
+                .join("attempts")
+                .join(format!("{attempt_id}.yaml"));
+            if !path.is_file() {
+                continue;
+            }
+            let identity: TaskChannelIdentity = load_yaml(&directory.join("channel.yaml"))?;
+            let attempt: WorkerAttempt = load_yaml(&path)?;
+            if found.is_some() {
+                bail!("attempt_id_conflict: {attempt_id} appears in multiple task channels");
+            }
+            found = Some((identity, attempt));
+        }
+        Ok(found)
+    }
+
+    pub fn record_worker_attempt(&self, attempt: &WorkerAttempt) -> Result<()> {
+        attempt.validate().map_err(anyhow::Error::msg)?;
+        if let Some((identity, existing)) = self.find_worker_attempt(&attempt.attempt_id)? {
+            if existing == *attempt
+                && identity.intent_id == attempt.intent_id
+                && identity.task_id == attempt.task_id
+            {
+                return Ok(());
+            }
+            bail!("attempt_id_conflict: {}", attempt.attempt_id);
+        }
+        self.ensure_task_channel_identity(
+            &attempt.intent_id,
+            &attempt.task_id,
+            &attempt.session_id,
+        )?;
+        save_immutable_yaml(
+            &self
+                .task_channel_dir(&attempt.intent_id, &attempt.task_id)
+                .join("attempts")
+                .join(format!("{}.yaml", attempt.attempt_id)),
+            attempt,
+        )
+    }
+
+    /// Replay the canonical event stream for one work session across every
+    /// task channel. Channel directories are a storage partition only; `seq`
+    /// belongs to the session and therefore may have gaps in an individual
+    /// task projection but must be contiguous in this merged stream.
+    fn replay_task_session_events(
+        &self,
+        session_id: &str,
+    ) -> Result<(Vec<ChannelEvent>, Vec<String>)> {
+        let mut events = Vec::new();
+        let mut channel_dirs = if self.task_channels_dir().is_dir() {
+            fs::read_dir(self.task_channels_dir())?
+                .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+                .filter(|path| path.is_dir())
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        channel_dirs.sort();
+        for directory in channel_dirs {
+            let identity_path = directory.join("channel.yaml");
+            if !identity_path.is_file() {
+                continue;
+            }
+            let identity: TaskChannelIdentity = load_yaml(&identity_path)?;
+            if identity.session_id == session_id {
+                events.extend(load_yaml_dir::<ChannelEvent>(&directory.join("events"))?);
+            }
+        }
+        events.sort_by(|left, right| {
+            left.seq
+                .cmp(&right.seq)
+                .then_with(|| left.event_id.cmp(&right.event_id))
+        });
+
+        let mut replayed = Vec::new();
+        let mut errors = Vec::new();
+        let mut event_ids: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        let mut expected_seq = 1_u64;
+        for event in events {
+            let bytes = serde_json::to_vec(&event)?;
+            if let Some(existing) = event_ids.get(&event.event_id) {
+                if *existing == bytes {
+                    continue;
+                }
+                errors.push(format!("event_id_conflict:{}", event.event_id));
+                break;
+            }
+            if event.seq != expected_seq {
+                errors.push(format!("session_sequence_gap:{expected_seq}-{}", event.seq));
+                break;
+            }
+            if event.session_id != session_id {
+                errors.push(format!("event_session_conflict:{}", event.event_id));
+                break;
+            }
+            if let Err(error) = event.validate() {
+                errors.push(format!("invalid_event:{}:{error}", event.event_id));
+                break;
+            }
+            event_ids.insert(event.event_id.clone(), bytes);
+            expected_seq += 1;
+            replayed.push(event);
+        }
+        Ok((replayed, errors))
+    }
+
+    fn record_task_event_locked(
+        &self,
+        intent_id: &str,
+        mut event: ChannelEvent,
+    ) -> Result<ChannelEvent> {
+        let identity =
+            self.ensure_task_channel_identity(intent_id, &event.task_id, &event.session_id)?;
+        let (session_events, replay_errors) = self.replay_task_session_events(&event.session_id)?;
+        if !replay_errors.is_empty() {
+            bail!("task_channel_corrupt: {}", replay_errors.join(", "));
+        }
+        if !event.event_id.is_empty() {
+            if let Some(existing) = session_events
+                .iter()
+                .find(|existing| existing.event_id == event.event_id)
+            {
+                event.seq = existing.seq;
+                event.recorded_at = existing.recorded_at.clone();
+                if event == *existing {
+                    return Ok(existing.clone());
+                }
+                bail!("event_id_conflict: {}", event.event_id);
+            }
+        }
+        event.seq = session_events.last().map_or(1, |existing| existing.seq + 1);
+        if event.event_id.is_empty() {
+            event.event_id = format!("evt_{}_{:020}", &identity.channel_id[4..], event.seq);
+        }
+        if event.recorded_at.is_empty() {
+            event.recorded_at = Local::now().to_rfc3339();
+        }
+        event.validate().map_err(anyhow::Error::msg)?;
+        let path = self
+            .task_channel_dir(intent_id, &event.task_id)
+            .join("events")
+            .join(format!("{:020}.yaml", event.seq));
+        save_immutable_yaml(&path, &event)?;
+        Ok(event)
+    }
+
+    pub fn record_task_event(&self, intent_id: &str, event: ChannelEvent) -> Result<ChannelEvent> {
+        let _lock = self.acquire_planning_lock()?;
+        self.record_task_event_locked(intent_id, event)
+    }
+
+    pub fn record_task_event_with_lock(
+        &self,
+        _lock: &PlanningLock,
+        intent_id: &str,
+        event: ChannelEvent,
+    ) -> Result<ChannelEvent> {
+        self.record_task_event_locked(intent_id, event)
+    }
+
+    pub fn record_question(&self, question: &Question) -> Result<()> {
+        question.validate().map_err(anyhow::Error::msg)?;
+        let Some((identity, attempt)) = self.find_worker_attempt(&question.attempt_id)? else {
+            bail!("question_attempt_missing: {}", question.attempt_id);
+        };
+        if attempt.session_id != question.session_id
+            || attempt.task_id != question.task_id
+            || identity.task_id != question.task_id
+        {
+            bail!(
+                "question_attempt_linkage_conflict: {}",
+                question.question_id
+            );
+        }
+        let channel = self.load_task_channel(&identity.intent_id, &identity.task_id)?;
+        let asked = channel
+            .events
+            .iter()
+            .find(|event| event.event_id == question.asked_event_id)
+            .ok_or_else(|| anyhow::anyhow!("question_asked_event_missing"))?;
+        if asked.seq != question.asked_seq
+            || asked.event_type != ChannelEventType::QuestionAsked
+            || asked.attempt_id.as_deref() != Some(question.attempt_id.as_str())
+        {
+            bail!("question_asked_event_linkage_conflict");
+        }
+        save_immutable_yaml(
+            &self
+                .task_channel_dir(&identity.intent_id, &identity.task_id)
+                .join("questions")
+                .join(format!("{}.yaml", question.question_id)),
+            question,
+        )
+    }
+
+    pub fn load_task_channel(&self, intent_id: &str, task_id: &str) -> Result<TaskChannel> {
+        let directory = self.task_channel_dir(intent_id, task_id);
+        if !directory.is_dir() {
+            return Ok(TaskChannel {
+                schema_version: 1,
+                channel_id: task_channel_id(intent_id, task_id),
+                session_id: format!("legacy:{intent_id}"),
+                intent_id: intent_id.to_string(),
+                task_id: task_id.to_string(),
+                highest_seq: 0,
+                attempts: Vec::new(),
+                questions: Vec::new(),
+                answers: Vec::new(),
+                events: Vec::new(),
+                replay_errors: Vec::new(),
+            });
+        }
+        let identity: TaskChannelIdentity = load_yaml(&directory.join("channel.yaml"))?;
+        if identity.schema_version != 1
+            || identity.channel_id != task_channel_id(intent_id, task_id)
+            || identity.intent_id != intent_id
+            || identity.task_id != task_id
+        {
+            bail!("task_channel_identity_conflict");
+        }
+
+        let (session_events, mut replay_errors) =
+            self.replay_task_session_events(&identity.session_id)?;
+        let events = session_events
+            .into_iter()
+            .filter(|event| event.task_id == identity.task_id)
+            .collect::<Vec<_>>();
+
+        let mut attempts: Vec<WorkerAttempt> = load_yaml_dir(&directory.join("attempts"))?;
+        let mut questions: Vec<Question> = load_yaml_dir(&directory.join("questions"))?;
+        let mut answers: Vec<Answer> = load_yaml_dir(&directory.join("answers"))?;
+        for attempt in &attempts {
+            if attempt.intent_id != intent_id || attempt.task_id != task_id {
+                replay_errors.push(format!("attempt_identity_conflict:{}", attempt.attempt_id));
+            }
+        }
+        for answer in &answers {
+            if !questions
+                .iter()
+                .any(|question| question.question_id == answer.question_id)
+            {
+                replay_errors.push(format!("answer_question_missing:{}", answer.answer_id));
+            }
+        }
+        for question in &mut questions {
+            if let Some(answer) = answers
+                .iter()
+                .find(|answer| answer.question_id == question.question_id)
+            {
+                question.state = QuestionState::Answered;
+                question.answer_id = Some(answer.answer_id.clone());
+            }
+        }
+        for event in &events {
+            let Some(attempt_id) = event.attempt_id.as_deref() else {
+                continue;
+            };
+            let Some(attempt) = attempts
+                .iter_mut()
+                .find(|attempt| attempt.attempt_id == attempt_id)
+            else {
+                replay_errors.push(format!("event_attempt_missing:{}", event.event_id));
+                continue;
+            };
+            match event.event_type {
+                ChannelEventType::WorkerStarted => attempt.state = AttemptState::Running,
+                ChannelEventType::WorkerCompleted => {
+                    if let Some(worker_session_ref) = event
+                        .payload
+                        .get("worker_session_ref")
+                        .and_then(|value| value.as_str())
+                        .filter(|value| !value.is_empty())
+                    {
+                        attempt.worker_session_ref = Some(worker_session_ref.to_string());
+                    }
+                    attempt.state = match event.payload.get("result").and_then(|v| v.as_str()) {
+                        Some("needs_user") => AttemptState::NeedsUser,
+                        Some("succeeded") => AttemptState::Succeeded,
+                        Some("timed_out") => AttemptState::TimedOut,
+                        Some("cancelled") => AttemptState::Cancelled,
+                        Some("abandoned") => AttemptState::Abandoned,
+                        _ => AttemptState::Failed,
+                    }
+                }
+                _ => {}
+            }
+        }
+        let attempt_order = events
+            .iter()
+            .filter_map(|event| {
+                (event.event_type == ChannelEventType::AttemptPrepared)
+                    .then(|| event.attempt_id.clone())
+                    .flatten()
+            })
+            .enumerate()
+            .map(|(index, id)| (id, index))
+            .collect::<BTreeMap<_, _>>();
+        attempts.sort_by_key(|attempt| {
+            attempt_order
+                .get(&attempt.attempt_id)
+                .copied()
+                .unwrap_or(usize::MAX)
+        });
+        questions.sort_by_key(|question| question.asked_seq);
+        let answer_order = events
+            .iter()
+            .filter_map(|event| {
+                (event.event_type == ChannelEventType::UserAnswered)
+                    .then(|| {
+                        event
+                            .payload
+                            .get("answer_id")
+                            .and_then(|value| value.as_str())
+                            .map(str::to_string)
+                    })
+                    .flatten()
+                    .map(|answer_id| (answer_id, event.seq))
+            })
+            .collect::<BTreeMap<_, _>>();
+        answers.sort_by_key(|answer| {
+            answer_order
+                .get(&answer.answer_id)
+                .copied()
+                .unwrap_or(u64::MAX)
+        });
+        let highest_seq = events.last().map_or(0, |event| event.seq);
+        Ok(TaskChannel {
+            schema_version: 1,
+            channel_id: identity.channel_id,
+            session_id: identity.session_id,
+            intent_id: identity.intent_id,
+            task_id: identity.task_id,
+            highest_seq,
+            attempts,
+            questions,
+            answers,
+            events,
+            replay_errors,
+        })
+    }
+
+    fn build_task_channel_index(channel: &TaskChannel) -> TaskChannelIndex {
+        let start = channel
+            .events
+            .len()
+            .saturating_sub(CHANNEL_INDEX_EVENT_LIMIT);
+        let tail_events = channel.events[start..].to_vec();
+        TaskChannelIndex {
+            schema_version: 1,
+            channel_id: channel.channel_id.clone(),
+            highest_applied_seq: channel.highest_seq,
+            retained_from_seq: tail_events.first().map_or(0, |event| event.seq),
+            event_count: channel.events.len(),
+            tail_events,
+        }
+    }
+
+    pub fn load_or_rebuild_task_channel(
+        &self,
+        intent_id: &str,
+        task_id: &str,
+    ) -> Result<TaskChannel> {
+        let channel = self.load_task_channel(intent_id, task_id)?;
+        if !channel.replay_errors.is_empty() {
+            bail!("task_channel_corrupt: {}", channel.replay_errors.join(", "));
+        }
+        let index = Self::build_task_channel_index(&channel);
+        write_str_atomic(
+            &self.task_channel_index_path(intent_id, task_id),
+            &yaml::to_string(&index)?,
+        )?;
+        Ok(channel)
+    }
+
+    fn channel_action_path(
+        &self,
+        intent_id: &str,
+        task_id: &str,
+        action_id: &str,
+        terminal: bool,
+    ) -> PathBuf {
+        self.task_channel_dir(intent_id, task_id)
+            .join("actions")
+            .join(format!(
+                "{action_id}.{}.yaml",
+                if terminal { "terminal" } else { "prepared" }
+            ))
+    }
+
+    fn load_answer_action_outcome(
+        &self,
+        request: &AnswerActionRequest,
+        receipt: ActionReceipt,
+    ) -> Result<AnswerActionOutcome> {
+        let channel = self.load_task_channel(&request.intent_id, &request.task_id)?;
+        let answer = channel
+            .answers
+            .into_iter()
+            .find(|answer| answer.answer_id == request.answer_id)
+            .ok_or_else(|| anyhow::anyhow!("answer_action_corrupt: answer missing"))?;
+        let attempt = channel
+            .attempts
+            .into_iter()
+            .find(|attempt| attempt.attempt_id == request.continuation_attempt_id)
+            .ok_or_else(|| anyhow::anyhow!("answer_action_corrupt: attempt missing"))?;
+        Ok(AnswerActionOutcome {
+            receipt,
+            answer,
+            attempt,
+        })
+    }
+
+    pub fn answer_question(&self, request: &AnswerActionRequest) -> Result<AnswerActionOutcome> {
+        if request.action_id.is_empty()
+            || request.answer_id.is_empty()
+            || request.continuation_attempt_id.is_empty()
+            || request.session_id.is_empty()
+            || request.intent_id.is_empty()
+            || request.task_id.is_empty()
+            || request.question_id.is_empty()
+            || request.text.trim().is_empty()
+            || request.worker_id.is_empty()
+        {
+            bail!("invalid answer action request");
+        }
+        let digest = channel_action_digest(request)?;
+        let _lock = self.acquire_planning_lock()?;
+        let terminal_path = self.channel_action_path(
+            &request.intent_id,
+            &request.task_id,
+            &request.action_id,
+            true,
+        );
+        if terminal_path.is_file() {
+            let receipt: ActionReceipt = load_yaml(&terminal_path)?;
+            if receipt.request_digest != digest {
+                bail!("idempotency_conflict: {}", request.action_id);
+            }
+            return self.load_answer_action_outcome(request, receipt);
+        }
+
+        let prepared_path = self.channel_action_path(
+            &request.intent_id,
+            &request.task_id,
+            &request.action_id,
+            false,
+        );
+        let recovering = if prepared_path.is_file() {
+            let existing: ActionReceipt = load_yaml(&prepared_path)?;
+            if existing.request_digest != digest {
+                bail!("idempotency_conflict: {}", request.action_id);
+            }
+            true
+        } else {
+            false
+        };
+        let channel = self.load_task_channel(&request.intent_id, &request.task_id)?;
+        let question = channel
+            .questions
+            .iter()
+            .find(|question| question.question_id == request.question_id)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("question_missing: {}", request.question_id))?;
+        if question.session_id != request.session_id || question.task_id != request.task_id {
+            bail!("question_linkage_conflict: {}", request.question_id);
+        }
+        if !recovering
+            && (question.state != QuestionState::Open
+                || channel
+                    .answers
+                    .iter()
+                    .any(|answer| answer.question_id == request.question_id))
+        {
+            bail!("question_closed: {}", request.question_id);
+        }
+        if recovering
+            && channel.answers.iter().any(|answer| {
+                answer.question_id == request.question_id
+                    && (answer.answer_id != request.answer_id
+                        || answer.action_id != request.action_id
+                        || answer.text != request.text)
+            })
+        {
+            bail!("idempotency_conflict: {}", request.action_id);
+        }
+
+        if !recovering {
+            save_immutable_yaml(
+                &prepared_path,
+                &ActionReceipt {
+                    schema_version: 1,
+                    action_id: request.action_id.clone(),
+                    session_id: request.session_id.clone(),
+                    task_id: request.task_id.clone(),
+                    action: ChannelActionKind::Answer,
+                    request_digest: digest.clone(),
+                    status: ChannelActionStatus::Prepared,
+                    result_event_ids: Vec::new(),
+                    result_attempt_id: Some(request.continuation_attempt_id.clone()),
+                    error: String::new(),
+                },
+            )?;
+        }
+
+        let event_id_suffix = stable_digest_bytes(request.action_id.as_bytes());
+        let requested = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{event_id_suffix}_requested"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::ActionRequested,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::User,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: Some(question.asked_event_id.clone()),
+                correlation_id: channel
+                    .events
+                    .first()
+                    .map(|event| event.correlation_id.clone())
+                    .unwrap_or_else(|| format!("cor_{}", channel.channel_id)),
+                task_id: request.task_id.clone(),
+                attempt_id: None,
+                payload: serde_json::json!({"action": "answer", "question_id": request.question_id}),
+                raw_ref: None,
+            },
+        )?;
+        let answered_event = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{event_id_suffix}_answered"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::UserAnswered,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::User,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: Some(question.asked_event_id.clone()),
+                correlation_id: requested.correlation_id.clone(),
+                task_id: request.task_id.clone(),
+                attempt_id: None,
+                payload: serde_json::json!({
+                    "answer_id": request.answer_id,
+                    "question_id": request.question_id,
+                    "text": request.text
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let answer = Answer {
+            schema_version: 1,
+            answer_id: request.answer_id.clone(),
+            question_id: request.question_id.clone(),
+            action_id: request.action_id.clone(),
+            answered_event_id: answered_event.event_id.clone(),
+            text: request.text.clone(),
+        };
+        answer.validate().map_err(anyhow::Error::msg)?;
+        save_immutable_yaml(
+            &self
+                .task_channel_dir(&request.intent_id, &request.task_id)
+                .join("answers")
+                .join(format!("{}.yaml", request.answer_id)),
+            &answer,
+        )?;
+
+        let native = request.supports_native_resume
+            && request
+                .worker_session_ref
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty());
+        let attempt = WorkerAttempt {
+            schema_version: 1,
+            attempt_id: request.continuation_attempt_id.clone(),
+            session_id: request.session_id.clone(),
+            intent_id: request.intent_id.clone(),
+            task_id: request.task_id.clone(),
+            worker_id: request.worker_id.clone(),
+            worker_session_ref: native.then(|| request.worker_session_ref.clone()).flatten(),
+            state: AttemptState::Prepared,
+            continuation: if native {
+                ContinuationMode::NativeResume
+            } else {
+                ContinuationMode::ExplicitPacket
+            },
+            caused_by_event_id: Some(answered_event.event_id.clone()),
+            caused_by_action_id: Some(request.action_id.clone()),
+            raw_stdout_ref: format!(
+                "task-channels/{}/attempts/{}/stdout.log",
+                channel.channel_id, request.continuation_attempt_id
+            ),
+            raw_stderr_ref: format!(
+                "task-channels/{}/attempts/{}/stderr.log",
+                channel.channel_id, request.continuation_attempt_id
+            ),
+        };
+        self.record_worker_attempt(&attempt)?;
+        let attempt_event = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{event_id_suffix}_attempt"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::AttemptPrepared,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: Some(answered_event.event_id.clone()),
+                correlation_id: requested.correlation_id.clone(),
+                task_id: request.task_id.clone(),
+                attempt_id: Some(attempt.attempt_id.clone()),
+                payload: serde_json::json!({
+                    "worker_id": attempt.worker_id,
+                    "worker_session_ref": attempt.worker_session_ref,
+                    "continuation": attempt.continuation
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let completed_event = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{event_id_suffix}_completed"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::ActionCompleted,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: Some(attempt_event.event_id.clone()),
+                correlation_id: requested.correlation_id,
+                task_id: request.task_id.clone(),
+                attempt_id: None,
+                payload: serde_json::json!({
+                    "answer_id": answer.answer_id,
+                    "attempt_id": attempt.attempt_id
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let receipt = ActionReceipt {
+            schema_version: 1,
+            action_id: request.action_id.clone(),
+            session_id: request.session_id.clone(),
+            task_id: request.task_id.clone(),
+            action: ChannelActionKind::Answer,
+            request_digest: digest,
+            status: ChannelActionStatus::Completed,
+            result_event_ids: vec![
+                requested.event_id,
+                answered_event.event_id,
+                attempt_event.event_id,
+                completed_event.event_id,
+            ],
+            result_attempt_id: Some(attempt.attempt_id.clone()),
+            error: String::new(),
+        };
+        save_immutable_yaml(&terminal_path, &receipt)?;
+        self.load_or_rebuild_task_channel(&request.intent_id, &request.task_id)?;
+        Ok(AnswerActionOutcome {
+            receipt,
+            answer,
+            attempt,
+        })
+    }
+
+    pub fn redirect_task(&self, request: &RedirectActionRequest) -> Result<RedirectActionOutcome> {
+        if request.action_id.is_empty()
+            || request.continuation_attempt_id.is_empty()
+            || request.session_id.is_empty()
+            || request.intent_id.is_empty()
+            || request.task_id.is_empty()
+            || request.stopped_attempt_id.is_empty()
+            || request.reason.trim().is_empty()
+            || request.guidance.trim().is_empty()
+            || request.worker_id.is_empty()
+        {
+            bail!("invalid redirect action request");
+        }
+        if !request.observed_terminal_state.is_terminal() {
+            bail!("redirect_requires_observed_terminal");
+        }
+        let digest = channel_action_digest(request)?;
+        let _lock = self.acquire_planning_lock()?;
+        let terminal_path = self.channel_action_path(
+            &request.intent_id,
+            &request.task_id,
+            &request.action_id,
+            true,
+        );
+        if terminal_path.is_file() {
+            let receipt: ActionReceipt = load_yaml(&terminal_path)?;
+            if receipt.request_digest != digest {
+                bail!("idempotency_conflict: {}", request.action_id);
+            }
+            let channel = self.load_task_channel(&request.intent_id, &request.task_id)?;
+            let attempt = channel
+                .attempts
+                .into_iter()
+                .find(|attempt| attempt.attempt_id == request.continuation_attempt_id)
+                .ok_or_else(|| anyhow::anyhow!("redirect_action_corrupt: attempt missing"))?;
+            return Ok(RedirectActionOutcome { receipt, attempt });
+        }
+
+        let channel = self.load_task_channel(&request.intent_id, &request.task_id)?;
+        let stopped = channel
+            .attempts
+            .iter()
+            .find(|attempt| attempt.attempt_id == request.stopped_attempt_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "redirect_stopped_attempt_missing: {}",
+                    request.stopped_attempt_id
+                )
+            })?;
+        if stopped.state != request.observed_terminal_state || !stopped.state.is_terminal() {
+            bail!("redirect_requires_observed_terminal");
+        }
+        let prepared_path = self.channel_action_path(
+            &request.intent_id,
+            &request.task_id,
+            &request.action_id,
+            false,
+        );
+        if prepared_path.is_file() {
+            let existing: ActionReceipt = load_yaml(&prepared_path)?;
+            if existing.request_digest != digest {
+                bail!("idempotency_conflict: {}", request.action_id);
+            }
+        } else {
+            save_immutable_yaml(
+                &prepared_path,
+                &ActionReceipt {
+                    schema_version: 1,
+                    action_id: request.action_id.clone(),
+                    session_id: request.session_id.clone(),
+                    task_id: request.task_id.clone(),
+                    action: ChannelActionKind::Redirect,
+                    request_digest: digest.clone(),
+                    status: ChannelActionStatus::Prepared,
+                    result_event_ids: Vec::new(),
+                    result_attempt_id: Some(request.continuation_attempt_id.clone()),
+                    error: String::new(),
+                },
+            )?;
+        }
+
+        let suffix = stable_digest_bytes(request.action_id.as_bytes());
+        let requested = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{suffix}_redirect_requested"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::ActionRequested,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::User,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: channel.events.last().map(|event| event.event_id.clone()),
+                correlation_id: channel
+                    .events
+                    .first()
+                    .map(|event| event.correlation_id.clone())
+                    .unwrap_or_else(|| format!("cor_{}", channel.channel_id)),
+                task_id: request.task_id.clone(),
+                attempt_id: None,
+                payload: serde_json::json!({
+                    "action": "redirect",
+                    "reason": request.reason,
+                    "guidance": request.guidance,
+                    "stopped_attempt_id": request.stopped_attempt_id,
+                    "observed_terminal_state": request.observed_terminal_state,
+                    "live_message_delivered": false
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let mut result_event_ids = vec![requested.event_id.clone()];
+        let cause = if let Some(checkpoint_ref) = request.checkpoint_ref.as_deref() {
+            let checkpoint = self.record_task_event_locked(
+                &request.intent_id,
+                ChannelEvent {
+                    schema_version: 1,
+                    event_id: format!("evt_{suffix}_checkpoint"),
+                    session_id: request.session_id.clone(),
+                    seq: 0,
+                    event_type: ChannelEventType::WorkerCheckpoint,
+                    recorded_at: Local::now().to_rfc3339(),
+                    actor: EventActor {
+                        kind: EventActorKind::System,
+                        id: String::new(),
+                    },
+                    action_id: Some(request.action_id.clone()),
+                    causation_id: Some(requested.event_id.clone()),
+                    correlation_id: requested.correlation_id.clone(),
+                    task_id: request.task_id.clone(),
+                    attempt_id: Some(request.stopped_attempt_id.clone()),
+                    payload: serde_json::json!({"checkpoint_ref": checkpoint_ref}),
+                    raw_ref: None,
+                },
+            )?;
+            result_event_ids.push(checkpoint.event_id.clone());
+            checkpoint.event_id
+        } else {
+            requested.event_id.clone()
+        };
+
+        let attempt = WorkerAttempt {
+            schema_version: 1,
+            attempt_id: request.continuation_attempt_id.clone(),
+            session_id: request.session_id.clone(),
+            intent_id: request.intent_id.clone(),
+            task_id: request.task_id.clone(),
+            worker_id: request.worker_id.clone(),
+            worker_session_ref: None,
+            state: AttemptState::Prepared,
+            continuation: ContinuationMode::Redirect,
+            caused_by_event_id: Some(cause.clone()),
+            caused_by_action_id: Some(request.action_id.clone()),
+            raw_stdout_ref: format!(
+                "task-channels/{}/attempts/{}/stdout.log",
+                channel.channel_id, request.continuation_attempt_id
+            ),
+            raw_stderr_ref: format!(
+                "task-channels/{}/attempts/{}/stderr.log",
+                channel.channel_id, request.continuation_attempt_id
+            ),
+        };
+        self.record_worker_attempt(&attempt)?;
+        let attempt_event = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{suffix}_redirect_attempt"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::AttemptPrepared,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: Some(cause),
+                correlation_id: requested.correlation_id.clone(),
+                task_id: request.task_id.clone(),
+                attempt_id: Some(attempt.attempt_id.clone()),
+                payload: serde_json::json!({
+                    "worker_id": attempt.worker_id,
+                    "continuation": "redirect",
+                    "guidance": request.guidance
+                }),
+                raw_ref: None,
+            },
+        )?;
+        result_event_ids.push(attempt_event.event_id.clone());
+        let completed = self.record_task_event_locked(
+            &request.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{suffix}_redirect_completed"),
+                session_id: request.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::ActionCompleted,
+                recorded_at: Local::now().to_rfc3339(),
+                actor: EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                action_id: Some(request.action_id.clone()),
+                causation_id: Some(attempt_event.event_id),
+                correlation_id: requested.correlation_id,
+                task_id: request.task_id.clone(),
+                attempt_id: None,
+                payload: serde_json::json!({"attempt_id": attempt.attempt_id}),
+                raw_ref: None,
+            },
+        )?;
+        result_event_ids.push(completed.event_id);
+        let receipt = ActionReceipt {
+            schema_version: 1,
+            action_id: request.action_id.clone(),
+            session_id: request.session_id.clone(),
+            task_id: request.task_id.clone(),
+            action: ChannelActionKind::Redirect,
+            request_digest: digest,
+            status: ChannelActionStatus::Completed,
+            result_event_ids,
+            result_attempt_id: Some(attempt.attempt_id.clone()),
+            error: String::new(),
+        };
+        save_immutable_yaml(&terminal_path, &receipt)?;
+        self.load_or_rebuild_task_channel(&request.intent_id, &request.task_id)?;
+        Ok(RedirectActionOutcome { receipt, attempt })
+    }
+
     pub fn load_transition_log(&self, task_id: &str) -> TransitionLog {
         let p = self.transition_path(task_id);
         if !p.is_file() {
@@ -3672,6 +4675,324 @@ routing:
         // A task that never paused reads as an empty transcript.
         assert!(ws.load_conversation("YARD-2").turns.is_empty());
 
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    fn channel_event(kind: ChannelEventType, attempt_id: Option<&str>) -> ChannelEvent {
+        ChannelEvent {
+            schema_version: 1,
+            event_id: String::new(),
+            session_id: "ses_channel".into(),
+            seq: 0,
+            event_type: kind,
+            recorded_at: "2026-07-14T00:00:00Z".into(),
+            actor: EventActor {
+                kind: EventActorKind::Worker,
+                id: "codex".into(),
+            },
+            action_id: None,
+            causation_id: None,
+            correlation_id: "cor_channel".into(),
+            task_id: "YARD-001".into(),
+            attempt_id: attempt_id.map(str::to_string),
+            payload: serde_json::json!({"text": "progress"}),
+            raw_ref: None,
+        }
+    }
+
+    fn prepared_attempt(id: &str) -> WorkerAttempt {
+        WorkerAttempt {
+            schema_version: 1,
+            attempt_id: id.into(),
+            session_id: "ses_channel".into(),
+            intent_id: "intent_channel".into(),
+            task_id: "YARD-001".into(),
+            worker_id: "codex".into(),
+            worker_session_ref: Some("thread-1".into()),
+            state: AttemptState::Prepared,
+            continuation: ContinuationMode::Fresh,
+            caused_by_event_id: None,
+            caused_by_action_id: None,
+            raw_stdout_ref: format!("attempts/{id}/stdout.log"),
+            raw_stderr_ref: format!("attempts/{id}/stderr.log"),
+        }
+    }
+
+    #[test]
+    fn channel_replay_recovers_a_deleted_or_malformed_bounded_index() {
+        let dir = temp_root("channel-index-replay");
+        let _ = fs::remove_dir_all(&dir);
+        let ws = Workspace::at(&dir);
+        ws.record_worker_attempt(&prepared_attempt("att_1"))
+            .unwrap();
+        let raw_path = ws
+            .task_channel_dir("intent_channel", "YARD-001")
+            .join("attempts/att_1/stdout.log");
+        fs::create_dir_all(raw_path.parent().unwrap()).unwrap();
+        fs::write(&raw_path, b"durable raw evidence").unwrap();
+
+        let mut prepared = channel_event(ChannelEventType::AttemptPrepared, Some("att_1"));
+        prepared.payload = serde_json::json!({"worker_id": "codex"});
+        ws.record_task_event("intent_channel", prepared).unwrap();
+        for index in 0..140 {
+            let mut event = channel_event(ChannelEventType::WorkerMessage, Some("att_1"));
+            event.payload = serde_json::json!({"text": format!("message-{index}")});
+            ws.record_task_event("intent_channel", event).unwrap();
+        }
+
+        let original = ws
+            .load_or_rebuild_task_channel("intent_channel", "YARD-001")
+            .unwrap();
+        let index_path = ws.task_channel_index_path("intent_channel", "YARD-001");
+        let bounded: TaskChannelIndex = load_yaml(&index_path).unwrap();
+        assert_eq!(original.events.len(), 141);
+        assert!(bounded.tail_events.len() <= CHANNEL_INDEX_EVENT_LIMIT);
+        assert_eq!(bounded.highest_applied_seq, 141);
+
+        fs::remove_file(&index_path).unwrap();
+        drop(ws);
+        let restarted = Workspace::at(&dir);
+        let rebuilt = restarted
+            .load_or_rebuild_task_channel("intent_channel", "YARD-001")
+            .unwrap();
+        assert_eq!(rebuilt, original);
+        assert!(index_path.is_file());
+        assert_eq!(fs::read(&raw_path).unwrap(), b"durable raw evidence");
+
+        fs::write(&index_path, "not: [valid yaml").unwrap();
+        let repaired = restarted
+            .load_or_rebuild_task_channel("intent_channel", "YARD-001")
+            .unwrap();
+        assert_eq!(repaired, original);
+        let repaired_index: TaskChannelIndex = load_yaml(&index_path).unwrap();
+        assert_eq!(repaired_index.highest_applied_seq, 141);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn channel_events_share_one_strict_sequence_across_tasks_in_a_session() {
+        let dir = temp_root("channel-session-sequence");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join(STATE_DIR)).unwrap();
+        let ws = Workspace::at(&dir);
+
+        let mut first = channel_event(ChannelEventType::WorkerMessage, Some("att_1"));
+        first.task_id = "YARD-001".into();
+        let mut second = channel_event(ChannelEventType::WorkerMessage, Some("att_2"));
+        second.task_id = "YARD-002".into();
+        let first = ws.record_task_event("intent_channel", first).unwrap();
+        let second = ws.record_task_event("intent_channel", second).unwrap();
+
+        assert_eq!(first.seq, 1);
+        assert_eq!(second.seq, 2);
+        assert_eq!(
+            ws.load_task_channel("intent_channel", "YARD-001")
+                .unwrap()
+                .events[0]
+                .seq,
+            1
+        );
+        assert_eq!(
+            ws.load_task_channel("intent_channel", "YARD-002")
+                .unwrap()
+                .events[0]
+                .seq,
+            2
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn answer_action_is_exact_idempotent_and_creates_a_new_continuation_attempt() {
+        let dir = temp_root("channel-answer-action");
+        let _ = fs::remove_dir_all(&dir);
+        let ws = Workspace::at(&dir);
+        ws.record_worker_attempt(&prepared_attempt("att_1"))
+            .unwrap();
+
+        let asked = ws
+            .record_task_event(
+                "intent_channel",
+                channel_event(ChannelEventType::QuestionAsked, Some("att_1")),
+            )
+            .unwrap();
+        ws.record_question(&Question {
+            schema_version: 1,
+            question_id: "qst_1".into(),
+            session_id: "ses_channel".into(),
+            task_id: "YARD-001".into(),
+            attempt_id: "att_1".into(),
+            asked_event_id: asked.event_id.clone(),
+            asked_seq: asked.seq,
+            context_start_seq: 1,
+            text: "Which path?".into(),
+            state: QuestionState::Open,
+            answer_id: None,
+        })
+        .unwrap();
+
+        let request = AnswerActionRequest {
+            action_id: "act_answer_1".into(),
+            answer_id: "ans_1".into(),
+            continuation_attempt_id: "att_2".into(),
+            session_id: "ses_channel".into(),
+            intent_id: "intent_channel".into(),
+            task_id: "YARD-001".into(),
+            question_id: "qst_1".into(),
+            text: "Path A".into(),
+            worker_id: "codex".into(),
+            worker_session_ref: Some("thread-1".into()),
+            supports_native_resume: false,
+        };
+        let first = ws.answer_question(&request).unwrap();
+        let duplicate = ws.answer_question(&request).unwrap();
+        assert_eq!(duplicate, first);
+        assert_eq!(first.attempt.attempt_id, "att_2");
+        assert_eq!(first.attempt.continuation, ContinuationMode::ExplicitPacket);
+        assert_eq!(first.answer.question_id, "qst_1");
+
+        let channel = ws.load_task_channel("intent_channel", "YARD-001").unwrap();
+        assert_eq!(channel.answers.len(), 1);
+        assert_eq!(channel.attempts.len(), 2);
+
+        let mut conflicting = request.clone();
+        conflicting.text = "Path B".into();
+        assert!(ws
+            .answer_question(&conflicting)
+            .unwrap_err()
+            .to_string()
+            .contains("idempotency_conflict"));
+
+        let mut stale = request;
+        stale.action_id = "act_answer_2".into();
+        stale.answer_id = "ans_2".into();
+        stale.continuation_attempt_id = "att_3".into();
+        assert!(ws
+            .answer_question(&stale)
+            .unwrap_err()
+            .to_string()
+            .contains("question_closed"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn answer_action_recovers_after_restart_from_a_prepared_receipt() {
+        let dir = temp_root("channel-answer-restart");
+        let _ = fs::remove_dir_all(&dir);
+        let ws = Workspace::at(&dir);
+        ws.record_worker_attempt(&prepared_attempt("att_1"))
+            .unwrap();
+        let asked = ws
+            .record_task_event(
+                "intent_channel",
+                channel_event(ChannelEventType::QuestionAsked, Some("att_1")),
+            )
+            .unwrap();
+        ws.record_question(&Question {
+            schema_version: 1,
+            question_id: "qst_restart".into(),
+            session_id: "ses_channel".into(),
+            task_id: "YARD-001".into(),
+            attempt_id: "att_1".into(),
+            asked_event_id: asked.event_id,
+            asked_seq: asked.seq,
+            context_start_seq: 1,
+            text: "Continue?".into(),
+            state: QuestionState::Open,
+            answer_id: None,
+        })
+        .unwrap();
+        let request = AnswerActionRequest {
+            action_id: "act_restart".into(),
+            answer_id: "ans_restart".into(),
+            continuation_attempt_id: "att_restart".into(),
+            session_id: "ses_channel".into(),
+            intent_id: "intent_channel".into(),
+            task_id: "YARD-001".into(),
+            question_id: "qst_restart".into(),
+            text: "Continue".into(),
+            worker_id: "generic-text".into(),
+            worker_session_ref: None,
+            supports_native_resume: false,
+        };
+        let digest = channel_action_digest(&request).unwrap();
+        save_immutable_yaml(
+            &ws.channel_action_path("intent_channel", "YARD-001", &request.action_id, false),
+            &ActionReceipt {
+                schema_version: 1,
+                action_id: request.action_id.clone(),
+                session_id: request.session_id.clone(),
+                task_id: request.task_id.clone(),
+                action: ChannelActionKind::Answer,
+                request_digest: digest,
+                status: ChannelActionStatus::Prepared,
+                result_event_ids: Vec::new(),
+                result_attempt_id: Some(request.continuation_attempt_id.clone()),
+                error: String::new(),
+            },
+        )
+        .unwrap();
+        drop(ws);
+
+        let restarted = Workspace::at(&dir);
+        let outcome = restarted.answer_question(&request).unwrap();
+        assert_eq!(outcome.receipt.status, ChannelActionStatus::Completed);
+        assert_eq!(
+            outcome.attempt.continuation,
+            ContinuationMode::ExplicitPacket
+        );
+        assert_eq!(restarted.answer_question(&request).unwrap(), outcome);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn redirect_requires_observed_terminal_state_before_new_guidance_attempt() {
+        let dir = temp_root("channel-redirect-action");
+        let _ = fs::remove_dir_all(&dir);
+        let ws = Workspace::at(&dir);
+        ws.record_worker_attempt(&prepared_attempt("att_1"))
+            .unwrap();
+        ws.record_task_event(
+            "intent_channel",
+            channel_event(ChannelEventType::AttemptPrepared, Some("att_1")),
+        )
+        .unwrap();
+
+        let request = RedirectActionRequest {
+            action_id: "act_redirect_1".into(),
+            continuation_attempt_id: "att_2".into(),
+            session_id: "ses_channel".into(),
+            intent_id: "intent_channel".into(),
+            task_id: "YARD-001".into(),
+            stopped_attempt_id: "att_1".into(),
+            observed_terminal_state: AttemptState::Cancelled,
+            reason: "user changed the target".into(),
+            guidance: "build path B".into(),
+            worker_id: "codex".into(),
+            checkpoint_ref: None,
+        };
+        assert!(ws
+            .redirect_task(&request)
+            .unwrap_err()
+            .to_string()
+            .contains("redirect_requires_observed_terminal"));
+
+        let mut completed = channel_event(ChannelEventType::WorkerCompleted, Some("att_1"));
+        completed.payload = serde_json::json!({"result": "cancelled", "reason": "user stop"});
+        ws.record_task_event("intent_channel", completed).unwrap();
+
+        let first = ws.redirect_task(&request).unwrap();
+        let duplicate = ws.redirect_task(&request).unwrap();
+        assert_eq!(first, duplicate);
+        assert_eq!(first.attempt.attempt_id, "att_2");
+        assert_eq!(first.attempt.continuation, ContinuationMode::Redirect);
+        assert!(first.attempt.worker_session_ref.is_none());
+        let channel = ws.load_task_channel("intent_channel", "YARD-001").unwrap();
+        assert_eq!(channel.attempts.len(), 2);
+        assert!(channel.events.iter().any(|event| {
+            event.event_type == ChannelEventType::ActionRequested
+                && event.payload["reason"] == "user changed the target"
+        }));
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -4289,6 +4289,43 @@ pub fn write_str(path: &Path, contents: &str) -> Result<()> {
     Ok(())
 }
 
+/// Create an immutable private evidence file. On Unix the requested mode is
+/// applied at inode creation, so there is no window where raw worker output is
+/// readable by group or other users.
+pub(crate) fn create_private_file(path: &Path) -> Result<fs::File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .with_context(|| format!("creating private evidence {}", path.display()))
+}
+
+/// Open a private append-only evidence file. `mode` affects creation only;
+/// callers retain append semantics for a combined log shared by stream readers.
+pub(crate) fn append_private_file(path: &Path) -> Result<fs::File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let mut options = fs::OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options
+        .open(path)
+        .with_context(|| format!("opening private evidence {}", path.display()))
+}
+
 /// Write a durable state snapshot through a same-directory temporary file so a
 /// crash cannot leave readers with a truncated JSON/YAML record.
 pub fn write_str_atomic(path: &Path, contents: &str) -> Result<()> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -2500,6 +2500,29 @@ impl Workspace {
                 question.answer_id = Some(answer.answer_id.clone());
             }
         }
+        for event in events
+            .iter()
+            .filter(|event| event.event_type == ChannelEventType::QuestionClosed)
+        {
+            let Some(question_id) = event
+                .payload
+                .get("question_id")
+                .and_then(|value| value.as_str())
+            else {
+                replay_errors.push(format!("question_closed_id_missing:{}", event.event_id));
+                continue;
+            };
+            let Some(question) = questions
+                .iter_mut()
+                .find(|question| question.question_id == question_id)
+            else {
+                replay_errors.push(format!("question_closed_missing:{question_id}"));
+                continue;
+            };
+            if question.answer_id.is_none() {
+                question.state = QuestionState::Closed;
+            }
+        }
         for event in &events {
             let Some(attempt_id) = event.attempt_id.as_deref() else {
                 continue;
@@ -3050,6 +3073,44 @@ impl Workspace {
             },
         )?;
         let mut result_event_ids = vec![requested.event_id.clone()];
+        let mut redirect_cause = requested.event_id.clone();
+        for question in channel.questions.iter().filter(|question| {
+            question.attempt_id == request.stopped_attempt_id
+                && question.state == QuestionState::Open
+                && !channel
+                    .answers
+                    .iter()
+                    .any(|answer| answer.question_id == question.question_id)
+        }) {
+            let closed = self.record_task_event_locked(
+                &request.intent_id,
+                ChannelEvent {
+                    schema_version: 1,
+                    event_id: format!("evt_{suffix}_closed_{}", question.question_id),
+                    session_id: request.session_id.clone(),
+                    seq: 0,
+                    event_type: ChannelEventType::QuestionClosed,
+                    recorded_at: Local::now().to_rfc3339(),
+                    actor: EventActor {
+                        kind: EventActorKind::System,
+                        id: String::new(),
+                    },
+                    action_id: Some(request.action_id.clone()),
+                    causation_id: Some(redirect_cause.clone()),
+                    correlation_id: requested.correlation_id.clone(),
+                    task_id: request.task_id.clone(),
+                    attempt_id: Some(request.stopped_attempt_id.clone()),
+                    payload: serde_json::json!({
+                        "question_id": question.question_id,
+                        "reason": "superseded_by_redirect",
+                        "continuation_attempt_id": request.continuation_attempt_id
+                    }),
+                    raw_ref: None,
+                },
+            )?;
+            redirect_cause = closed.event_id.clone();
+            result_event_ids.push(closed.event_id);
+        }
         let cause = if let Some(checkpoint_ref) = request.checkpoint_ref.as_deref() {
             let checkpoint = self.record_task_event_locked(
                 &request.intent_id,
@@ -3065,7 +3126,7 @@ impl Workspace {
                         id: String::new(),
                     },
                     action_id: Some(request.action_id.clone()),
-                    causation_id: Some(requested.event_id.clone()),
+                    causation_id: Some(redirect_cause.clone()),
                     correlation_id: requested.correlation_id.clone(),
                     task_id: request.task_id.clone(),
                     attempt_id: Some(request.stopped_attempt_id.clone()),
@@ -3076,7 +3137,7 @@ impl Workspace {
             result_event_ids.push(checkpoint.event_id.clone());
             checkpoint.event_id
         } else {
-            requested.event_id.clone()
+            redirect_cause
         };
 
         let attempt = WorkerAttempt {
@@ -3163,6 +3224,17 @@ impl Workspace {
             result_attempt_id: Some(attempt.attempt_id.clone()),
             error: String::new(),
         };
+        let mut queue = self.load_queue()?;
+        if let Some(task) = queue
+            .tasks
+            .iter_mut()
+            .find(|task| task.id == request.task_id)
+        {
+            if task.state == TaskState::Queued {
+                task.state = TaskState::NeedsUser;
+                self.save_queue_locked(&_lock, &queue)?;
+            }
+        }
         save_immutable_yaml(&terminal_path, &receipt)?;
         self.load_or_rebuild_task_channel(&request.intent_id, &request.task_id)?;
         Ok(RedirectActionOutcome { receipt, attempt })

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -456,13 +456,34 @@ impl App {
                 .map(|v| v.trim().trim_matches('"').to_string())
                 .unwrap_or_default()
         };
+        let task_id = field("task_id:");
+        if let Some(intent_id) = self
+            .snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.queue.intent_id.as_str())
+            .filter(|intent_id| !intent_id.is_empty())
+        {
+            if let Ok(channel) = self.ws.load_task_channel(intent_id, &task_id) {
+                let projected = channel_projection_lines(&channel);
+                let has_public_progress = channel.events.iter().any(|event| {
+                    !matches!(
+                        event.event_type,
+                        crate::schemas::ChannelEventType::AttemptPrepared
+                            | crate::schemas::ChannelEventType::WorkerStarted
+                    )
+                });
+                if has_public_progress && !projected.is_empty() {
+                    self.monitor.log_lines = projected;
+                }
+            }
+        }
         self.monitor.header = Some(MonitorHeader {
             run_name: dir
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("")
                 .to_string(),
-            task_id: field("task_id:"),
+            task_id,
             worker: field("worker:"),
             recorded_state: field("state:"),
         });
@@ -2664,6 +2685,101 @@ fn current_intent_id(app: &App) -> Option<&str> {
         .filter(|id| !id.is_empty())
 }
 
+fn channel_projection_lines(channel: &crate::schemas::TaskChannel) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current_attempt: Option<&str> = None;
+    for event in &channel.events {
+        if event.attempt_id.as_deref() != current_attempt {
+            current_attempt = event.attempt_id.as_deref();
+            if let Some(attempt_id) = current_attempt {
+                let worker = channel
+                    .attempts
+                    .iter()
+                    .find(|attempt| attempt.attempt_id == attempt_id)
+                    .map(|attempt| attempt.worker_id.as_str())
+                    .unwrap_or("unknown");
+                lines.push(format!("--- attempt {attempt_id} · {worker} ---"));
+            }
+        }
+        let text = match event.event_type {
+            crate::schemas::ChannelEventType::WorkerStarted => Some("worker started".to_string()),
+            crate::schemas::ChannelEventType::WorkerMessage => event
+                .payload
+                .get("text")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+            crate::schemas::ChannelEventType::ToolStarted => Some(format!(
+                "tool started: {}",
+                event
+                    .payload
+                    .get("name")
+                    .or_else(|| event.payload.get("command"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("tool")
+            )),
+            crate::schemas::ChannelEventType::ToolCompleted => Some(format!(
+                "tool completed: {}",
+                event
+                    .payload
+                    .get("name")
+                    .or_else(|| event.payload.get("command"))
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("tool")
+            )),
+            crate::schemas::ChannelEventType::QuestionAsked => event
+                .payload
+                .get("text")
+                .and_then(|value| value.as_str())
+                .map(|text| format!("question: {text}")),
+            crate::schemas::ChannelEventType::UserAnswered => event
+                .payload
+                .get("text")
+                .and_then(|value| value.as_str())
+                .map(|text| format!("user: {text}")),
+            crate::schemas::ChannelEventType::WorkerCheckpoint => {
+                Some("worker checkpoint recorded".to_string())
+            }
+            crate::schemas::ChannelEventType::WorkerCompleted => Some(format!(
+                "worker completed: {}",
+                event
+                    .payload
+                    .get("result")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown")
+            )),
+            crate::schemas::ChannelEventType::CompletionRecorded => Some(format!(
+                "task completed: {}",
+                event
+                    .payload
+                    .get("task_state")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("unknown")
+            )),
+            crate::schemas::ChannelEventType::ValidationStarted => {
+                Some("validation started".to_string())
+            }
+            crate::schemas::ChannelEventType::ValidationCompleted => Some(format!(
+                "validation completed: {}",
+                if event
+                    .payload
+                    .get("passed")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false)
+                {
+                    "passed"
+                } else {
+                    "failed"
+                }
+            )),
+            _ => None,
+        };
+        if let Some(text) = text.filter(|text| !text.trim().is_empty()) {
+            lines.push(format!("[{}] {text}", event.seq));
+        }
+    }
+    lines
+}
+
 /// Latest run for this task that belongs to the live intent. Task ids repeat
 /// across plans, so a bare latest-by-task lookup can expose a past intent's
 /// worker output on the Answer screen.
@@ -2785,9 +2901,24 @@ fn build_answer_context(app: &App, target_id: &str, question: &str) -> String {
 
     let run_dir = latest_answer_run(app, target_id);
     let mut has_detail = false;
-    if let Some(output) = run_dir.as_deref().and_then(readable_worker_output) {
-        context.push_str(&format!("## {}\n\n{output}\n\n", l.worker_output_title));
-        has_detail = true;
+    if let Some(intent_id) = current_intent_id(app) {
+        if let Ok(channel) = app.ws.load_task_channel(intent_id, target_id) {
+            let lines = channel_projection_lines(&channel);
+            if !lines.is_empty() {
+                context.push_str(&format!(
+                    "## {}\n\n{}\n\n",
+                    l.worker_output_title,
+                    lines.join("\n")
+                ));
+                has_detail = true;
+            }
+        }
+    }
+    if !has_detail {
+        if let Some(output) = run_dir.as_deref().and_then(readable_worker_output) {
+            context.push_str(&format!("## {}\n\n{output}\n\n", l.worker_output_title));
+            has_detail = true;
+        }
     }
     if let Some(conversation) = answer_conversation(app, target_id, question) {
         context.push_str(&format!(
@@ -2874,6 +3005,10 @@ fn start_answer(app: &mut App) {
     let ws = app.ws.clone();
     let lang = app.lang;
     let answer = app.input.trim().to_string();
+    if let Err(e) = run::prepare_answer_action(&app.ws, &task_id, &answer, None) {
+        app.toast = Some((false, format!("{} {e}", app.lang.l().answer_failed)));
+        return;
+    }
     let lbl = app.lang.l();
     let (resumed_via, failed) = (lbl.resumed_via, lbl.answer_failed);
     let (tx, rx) = mpsc::channel();

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -73,6 +73,9 @@ pub struct NormalizedWorkerEvent {
     pub raw_ref: RawEventRef,
 }
 
+pub type AttemptEventSink =
+    std::sync::Arc<dyn Fn(NormalizedWorkerEvent) -> std::result::Result<(), String> + Send + Sync>;
+
 #[derive(Debug, Clone)]
 pub struct AttemptCapture {
     pub combined_log: PathBuf,
@@ -284,6 +287,35 @@ pub fn normalize_worker_output(
         start = end;
     }
     events
+}
+
+fn publish_complete_public_lines(
+    worker_id: &str,
+    stream: RawStreamKind,
+    artifact_id: &str,
+    pending: &mut Vec<u8>,
+    consumed: &mut u64,
+    flush_tail: bool,
+    sink: &AttemptEventSink,
+) -> std::io::Result<()> {
+    loop {
+        let line_len = pending
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|newline| newline + 1)
+            .or_else(|| (flush_tail && !pending.is_empty()).then_some(pending.len()));
+        let Some(line_len) = line_len else {
+            break;
+        };
+        let line = pending.drain(..line_len).collect::<Vec<_>>();
+        for mut event in normalize_worker_output(worker_id, stream, &line, artifact_id) {
+            event.raw_ref.byte_start += *consumed;
+            event.raw_ref.byte_end += *consumed;
+            sink(event).map_err(std::io::Error::other)?;
+        }
+        *consumed += line_len as u64;
+    }
+    Ok(())
 }
 
 /// A model/effort value counts as explicit only when it is set and is not the
@@ -595,6 +627,7 @@ pub fn spawn(
         env,
         output_log,
         None,
+        None,
         timeout,
         full_access,
         images,
@@ -618,6 +651,39 @@ pub fn spawn_attempt(
     session: Option<&str>,
     resume: bool,
 ) -> Result<WorkerOutcome> {
+    spawn_attempt_with_sink(
+        profile,
+        bin,
+        packet,
+        worker_run_dir,
+        cwd,
+        env,
+        capture,
+        None,
+        timeout,
+        full_access,
+        images,
+        session,
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_attempt_with_sink(
+    profile: &WorkerProfile,
+    bin: &Path,
+    packet: &str,
+    worker_run_dir: &Path,
+    cwd: &Path,
+    env: &[(String, String)],
+    capture: &AttemptCapture,
+    event_sink: Option<AttemptEventSink>,
+    timeout: Duration,
+    full_access: bool,
+    images: &[String],
+    session: Option<&str>,
+    resume: bool,
+) -> Result<WorkerOutcome> {
     spawn_internal(
         profile,
         bin,
@@ -627,6 +693,7 @@ pub fn spawn_attempt(
         env,
         &capture.combined_log,
         Some(capture),
+        event_sink,
         timeout,
         full_access,
         images,
@@ -645,6 +712,7 @@ fn spawn_internal(
     env: &[(String, String)],
     output_log: &Path,
     attempt_capture: Option<&AttemptCapture>,
+    event_sink: Option<AttemptEventSink>,
     timeout: Duration,
     full_access: bool,
     images: &[String],
@@ -813,60 +881,109 @@ fn spawn_internal(
         None => (None, None),
     };
     type RawSink = Option<std::sync::Arc<std::sync::Mutex<std::fs::File>>>;
-    let mut sources: Vec<(Box<dyn Read + Send>, bool, RawSink)> = Vec::new();
+    let attempt_id = attempt_capture.and_then(|capture| {
+        capture
+            .stdout_log
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+    });
+    type StreamSource = (Box<dyn Read + Send>, bool, RawSink, RawStreamKind, String);
+    let mut sources: Vec<StreamSource> = Vec::new();
     if let Some(o) = child.stdout.take() {
-        sources.push((Box::new(o), profile.id == "codex" && !resume, stdout_raw));
+        sources.push((
+            Box::new(o),
+            profile.id == "codex" && !resume,
+            stdout_raw,
+            RawStreamKind::Stdout,
+            format!("raw_{}_stdout", attempt_id.unwrap_or("unknown")),
+        ));
     }
     if let Some(e) = child.stderr.take() {
-        sources.push((Box::new(e), false, stderr_raw));
+        sources.push((
+            Box::new(e),
+            false,
+            stderr_raw,
+            RawStreamKind::Stderr,
+            format!("raw_{}_stderr", attempt_id.unwrap_or("unknown")),
+        ));
     }
     let readers: Vec<_> = sources
         .into_iter()
-        .map(|(mut src, capture_session, raw_sink)| {
-            let log = std::sync::Arc::clone(&log_file);
-            let captured = std::sync::Arc::clone(&captured_session);
-            thread::spawn(move || -> std::io::Result<()> {
-                let mut buf = [0u8; 4096];
-                let mut pending = Vec::new();
-                loop {
-                    match src.read(&mut buf) {
-                        Ok(0) => {
-                            if capture_session && !pending.is_empty() {
-                                if let Some(id) = codex_thread_id_from_json_line(&pending) {
-                                    if let Ok(mut guard) = captured.lock() {
-                                        *guard = Some(id);
+        .map(
+            |(mut src, capture_session, raw_sink, stream, artifact_id)| {
+                let log = std::sync::Arc::clone(&log_file);
+                let captured = std::sync::Arc::clone(&captured_session);
+                let worker_id = profile.id.clone();
+                let event_sink = event_sink.clone();
+                thread::spawn(move || -> std::io::Result<()> {
+                    let mut buf = [0u8; 4096];
+                    let mut pending = Vec::new();
+                    let mut public_pending = Vec::new();
+                    let mut public_consumed = 0_u64;
+                    loop {
+                        match src.read(&mut buf) {
+                            Ok(0) => {
+                                if capture_session && !pending.is_empty() {
+                                    if let Some(id) = codex_thread_id_from_json_line(&pending) {
+                                        if let Ok(mut guard) = captured.lock() {
+                                            *guard = Some(id);
+                                        }
                                     }
                                 }
-                            }
-                            break;
-                        }
-                        Err(error) => return Err(error),
-                        Ok(n) => {
-                            if capture_session {
-                                capture_codex_thread_id(&mut pending, &buf[..n], &captured);
-                            }
-                            if let Ok(mut guard) = log.lock() {
-                                if let Some(f) = guard.as_mut() {
-                                    let _ = f.write_all(&buf[..n]);
-                                    let _ = f.flush();
+                                if let Some(sink) = &event_sink {
+                                    publish_complete_public_lines(
+                                        &worker_id,
+                                        stream,
+                                        &artifact_id,
+                                        &mut public_pending,
+                                        &mut public_consumed,
+                                        true,
+                                        sink,
+                                    )?;
                                 }
+                                break;
                             }
-                            if let Some(raw_sink) = &raw_sink {
-                                if let Ok(mut raw) = raw_sink.lock() {
-                                    raw.write_all(&buf[..n])?;
-                                    raw.flush()?;
-                                } else {
-                                    return Err(std::io::Error::other(
-                                        "attempt raw stream lock poisoned",
-                                    ));
+                            Err(error) => return Err(error),
+                            Ok(n) => {
+                                if capture_session {
+                                    capture_codex_thread_id(&mut pending, &buf[..n], &captured);
+                                }
+                                if let Ok(mut guard) = log.lock() {
+                                    if let Some(f) = guard.as_mut() {
+                                        let _ = f.write_all(&buf[..n]);
+                                        let _ = f.flush();
+                                    }
+                                }
+                                if let Some(raw_sink) = &raw_sink {
+                                    if let Ok(mut raw) = raw_sink.lock() {
+                                        raw.write_all(&buf[..n])?;
+                                        raw.flush()?;
+                                    } else {
+                                        return Err(std::io::Error::other(
+                                            "attempt raw stream lock poisoned",
+                                        ));
+                                    }
+                                }
+                                if let Some(sink) = &event_sink {
+                                    public_pending.extend_from_slice(&buf[..n]);
+                                    publish_complete_public_lines(
+                                        &worker_id,
+                                        stream,
+                                        &artifact_id,
+                                        &mut public_pending,
+                                        &mut public_consumed,
+                                        false,
+                                        sink,
+                                    )?;
                                 }
                             }
                         }
                     }
-                }
-                Ok(())
-            })
-        })
+                    Ok(())
+                })
+            },
+        )
         .collect();
 
     let start = Instant::now();

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -17,13 +17,252 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 
-use crate::schemas::{Invocation, WorkerProfile};
+use crate::schemas::{ChannelEventType, Invocation, RawEventRef, WorkerProfile};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RawStreamKind {
+    Stdout,
+    Stderr,
+}
+
+impl RawStreamKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NormalizedWorkerEvent {
+    pub event_type: ChannelEventType,
+    pub payload: serde_json::Value,
+    pub raw_ref: RawEventRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct AttemptCapture {
+    pub combined_log: PathBuf,
+    pub stdout_log: PathBuf,
+    pub stderr_log: PathBuf,
+}
+
+fn normalized_event(
+    event_type: ChannelEventType,
+    payload: serde_json::Value,
+    artifact_id: &str,
+    stream: RawStreamKind,
+    byte_start: usize,
+    byte_end: usize,
+) -> NormalizedWorkerEvent {
+    NormalizedWorkerEvent {
+        event_type,
+        payload,
+        raw_ref: RawEventRef {
+            artifact_id: artifact_id.to_string(),
+            stream: stream.as_str().to_string(),
+            byte_start: byte_start as u64,
+            byte_end: byte_end as u64,
+        },
+    }
+}
+
+fn text_event(
+    text: &str,
+    artifact_id: &str,
+    stream: RawStreamKind,
+    start: usize,
+    end: usize,
+) -> Option<NormalizedWorkerEvent> {
+    let text = text.trim();
+    (!text.is_empty()).then(|| {
+        normalized_event(
+            ChannelEventType::WorkerMessage,
+            serde_json::json!({"text": text}),
+            artifact_id,
+            stream,
+            start,
+            end,
+        )
+    })
+}
+
+fn normalize_codex_json(
+    value: &serde_json::Value,
+    artifact_id: &str,
+    stream: RawStreamKind,
+    start: usize,
+    end: usize,
+) -> Vec<NormalizedWorkerEvent> {
+    let Some(kind) = value.get("type").and_then(|value| value.as_str()) else {
+        return Vec::new();
+    };
+    let item = value.get("item").unwrap_or(value);
+    let item_type = item.get("type").and_then(|value| value.as_str());
+    if matches!(item_type, Some("reasoning" | "thinking" | "analysis")) {
+        return Vec::new();
+    }
+    match (kind, item_type) {
+        ("item.started", Some("command_execution" | "tool_call")) => vec![normalized_event(
+            ChannelEventType::ToolStarted,
+            serde_json::json!({
+                "name": item.get("name").and_then(|value| value.as_str()).unwrap_or("command"),
+                "command": item.get("command").and_then(|value| value.as_str()).unwrap_or("")
+            }),
+            artifact_id,
+            stream,
+            start,
+            end,
+        )],
+        ("item.completed", Some("command_execution" | "tool_call")) => {
+            vec![normalized_event(
+                ChannelEventType::ToolCompleted,
+                serde_json::json!({
+                    "name": item.get("name").and_then(|value| value.as_str()).unwrap_or("command"),
+                    "command": item.get("command").and_then(|value| value.as_str()).unwrap_or(""),
+                    "exit_code": item.get("exit_code").cloned().unwrap_or(serde_json::Value::Null)
+                }),
+                artifact_id,
+                stream,
+                start,
+                end,
+            )]
+        }
+        ("item.completed", Some("agent_message" | "message")) => item
+            .get("text")
+            .and_then(|value| value.as_str())
+            .and_then(|text| text_event(text, artifact_id, stream, start, end))
+            .into_iter()
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn normalize_claude_json(
+    value: &serde_json::Value,
+    artifact_id: &str,
+    stream: RawStreamKind,
+    start: usize,
+    end: usize,
+) -> Vec<NormalizedWorkerEvent> {
+    let mut out = Vec::new();
+    if value.get("type").and_then(|value| value.as_str()) == Some("content_block_start") {
+        let block = &value["content_block"];
+        if block.get("type").and_then(|value| value.as_str()) == Some("tool_use") {
+            out.push(normalized_event(
+                ChannelEventType::ToolStarted,
+                serde_json::json!({
+                    "name": block.get("name").and_then(|value| value.as_str()).unwrap_or("tool")
+                }),
+                artifact_id,
+                stream,
+                start,
+                end,
+            ));
+        }
+        return out;
+    }
+    let content = value
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(|content| content.as_array());
+    if let Some(content) = content {
+        for block in content {
+            match block.get("type").and_then(|value| value.as_str()) {
+                Some("text") => {
+                    if let Some(event) = block
+                        .get("text")
+                        .and_then(|value| value.as_str())
+                        .and_then(|text| text_event(text, artifact_id, stream, start, end))
+                    {
+                        out.push(event);
+                    }
+                }
+                Some("tool_use") => out.push(normalized_event(
+                    ChannelEventType::ToolStarted,
+                    serde_json::json!({
+                        "name": block.get("name").and_then(|value| value.as_str()).unwrap_or("tool")
+                    }),
+                    artifact_id,
+                    stream,
+                    start,
+                    end,
+                )),
+                Some("thinking" | "reasoning" | "analysis") => {}
+                _ => {}
+            }
+        }
+    } else if value.get("type").and_then(|value| value.as_str()) == Some("result") {
+        if let Some(event) = value
+            .get("result")
+            .and_then(|value| value.as_str())
+            .and_then(|text| text_event(text, artifact_id, stream, start, end))
+        {
+            out.push(event);
+        }
+    }
+    out
+}
+
+/// Normalize only provider-exposed public messages/tool activity. Raw bytes
+/// remain the source of truth and every emitted event points at its exact line.
+pub fn normalize_worker_output(
+    worker_id: &str,
+    stream: RawStreamKind,
+    raw: &[u8],
+    artifact_id: &str,
+) -> Vec<NormalizedWorkerEvent> {
+    let mut events = Vec::new();
+    let mut start = 0_usize;
+    while start < raw.len() {
+        let end = raw[start..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(raw.len(), |offset| start + offset + 1);
+        let line = String::from_utf8_lossy(&raw[start..end]);
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            match serde_json::from_str::<serde_json::Value>(trimmed) {
+                Ok(value) if worker_id == "codex" => {
+                    events.extend(normalize_codex_json(
+                        &value,
+                        artifact_id,
+                        stream,
+                        start,
+                        end,
+                    ));
+                }
+                Ok(value) if worker_id == "claude-code" => {
+                    events.extend(normalize_claude_json(
+                        &value,
+                        artifact_id,
+                        stream,
+                        start,
+                        end,
+                    ));
+                }
+                Ok(_) | Err(_) => {
+                    if let Some(event) = text_event(trimmed, artifact_id, stream, start, end) {
+                        events.push(event);
+                    }
+                }
+            }
+        }
+        start = end;
+    }
+    events
+}
 
 /// A model/effort value counts as explicit only when it is set and is not the
 /// "auto" sentinel. Empty or "auto" means: omit the flag and let the worker CLI
 /// choose (its own default / automatic selection).
 fn explicit(v: &str) -> bool {
     !v.trim().is_empty() && !v.eq_ignore_ascii_case("auto")
+}
+
+pub fn supports_native_resume(worker_id: &str) -> bool {
+    matches!(worker_id, "codex" | "claude-code")
 }
 
 /// The profile a task actually runs with. A per-task `model`/`effort` overrides
@@ -315,6 +554,71 @@ pub fn spawn(
     session: Option<&str>,
     resume: bool,
 ) -> Result<WorkerOutcome> {
+    spawn_internal(
+        profile,
+        bin,
+        packet,
+        worker_run_dir,
+        cwd,
+        env,
+        output_log,
+        None,
+        timeout,
+        full_access,
+        images,
+        session,
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_attempt(
+    profile: &WorkerProfile,
+    bin: &Path,
+    packet: &str,
+    worker_run_dir: &Path,
+    cwd: &Path,
+    env: &[(String, String)],
+    capture: &AttemptCapture,
+    timeout: Duration,
+    full_access: bool,
+    images: &[String],
+    session: Option<&str>,
+    resume: bool,
+) -> Result<WorkerOutcome> {
+    spawn_internal(
+        profile,
+        bin,
+        packet,
+        worker_run_dir,
+        cwd,
+        env,
+        &capture.combined_log,
+        Some(capture),
+        timeout,
+        full_access,
+        images,
+        session,
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_internal(
+    profile: &WorkerProfile,
+    bin: &Path,
+    packet: &str,
+    worker_run_dir: &Path,
+    cwd: &Path,
+    env: &[(String, String)],
+    output_log: &Path,
+    attempt_capture: Option<&AttemptCapture>,
+    timeout: Duration,
+    full_access: bool,
+    images: &[String],
+    session: Option<&str>,
+    resume: bool,
+) -> Result<WorkerOutcome> {
     use std::io::{Read, Write};
 
     // `worker_run_dir` may be a staging directory inside an isolated worktree,
@@ -373,6 +677,38 @@ pub fn spawn(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
+    let attempt_raw_files = if let Some(capture) = attempt_capture {
+        for path in [&capture.stdout_log, &capture.stderr_log] {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+            }
+            if path.exists() {
+                anyhow::bail!("attempt raw stream already exists: {}", path.display());
+            }
+        }
+        let stdout = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&capture.stdout_log)
+            .with_context(|| format!("creating {}", capture.stdout_log.display()))?;
+        let stderr = match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&capture.stderr_log)
+        {
+            Ok(file) => file,
+            Err(error) => {
+                let _ = std::fs::remove_file(&capture.stdout_log);
+                return Err(error)
+                    .with_context(|| format!("creating {}", capture.stderr_log.display()));
+            }
+        };
+        Some((stdout, stderr))
+    } else {
+        None
+    };
+
     let mut child = cmd
         .spawn()
         .with_context(|| format!("spawning worker '{}'", bin.display()))?;
@@ -390,28 +726,49 @@ pub fn spawn(
     // can tail the worker live. Worker CLIs often route progress to stderr or
     // block-buffer stdout on a pipe, so capturing stderr live (not only after
     // exit) is what keeps the monitor non-empty during a run.
-    let log_file = std::sync::Arc::new(std::sync::Mutex::new(
-        std::fs::File::create(output_log).ok(),
-    ));
+    let combined = if attempt_capture.is_some() {
+        if let Some(parent) = output_log.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        Some(
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(output_log)
+                .with_context(|| format!("opening {}", output_log.display()))?,
+        )
+    } else {
+        std::fs::File::create(output_log).ok()
+    };
+    let log_file = std::sync::Arc::new(std::sync::Mutex::new(combined));
     let captured_session = std::sync::Arc::new(std::sync::Mutex::new(None));
-    let mut sources: Vec<(Box<dyn Read + Send>, bool)> = Vec::new();
+    let (stdout_raw, stderr_raw) = match attempt_raw_files {
+        Some((stdout, stderr)) => (
+            Some(std::sync::Arc::new(std::sync::Mutex::new(stdout))),
+            Some(std::sync::Arc::new(std::sync::Mutex::new(stderr))),
+        ),
+        None => (None, None),
+    };
+    type RawSink = Option<std::sync::Arc<std::sync::Mutex<std::fs::File>>>;
+    let mut sources: Vec<(Box<dyn Read + Send>, bool, RawSink)> = Vec::new();
     if let Some(o) = child.stdout.take() {
-        sources.push((Box::new(o), profile.id == "codex" && !resume));
+        sources.push((Box::new(o), profile.id == "codex" && !resume, stdout_raw));
     }
     if let Some(e) = child.stderr.take() {
-        sources.push((Box::new(e), false));
+        sources.push((Box::new(e), false, stderr_raw));
     }
     let readers: Vec<_> = sources
         .into_iter()
-        .map(|(mut src, capture_session)| {
+        .map(|(mut src, capture_session, raw_sink)| {
             let log = std::sync::Arc::clone(&log_file);
             let captured = std::sync::Arc::clone(&captured_session);
-            thread::spawn(move || {
+            thread::spawn(move || -> std::io::Result<()> {
                 let mut buf = [0u8; 4096];
                 let mut pending = Vec::new();
                 loop {
                     match src.read(&mut buf) {
-                        Ok(0) | Err(_) => {
+                        Ok(0) => {
                             if capture_session && !pending.is_empty() {
                                 if let Some(id) = codex_thread_id_from_json_line(&pending) {
                                     if let Ok(mut guard) = captured.lock() {
@@ -421,6 +778,7 @@ pub fn spawn(
                             }
                             break;
                         }
+                        Err(error) => return Err(error),
                         Ok(n) => {
                             if capture_session {
                                 capture_codex_thread_id(&mut pending, &buf[..n], &captured);
@@ -431,9 +789,20 @@ pub fn spawn(
                                     let _ = f.flush();
                                 }
                             }
+                            if let Some(raw_sink) = &raw_sink {
+                                if let Ok(mut raw) = raw_sink.lock() {
+                                    raw.write_all(&buf[..n])?;
+                                    raw.flush()?;
+                                } else {
+                                    return Err(std::io::Error::other(
+                                        "attempt raw stream lock poisoned",
+                                    ));
+                                }
+                            }
                         }
                     }
                 }
+                Ok(())
             })
         })
         .collect();
@@ -451,10 +820,24 @@ pub fn spawn(
         }
         thread::sleep(Duration::from_millis(200));
     };
-    for r in readers {
-        let _ = r.join();
+    let mut reader_error = None;
+    for reader in readers {
+        match reader.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                reader_error.get_or_insert(error);
+            }
+            Err(_) => {
+                reader_error.get_or_insert_with(|| {
+                    std::io::Error::other("worker stream reader thread panicked")
+                });
+            }
+        }
     }
     let _ = std::fs::remove_file(&pid_path);
+    if let Some(error) = reader_error {
+        return Err(error).context("preserving attempt raw stream");
+    }
     let session_id = captured_session
         .lock()
         .ok()
@@ -979,5 +1362,135 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
                 "claude --effort omitted for {effort:?}"
             );
         }
+    }
+
+    #[test]
+    fn codex_public_stream_normalizes_messages_and_tools_but_not_reasoning() {
+        let raw = concat!(
+            "{\"type\":\"thread.started\",\"thread_id\":\"11111111-2222-4333-8444-555555555555\"}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"reasoning\",\"text\":\"private\"}}\n",
+            "{\"type\":\"item.started\",\"item\":{\"type\":\"command_execution\",\"command\":\"cargo test\"}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"command_execution\",\"command\":\"cargo test\",\"exit_code\":0}}\n",
+            "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"public update\"}}\n"
+        );
+        let events = normalize_worker_output(
+            "codex",
+            RawStreamKind::Stdout,
+            raw.as_bytes(),
+            "raw_att_1_stdout",
+        );
+
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events[0].event_type,
+            crate::schemas::ChannelEventType::ToolStarted
+        );
+        assert_eq!(
+            events[1].event_type,
+            crate::schemas::ChannelEventType::ToolCompleted
+        );
+        assert_eq!(
+            events[2].event_type,
+            crate::schemas::ChannelEventType::WorkerMessage
+        );
+        assert_eq!(events[2].payload["text"], "public update");
+        assert!(events.iter().all(|event| {
+            event.raw_ref.byte_end > event.raw_ref.byte_start
+                && event.raw_ref.artifact_id == "raw_att_1_stdout"
+        }));
+        assert!(events
+            .iter()
+            .all(|event| !event.payload.to_string().contains("private")));
+    }
+
+    #[test]
+    fn text_only_stream_degrades_to_message_events_with_exact_spans() {
+        let events = normalize_worker_output(
+            "generic-text",
+            RawStreamKind::Stderr,
+            b"first line\n\nsecond line\n",
+            "raw_att_2_stderr",
+        );
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].payload["text"], "first line");
+        assert_eq!(events[0].raw_ref.byte_start, 0);
+        assert_eq!(events[0].raw_ref.byte_end, 11);
+        assert_eq!(events[1].payload["text"], "second line");
+        assert_eq!(events[1].raw_ref.stream, "stderr");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn attempt_capture_separates_stdout_stderr_and_refuses_overwrite() {
+        let root =
+            std::env::temp_dir().join(format!("yard-attempt-capture-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let profile: WorkerProfile = crate::yaml::from_str(
+            r#"
+id: fixture
+invocation:
+  command: sh
+  args: ["-c", "printf stdout-only; printf stderr-only >&2"]
+limits: {max_wall_minutes: 1}
+"#,
+        )
+        .unwrap();
+        let capture = AttemptCapture {
+            combined_log: root.join("worker-output.log"),
+            stdout_log: root.join("attempts/att_1/stdout.log"),
+            stderr_log: root.join("attempts/att_1/stderr.log"),
+        };
+        let outcome = spawn_attempt(
+            &profile,
+            Path::new("/bin/sh"),
+            "packet",
+            &root,
+            &root,
+            &[],
+            &capture,
+            Duration::from_secs(5),
+            false,
+            &[],
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(outcome.exit_ok);
+        assert_eq!(
+            std::fs::read_to_string(&capture.stdout_log).unwrap(),
+            "stdout-only"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&capture.stderr_log).unwrap(),
+            "stderr-only"
+        );
+        let combined = std::fs::read_to_string(&capture.combined_log).unwrap();
+        assert!(combined.contains("stdout-only"));
+        assert!(combined.contains("stderr-only"));
+
+        let error = spawn_attempt(
+            &profile,
+            Path::new("/bin/sh"),
+            "packet",
+            &root,
+            &root,
+            &[],
+            &capture,
+            Duration::from_secs(5),
+            false,
+            &[],
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("attempt raw stream already exists"));
+        assert_eq!(
+            std::fs::read_to_string(&capture.stdout_log).unwrap(),
+            "stdout-only"
+        );
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -687,21 +687,12 @@ fn spawn_internal(
                 anyhow::bail!("attempt raw stream already exists: {}", path.display());
             }
         }
-        let stdout = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&capture.stdout_log)
-            .with_context(|| format!("creating {}", capture.stdout_log.display()))?;
-        let stderr = match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&capture.stderr_log)
-        {
+        let stdout = crate::state::create_private_file(&capture.stdout_log)?;
+        let stderr = match crate::state::create_private_file(&capture.stderr_log) {
             Ok(file) => file,
             Err(error) => {
                 let _ = std::fs::remove_file(&capture.stdout_log);
-                return Err(error)
-                    .with_context(|| format!("creating {}", capture.stderr_log.display()));
+                return Err(error);
             }
         };
         Some((stdout, stderr))
@@ -731,13 +722,7 @@ fn spawn_internal(
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating {}", parent.display()))?;
         }
-        Some(
-            std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(output_log)
-                .with_context(|| format!("opening {}", output_log.display()))?,
-        )
+        Some(crate::state::append_private_file(output_log)?)
     } else {
         std::fs::File::create(output_log).ok()
     };

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -19,6 +19,38 @@ use anyhow::{Context, Result};
 
 use crate::schemas::{ChannelEventType, Invocation, RawEventRef, WorkerProfile};
 
+pub(crate) const WORKER_PROCESS_PROVENANCE_FILE: &str = "worker-process.yaml";
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct WorkerProcessProvenance {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub attempt_id: String,
+    pub worker_id: String,
+    pub pid: u32,
+    pub process_start_marker: String,
+}
+
+pub(crate) fn process_start_marker(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "lstart="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let marker = String::from_utf8(output.stdout)
+        .ok()?
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!marker.is_empty()).then_some(marker)
+}
+
+pub(crate) fn load_worker_process_provenance(run_dir: &Path) -> Result<WorkerProcessProvenance> {
+    crate::state::load_yaml(&run_dir.join(WORKER_PROCESS_PROVENANCE_FILE))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RawStreamKind {
     Stdout,
@@ -704,9 +736,54 @@ fn spawn_internal(
         .spawn()
         .with_context(|| format!("spawning worker '{}'", bin.display()))?;
 
-    // Record the worker PID so the TUI can stop it (Esc) by killing the process.
+    let provenance_path = control_run_dir.join(WORKER_PROCESS_PROVENANCE_FILE);
+    let provenance_result = (|| -> Result<()> {
+        let Some(capture) = attempt_capture else {
+            return Ok(());
+        };
+        let run_id = control_run_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("worker control directory has no run identity"))?;
+        let attempt_id = capture
+            .stdout_log
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("attempt capture path has no attempt identity"))?;
+        let process_start_marker = process_start_marker(child.id())
+            .ok_or_else(|| anyhow::anyhow!("could not observe spawned worker process identity"))?;
+        let provenance = WorkerProcessProvenance {
+            schema_version: 1,
+            run_id: run_id.to_string(),
+            attempt_id: attempt_id.to_string(),
+            worker_id: profile.id.clone(),
+            pid: child.id(),
+            process_start_marker,
+        };
+        let mut file = crate::state::create_private_file(&provenance_path)?;
+        file.write_all(crate::yaml::to_string(&provenance)?.as_bytes())?;
+        file.sync_all()?;
+        Ok(())
+    })();
+    if let Err(error) = provenance_result {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&provenance_path);
+        return Err(error).context("recording run-owned worker process provenance");
+    }
+
+    // Keep the legacy PID projection for monitors. Redirect signaling verifies
+    // the separate run-owned provenance record and never trusts this file.
     let pid_path = control_run_dir.join("worker.pid");
-    let _ = std::fs::write(&pid_path, child.id().to_string());
+    if let Err(error) = crate::state::write_str_atomic(&pid_path, &child.id().to_string()) {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&provenance_path);
+        return Err(error).context("recording worker PID projection");
+    }
 
     if let Some(mut stdin) = child.stdin.take() {
         // Best-effort: a worker that ignores stdin will simply not receive it.
@@ -820,6 +897,7 @@ fn spawn_internal(
         }
     }
     let _ = std::fs::remove_file(&pid_path);
+    let _ = std::fs::remove_file(&provenance_path);
     if let Some(error) = reader_error {
         return Err(error).context("preserving attempt raw stream");
     }

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -112,6 +112,41 @@ case "$task_id" in
       write_question "index rebuild를 계속할까요?"
     fi
     ;;
+  YARD-LIVE)
+    printf '{"type":"item.started","item":{"type":"command_execution","command":"printf live"}}\n'
+    printf '{"type":"item.completed","item":{"type":"reasoning","text":"private fixture reasoning"}}\n'
+    printf '{"type":"item.completed","item":{"type":"agent_message","text":"live public message"}}\n'
+    printf '{"type":"item.completed","item":{"type":"command_execution","command":"printf live","exit_code":0}}\n'
+    sleep 3
+    printf 'live worker artifact\n' >live-worker-artifact.txt
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "changes": {"files_created": ["live-worker-artifact.txt"]},\n  "compact_summary": "live event and artifact fixture complete"\n}\n' \
+      "$run_id" "$task_id" >"$run_dir/result.json"
+    write_handoff "live event and artifact fixture complete"
+    ;;
+  YARD-REDIRECT-QUESTION)
+    if grep -q '> \[user\] resolve current question' <<<"$packet"; then
+      printf 'current question resolved\n'
+      write_done "redirected current question resolved"
+    elif grep -q '> \[user\] ask a current question' <<<"$packet"; then
+      printf 'redirected question context\n'
+      write_question "current question after redirect"
+    elif grep -q '> \[user\] stale answer' <<<"$packet"; then
+      printf 'stale question was incorrectly resumed\n'
+      write_done "stale question incorrectly resumed"
+    else
+      printf 'superseded question context\n'
+      write_question "question that redirect will supersede"
+    fi
+    ;;
+  YARD-FALLBACK)
+    if grep -q 'Explicit continuation packet' <<<"$packet"; then
+      printf 'fallback worker explicit continuation\n'
+      write_done "fallback worker completed explicit continuation"
+    else
+      printf 'producer worker question context\n'
+      write_question "continue with a fallback worker?"
+    fi
+    ;;
   *)
     printf 'unexpected fixture task: %s\n' "$task_id" >&2
     exit 64

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -6,35 +6,56 @@ if [[ "${1:-}" == "--version" ]]; then
   exit 0
 fi
 
-run_dir="$1"
+run_dir="${1:?run directory is required}"
 packet="$(cat)"
+task_id="$(sed -n 's/^# Yardlet task packet: //p' <<<"$packet" | head -n 1)"
+run_id="${run_dir##*/}"
 mkdir -p "$run_dir"
 
-if grep -q '> \[user\] A' <<<"$packet"; then
-  printf 'fixture second stdout\n'
-  printf 'fixture second stderr\n' >&2
-  cat >"$run_dir/result.json" <<'JSON'
-{
-  "schema_version": 1,
-  "run_id": "fixture-result",
-  "task_id": "YARD-001",
-  "status": "done",
-  "compact_summary": "질문 답변 뒤 explicit continuation 완료"
+write_handoff() {
+  printf '# Handoff\n\n%s\n' "$1" >"$run_dir/handoff.md"
 }
-JSON
-  printf '# Handoff\n\n답변 뒤 완료했습니다.\n' >"$run_dir/handoff.md"
-else
-  printf 'fixture first stdout\n'
-  printf 'fixture first stderr\n' >&2
-  cat >"$run_dir/result.json" <<'JSON'
-{
-  "schema_version": 1,
-  "run_id": "fixture-result",
-  "task_id": "YARD-001",
-  "status": "needs_user",
-  "question_for_user": "A 또는 B를 선택해 주세요.",
-  "compact_summary": "사용자 선택 대기"
+
+write_done() {
+  local summary="$1"
+  printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "compact_summary": "%s"\n}\n' \
+    "$run_id" "$task_id" "$summary" >"$run_dir/result.json"
+  write_handoff "$summary"
 }
-JSON
-  printf '# Handoff\n\n사용자 선택을 기다립니다.\n' >"$run_dir/handoff.md"
-fi
+
+write_question() {
+  local question="$1"
+  printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "needs_user",\n  "question_for_user": "%s",\n  "compact_summary": "사용자 선택 대기"\n}\n' \
+    "$run_id" "$task_id" "$question" >"$run_dir/result.json"
+  write_handoff "사용자 선택을 기다립니다."
+}
+
+case "$task_id" in
+  YARD-ASK)
+    printf 'ask worker public context before question\n'
+    printf 'ask worker diagnostic stream\n' >&2
+    write_question "A 또는 B를 선택해 주세요."
+    ;;
+  YARD-DRAIN)
+    sleep 1
+    printf 'drain worker public progress\n'
+    printf 'drain worker diagnostic stream\n' >&2
+    printf 'validated fixture artifact\n' >drain-artifact.txt
+    write_done "독립 task worker 완료"
+    ;;
+  YARD-001)
+    if grep -q '> \[user\] A' <<<"$packet"; then
+      printf 'fixture second stdout\n'
+      printf 'fixture second stderr\n' >&2
+      write_done "질문 답변 뒤 explicit continuation 완료"
+    else
+      printf 'fixture first stdout\n'
+      printf 'fixture first stderr\n' >&2
+      write_question "A 또는 B를 선택해 주세요."
+    fi
+    ;;
+  *)
+    printf 'unexpected fixture task: %s\n' "$task_id" >&2
+    exit 64
+    ;;
+esac

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fixture-worker 1.0\n'
+  exit 0
+fi
+
+run_dir="$1"
+packet="$(cat)"
+mkdir -p "$run_dir"
+
+if grep -q '> \[user\] A' <<<"$packet"; then
+  printf 'fixture second stdout\n'
+  printf 'fixture second stderr\n' >&2
+  cat >"$run_dir/result.json" <<'JSON'
+{
+  "schema_version": 1,
+  "run_id": "fixture-result",
+  "task_id": "YARD-001",
+  "status": "done",
+  "compact_summary": "질문 답변 뒤 explicit continuation 완료"
+}
+JSON
+  printf '# Handoff\n\n답변 뒤 완료했습니다.\n' >"$run_dir/handoff.md"
+else
+  printf 'fixture first stdout\n'
+  printf 'fixture first stderr\n' >&2
+  cat >"$run_dir/result.json" <<'JSON'
+{
+  "schema_version": 1,
+  "run_id": "fixture-result",
+  "task_id": "YARD-001",
+  "status": "needs_user",
+  "question_for_user": "A 또는 B를 선택해 주세요.",
+  "compact_summary": "사용자 선택 대기"
+}
+JSON
+  printf '# Handoff\n\n사용자 선택을 기다립니다.\n' >"$run_dir/handoff.md"
+fi

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -6,8 +6,18 @@ if [[ "${1:-}" == "--version" ]]; then
   exit 0
 fi
 
-run_dir="${1:?run directory is required}"
 packet="$(cat)"
+native_adapter=false
+if [[ "${1:-}" == "exec" ]]; then
+  native_adapter=true
+  run_dir="$(sed -n 's#.*- `\(/.*\)/result.json`.*#\1#p' <<<"$packet" | head -n 1)"
+else
+  run_dir="${1:?run directory is required}"
+fi
+if [[ -z "$run_dir" ]]; then
+  printf 'fixture could not resolve run directory\n' >&2
+  exit 65
+fi
 task_id="$(sed -n 's/^# Yardlet task packet: //p' <<<"$packet" | head -n 1)"
 run_id="${run_dir##*/}"
 mkdir -p "$run_dir"
@@ -52,6 +62,54 @@ case "$task_id" in
       printf 'fixture first stdout\n'
       printf 'fixture first stderr\n' >&2
       write_question "A 또는 B를 선택해 주세요."
+    fi
+    ;;
+  YARD-NATIVE)
+    if [[ "$native_adapter" != true ]]; then
+      printf 'native fixture requires the codex adapter\n' >&2
+      exit 66
+    fi
+    printf '%s\n' "$*" >"$run_dir/native-args.txt"
+    if [[ " $* " == *" resume "* ]]; then
+      printf '{"type":"item.completed","item":{"type":"agent_message","text":"native resumed stdout"}}\n'
+      printf 'native resumed stderr\n' >&2
+      write_done "native session resume 완료"
+    else
+      printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n'
+      printf '{"type":"item.completed","item":{"type":"agent_message","text":"native first stdout"}}\n'
+      printf 'native first stderr\n' >&2
+      write_question "native session으로 이어갈까요?"
+    fi
+    ;;
+  YARD-REDIRECT)
+    if grep -q 'Explicit continuation packet' <<<"$packet"; then
+      printf 'redirected worker public completion\n'
+      printf 'redirected worker diagnostic completion\n' >&2
+      write_done "redirect guidance 완료"
+    else
+      printf 'running worker public progress\n'
+      printf 'running worker diagnostic progress\n' >&2
+      write_handoff "checkpoint before redirect"
+      child_pid=''
+      trap '[[ -z "$child_pid" ]] || kill "$child_pid" 2>/dev/null || true; exit 143' TERM INT
+      while true; do
+        sleep 30 &
+        child_pid=$!
+        wait "$child_pid"
+      done
+    fi
+    ;;
+  YARD-INDEX)
+    if grep -q '> \[user\] A' <<<"$packet"; then
+      printf 'index continuation stdout\n'
+      printf 'index continuation stderr\n' >&2
+      write_done "bounded index rebuild 완료"
+    else
+      for index in $(seq 1 140); do
+        printf 'index public progress %03d\n' "$index"
+      done
+      printf 'index diagnostic stream\n' >&2
+      write_question "index rebuild를 계속할까요?"
     fi
     ;;
   *)

--- a/tests/state_architecture_guard.rs
+++ b/tests/state_architecture_guard.rs
@@ -17,6 +17,8 @@ const CANONICAL_STATE_MARKERS: &[&str] = &[
     "activation_path(",
     "runtime_task_receipt_path(",
     "runtime_capability_receipt_path(",
+    "task_channel_dir(",
+    "task_channel_index_path(",
     ".agents/work-queue.yaml",
     ".agents/intent-contract.yaml",
     ".agents/transitions",
@@ -24,6 +26,7 @@ const CANONICAL_STATE_MARKERS: &[&str] = &[
     ".agents/activations",
     ".agents/runtime-task-receipts",
     ".agents/runtime-capability-receipts",
+    ".agents/task-channels",
 ];
 
 #[test]

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -160,15 +160,19 @@ mod unix {
     }
 
     fn channel_dir(root: &Path, task_id: &str) -> PathBuf {
+        maybe_channel_dir(root, task_id)
+            .unwrap_or_else(|| panic!("channel for {task_id} not found"))
+    }
+
+    fn maybe_channel_dir(root: &Path, task_id: &str) -> Option<PathBuf> {
         fs::read_dir(root.join(".agents/task-channels"))
-            .unwrap()
+            .ok()?
             .flatten()
             .map(|entry| entry.path())
             .find(|path| {
                 path.join("channel.yaml").is_file()
                     && string(&read_yaml(&path.join("channel.yaml")), "task_id") == task_id
             })
-            .unwrap_or_else(|| panic!("channel for {task_id} not found"))
     }
 
     fn yaml_dir(path: &Path) -> Vec<Value> {
@@ -232,6 +236,10 @@ mod unix {
             .stderr(Stdio::null())
             .status()
             .is_ok_and(|status| status.success())
+    }
+
+    fn worker_path(fixture: &FixtureWorkspace) -> PathBuf {
+        fixture.root.join(".agents/fixture-bin/worker.sh")
     }
 
     #[test]
@@ -980,5 +988,345 @@ mod unix {
             String::from_utf8_lossy(&output.stderr).contains("attempt raw stream already exists")
         );
         assert_eq!(fs::read(&overwrite_path).unwrap(), b"do not overwrite\n");
+    }
+
+    #[test]
+    fn provider_progress_is_canonical_while_worker_lives_and_artifacts_keep_attempt_provenance() {
+        let fixture = FixtureWorkspace::new("live-progress-artifacts");
+        fixture.write_queue(
+            "  - id: YARD-LIVE\n    title: live provider progress and artifacts\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n",
+        );
+
+        let mut running = Command::new(&fixture.binary)
+            .args(["run", "--task", "YARD-LIVE", "--execute"])
+            .current_dir(&fixture.root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let live_events_visible = wait_until(Duration::from_secs(10), || {
+            let Some(channel) = maybe_channel_dir(&fixture.root, "YARD-LIVE") else {
+                return false;
+            };
+            let Some(pid_path) = files_below(&fixture.root.join(".agents/runs"), "/worker.pid")
+                .into_iter()
+                .next()
+            else {
+                return false;
+            };
+            let Some(pid) = fs::read_to_string(pid_path)
+                .ok()
+                .and_then(|text| text.trim().parse::<u32>().ok())
+            else {
+                return false;
+            };
+            if !process_is_alive(pid) {
+                return false;
+            }
+            let events = yaml_dir(&channel.join("events"));
+            events
+                .iter()
+                .any(|event| string(event, "event_type") == "worker.message")
+                && events
+                    .iter()
+                    .any(|event| string(event, "event_type") == "tool.started")
+                && events
+                    .iter()
+                    .any(|event| string(event, "event_type") == "tool.completed")
+        });
+        assert!(
+            live_events_visible,
+            "normalized events were not visible while the worker lived"
+        );
+        assert!(
+            running.try_wait().unwrap().is_none(),
+            "worker run exited before live channel observation"
+        );
+
+        let channel = channel_dir(&fixture.root, "YARD-LIVE");
+        let live_events = yaml_dir(&channel.join("events"));
+        let attempts = yaml_dir(&channel.join("attempts"));
+        let attempt = attempts.first().unwrap();
+        let stdout_path = {
+            let path = PathBuf::from(string(attempt, "raw_stdout_ref"));
+            if path.is_absolute() {
+                path
+            } else {
+                fixture.root.join(".agents").join(path)
+            }
+        };
+        let stdout = fs::read(&stdout_path).unwrap();
+        for event in live_events.iter().filter(|event| {
+            matches!(
+                string(event, "event_type"),
+                "worker.message" | "tool.started" | "tool.completed"
+            )
+        }) {
+            assert_eq!(event["raw_ref"]["stream"], "stdout");
+            let start = number(&event["raw_ref"], "byte_start") as usize;
+            let end = number(&event["raw_ref"], "byte_end") as usize;
+            assert!(start < end && end <= stdout.len());
+            assert!(String::from_utf8_lossy(&stdout[start..end]).contains("item."));
+        }
+        assert!(live_events.iter().all(|event| {
+            !serde_yaml_ng::to_string(&event["payload"])
+                .unwrap()
+                .contains("private fixture reasoning")
+        }));
+
+        let output = running.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "live fixture failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let events = yaml_dir(&channel.join("events"));
+        let artifact_events = events
+            .iter()
+            .filter(|event| string(event, "event_type") == "artifact.created")
+            .collect::<Vec<_>>();
+        let roles = artifact_events
+            .iter()
+            .filter_map(|event| event["payload"]["role"].as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        for role in [
+            "worker_result",
+            "evaluation",
+            "checkpoint",
+            "handoff",
+            "worker_declared",
+        ] {
+            assert!(
+                roles.contains(role),
+                "missing artifact role {role}: {roles:?}"
+            );
+        }
+        assert!(artifact_events.iter().all(|event| {
+            event["attempt_id"] == attempt["attempt_id"]
+                && event["payload"]["producer_attempt_id"] == attempt["attempt_id"]
+                && event["payload"]["content_digest"]
+                    .as_str()
+                    .is_some_and(|digest| !digest.is_empty())
+        }));
+    }
+
+    #[test]
+    fn redirect_closes_superseded_question_and_stale_answer_fails_without_mutation() {
+        let fixture = FixtureWorkspace::new("redirect-question-close");
+        fixture.write_queue(
+            "  - id: YARD-REDIRECT-QUESTION\n    title: redirect closes prior question\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+        fixture.run(&["run", "--task", "YARD-REDIRECT-QUESTION", "--execute"]);
+        let channel = channel_dir(&fixture.root, "YARD-REDIRECT-QUESTION");
+        let first_question = yaml_dir(&channel.join("questions"))
+            .into_iter()
+            .next()
+            .unwrap();
+        fixture.run(&[
+            "redirect",
+            "YARD-REDIRECT-QUESTION",
+            "ask a current question",
+            "--reason",
+            "prior question superseded",
+            "--action-id",
+            "act-question-redirect",
+        ]);
+        fixture.run(&[
+            "answer",
+            "resolve current question",
+            "--task",
+            "YARD-REDIRECT-QUESTION",
+            "--action-id",
+            "act-current-answer",
+        ]);
+        assert_eq!(task_state(&fixture.root, "YARD-REDIRECT-QUESTION"), "done");
+
+        let events = yaml_dir(&channel.join("events"));
+        let closed = events
+            .iter()
+            .find(|event| {
+                string(event, "event_type") == "question.closed"
+                    && event["payload"]["question_id"] == first_question["question_id"]
+            })
+            .expect("redirect did not record a question.closed event");
+        assert_eq!(string(closed, "action_id"), "act-question-redirect");
+
+        let attempts_before = yaml_dir(&channel.join("attempts"));
+        let events_before = yaml_dir(&channel.join("events"));
+        let stale = command(
+            &fixture.root,
+            &fixture.binary,
+            &[
+                "answer",
+                "stale answer",
+                "--task",
+                "YARD-REDIRECT-QUESTION",
+                "--action-id",
+                "act-stale-answer",
+            ],
+        );
+        assert!(
+            !stale.status.success(),
+            "stale answer unexpectedly resumed work"
+        );
+        assert_eq!(yaml_dir(&channel.join("attempts")), attempts_before);
+        assert_eq!(yaml_dir(&channel.join("events")), events_before);
+        assert!(!channel
+            .join("actions/act-stale-answer.terminal.yaml")
+            .exists());
+    }
+
+    #[test]
+    fn unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet() {
+        let fixture = FixtureWorkspace::new("answer-fallback-worker");
+        let worker = worker_path(&fixture);
+        let workers_path = fixture.root.join(".agents/workers.yaml");
+        let write_workers = |producer_command: &Path| {
+            fs::write(
+                &workers_path,
+                format!(
+                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n",
+                    producer_command.display(),
+                    worker.display()
+                ),
+            )
+            .unwrap();
+        };
+        write_workers(&worker);
+        fixture.write_queue(
+            "  - id: YARD-FALLBACK\n    title: fallback owns answer continuation\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture-fallback-a\n",
+        );
+        fixture.run(&["run", "--task", "YARD-FALLBACK", "--execute"]);
+        write_workers(Path::new("yardlet-missing-question-producer"));
+
+        fixture.run(&[
+            "answer",
+            "continue on fallback",
+            "--task",
+            "YARD-FALLBACK",
+            "--action-id",
+            "act-fallback-answer",
+        ]);
+        let channel = channel_dir(&fixture.root, "YARD-FALLBACK");
+        let attempts = yaml_dir(&channel.join("attempts"));
+        let continuation = attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "explicit_packet")
+            .unwrap();
+        assert_eq!(string(continuation, "worker_id"), "fixture-fallback-b");
+        assert_eq!(
+            string(continuation, "caused_by_action_id"),
+            "act-fallback-answer"
+        );
+        assert_eq!(task_state(&fixture.root, "YARD-FALLBACK"), "done");
+        assert!(
+            files_below(&fixture.root.join(".agents/runs"), "/task-packet.md")
+                .iter()
+                .any(|path| fs::read_to_string(path)
+                    .is_ok_and(|packet| packet.contains("Explicit continuation packet")))
+        );
+    }
+
+    #[test]
+    fn redirect_receipt_crash_retries_same_action_and_runs_stored_attempt_once() {
+        let fixture = FixtureWorkspace::new("redirect-receipt-crash");
+        fixture.write_queue(
+            "  - id: YARD-REDIRECT\n    title: redirect receipt crash recovery\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+        let running = Command::new(&fixture.binary)
+            .args(["run", "--task", "YARD-REDIRECT", "--execute"])
+            .current_dir(&fixture.root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        assert!(wait_until(Duration::from_secs(10), || {
+            task_state(&fixture.root, "YARD-REDIRECT") == "running"
+                && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
+        }));
+
+        let crashed = Command::new(&fixture.binary)
+            .args([
+                "redirect",
+                "YARD-REDIRECT",
+                "recover stored redirect guidance",
+                "--reason",
+                "inject receipt crash",
+                "--action-id",
+                "act-redirect-crash",
+            ])
+            .env("YARDLET_TEST_CRASH_AFTER_REDIRECT_RECEIPT", "1")
+            .current_dir(&fixture.root)
+            .output()
+            .unwrap();
+        assert!(
+            !crashed.status.success(),
+            "redirect did not stop after the terminal receipt"
+        );
+        let original = running.wait_with_output().unwrap();
+        assert!(original.status.success());
+        let channel = channel_dir(&fixture.root, "YARD-REDIRECT");
+        let prepared_attempts = yaml_dir(&channel.join("attempts"));
+        assert_eq!(prepared_attempts.len(), 2);
+        assert!(channel
+            .join("actions/act-redirect-crash.terminal.yaml")
+            .is_file());
+
+        fixture.run(&[
+            "redirect",
+            "YARD-REDIRECT",
+            "recover stored redirect guidance",
+            "--reason",
+            "inject receipt crash",
+            "--action-id",
+            "act-redirect-crash",
+        ]);
+        let attempts = yaml_dir(&channel.join("attempts"));
+        assert_eq!(
+            attempts.len(),
+            2,
+            "restart created a duplicate redirect attempt"
+        );
+        let redirect_attempt = attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "redirect")
+            .unwrap();
+        let events = yaml_dir(&channel.join("events"));
+        let starts = events
+            .iter()
+            .filter(|event| {
+                string(event, "event_type") == "worker.started"
+                    && event["attempt_id"] == redirect_attempt["attempt_id"]
+            })
+            .count();
+        assert_eq!(
+            starts, 1,
+            "stored redirect attempt did not execute exactly once"
+        );
+        assert_eq!(task_state(&fixture.root, "YARD-REDIRECT"), "done");
+    }
+
+    #[test]
+    fn needs_user_question_precedes_worker_completed_and_is_its_cause() {
+        let fixture = FixtureWorkspace::new("needs-user-ordering");
+        fixture.write_queue(
+            "  - id: YARD-ASK\n    title: question ordering\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture-ask\n",
+        );
+        fixture.run(&["run", "--task", "YARD-ASK", "--execute"]);
+        let channel = channel_dir(&fixture.root, "YARD-ASK");
+        let events = yaml_dir(&channel.join("events"));
+        let asked = events
+            .iter()
+            .find(|event| string(event, "event_type") == "question.asked")
+            .unwrap();
+        let completed = events
+            .iter()
+            .find(|event| string(event, "event_type") == "worker.completed")
+            .unwrap();
+        assert!(number(asked, "seq") < number(completed, "seq"));
+        assert_eq!(string(completed, "causation_id"), string(asked, "event_id"));
+        assert_eq!(completed["payload"]["result"], "needs_user");
     }
 }

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -225,6 +225,15 @@ mod unix {
         false
     }
 
+    fn process_is_alive(pid: u32) -> bool {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
     #[test]
     fn text_worker_answer_creates_a_new_attempt_and_preserves_both_raw_streams() {
         let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -625,6 +634,191 @@ mod unix {
         assert!(!duplicate.status.success());
         fixture.run(&["queue"]);
         assert_eq!(yaml_dir(&channel.join("attempts")), before_restart);
+    }
+
+    #[test]
+    fn action_id_rejects_absolute_and_parent_paths_without_receipt_escape() {
+        for kind in ["absolute", "parent"] {
+            let fixture = FixtureWorkspace::new(&format!("unsafe-action-id-{kind}"));
+            fixture.write_queue(
+                "  - id: YARD-001\n    title: unsafe action id boundary\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+            );
+            fixture.run(&["run", "--task", "YARD-001", "--execute"]);
+            let channel = channel_dir(&fixture.root, "YARD-001");
+            let (action_id, escaped_paths) = if kind == "absolute" {
+                let base = fixture.root.join("escaped-absolute-action");
+                (
+                    base.display().to_string(),
+                    vec![
+                        PathBuf::from(format!("{}.prepared.yaml", base.display())),
+                        PathBuf::from(format!("{}.terminal.yaml", base.display())),
+                    ],
+                )
+            } else {
+                (
+                    "../escaped-parent-action".to_string(),
+                    vec![
+                        channel.join("escaped-parent-action.prepared.yaml"),
+                        channel.join("escaped-parent-action.terminal.yaml"),
+                    ],
+                )
+            };
+
+            let output = command(
+                &fixture.root,
+                &fixture.binary,
+                &[
+                    "answer",
+                    "A",
+                    "--task",
+                    "YARD-001",
+                    "--action-id",
+                    &action_id,
+                ],
+            );
+            assert!(
+                !output.status.success(),
+                "unsafe {kind} action id unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                String::from_utf8_lossy(&output.stderr).contains("invalid action id"),
+                "unsafe {kind} action id did not fail at validation: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(
+                escaped_paths.iter().all(|path| !path.exists()),
+                "unsafe {kind} action id created a receipt outside actions/: {escaped_paths:?}"
+            );
+            assert!(
+                yaml_dir(&channel.join("actions")).is_empty(),
+                "unsafe {kind} action id created a channel action receipt"
+            );
+        }
+    }
+
+    #[test]
+    fn redirect_ignores_decoy_pid_and_signals_verified_worker() {
+        let fixture = FixtureWorkspace::new("redirect-worker-provenance");
+        fixture.write_queue(
+            "  - id: YARD-REDIRECT\n    title: redirect verifies worker provenance\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+
+        let mut running = Command::new(&fixture.binary)
+            .args(["run", "--task", "YARD-REDIRECT", "--execute"])
+            .current_dir(&fixture.root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let started = wait_until(Duration::from_secs(10), || {
+            task_state(&fixture.root, "YARD-REDIRECT") == "running"
+                && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
+        });
+        if !started {
+            let _ = running.kill();
+            let output = running.wait_with_output().unwrap();
+            panic!(
+                "redirect provenance fixture never reached running\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let pid_path = files_below(&fixture.root.join(".agents/runs"), "/worker.pid")
+            .into_iter()
+            .next()
+            .unwrap();
+        let worker_pid: u32 = fs::read_to_string(&pid_path)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let run_dir = pid_path.parent().unwrap();
+        let provenance_path = run_dir.join("worker-process.yaml");
+        let provenance = read_yaml(&provenance_path);
+        assert_eq!(
+            fs::metadata(&provenance_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(number(&provenance, "pid"), u64::from(worker_pid));
+        assert_eq!(string(&provenance, "worker_id"), "fixture");
+        assert_eq!(
+            string(&provenance, "run_id"),
+            run_dir.file_name().unwrap().to_str().unwrap()
+        );
+        assert_eq!(
+            string(&provenance, "attempt_id"),
+            fs::read_to_string(run_dir.join("latest-attempt"))
+                .unwrap()
+                .trim()
+        );
+        assert!(!string(&provenance, "process_start_marker").is_empty());
+
+        let unsafe_redirect = command(
+            &fixture.root,
+            &fixture.binary,
+            &[
+                "redirect",
+                "YARD-REDIRECT",
+                "this guidance must not stop the worker",
+                "--action-id",
+                "../escaped-redirect-action",
+            ],
+        );
+        assert!(!unsafe_redirect.status.success());
+        assert!(String::from_utf8_lossy(&unsafe_redirect.stderr).contains("invalid action id"));
+        assert!(
+            process_is_alive(worker_pid),
+            "invalid redirect action id stopped the worker before validation"
+        );
+        assert!(!run_dir.join("cancelled").exists());
+
+        let mut decoy = Command::new("sleep").arg("60").spawn().unwrap();
+        let decoy_pid = decoy.id();
+        fs::write(&pid_path, decoy_pid.to_string()).unwrap();
+
+        let redirect = command(
+            &fixture.root,
+            &fixture.binary,
+            &[
+                "redirect",
+                "YARD-REDIRECT",
+                "finish with verified worker guidance",
+                "--reason",
+                "verify run-owned worker provenance",
+                "--action-id",
+                "act-verified-worker-redirect",
+            ],
+        );
+        let worker_was_still_alive = process_is_alive(worker_pid);
+        let decoy_survived = decoy.try_wait().unwrap().is_none();
+
+        if worker_was_still_alive {
+            let _ = Command::new("kill").arg(worker_pid.to_string()).status();
+        }
+        let original = running.wait_with_output().unwrap();
+        if decoy_survived {
+            let _ = decoy.kill();
+        }
+        let _ = decoy.wait();
+
+        assert!(
+            redirect.status.success(),
+            "redirect failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&redirect.stdout),
+            String::from_utf8_lossy(&redirect.stderr)
+        );
+        assert!(
+            original.status.success(),
+            "original yardlet run failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&original.stdout),
+            String::from_utf8_lossy(&original.stderr)
+        );
+        assert!(!worker_was_still_alive, "verified worker was not stopped");
+        assert!(decoy_survived, "redirect signalled the decoy process");
+        assert_eq!(task_state(&fixture.root, "YARD-REDIRECT"), "done");
     }
 
     #[test]

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -1,0 +1,159 @@
+#[cfg(unix)]
+mod unix {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Output};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn command(root: &Path, program: &Path, args: &[&str]) -> Output {
+        Command::new(program)
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()))
+    }
+
+    fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+        let output = command(root, program, args);
+        assert!(
+            output.status.success(),
+            "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            program.display(),
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn files_below(root: &Path, suffix: &str) -> Vec<PathBuf> {
+        fn walk(path: &Path, suffix: &str, out: &mut Vec<PathBuf>) {
+            let Ok(entries) = fs::read_dir(path) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, suffix, out);
+                } else if path.to_string_lossy().ends_with(suffix) {
+                    out.push(path);
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(root, suffix, &mut out);
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn text_worker_answer_creates_a_new_attempt_and_preserves_both_raw_streams() {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "yardlet-v010-003-process-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+
+        must_succeed(&root, Path::new("git"), &["init", "-q"]);
+        must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["config", "user.email", "fixture@example.invalid"],
+        );
+        fs::write(root.join("README.md"), "fixture\n").unwrap();
+        must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+        must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+        must_succeed(&root, &binary, &["init"]);
+
+        let worker = root.join("fixture-worker.sh");
+        fs::copy(
+            manifest.join("tests/fixtures/v010_003_task_channels/worker.sh"),
+            &worker,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&worker).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&worker, permissions).unwrap();
+        fs::write(
+            root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                worker.display()
+            ),
+        )
+        .unwrap();
+        fs::write(
+            root.join(".agents/intent-contract.yaml"),
+            "schema_version: 1\nid: intent-channel-process\nsummary: durable channel fixture\nstatus: accepted\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join(".agents/work-queue.yaml"),
+            "schema_version: 1\nqueue_id: queue-channel-process\nintent_id: intent-channel-process\ntasks:\n  - id: YARD-001\n    title: text worker asks then completes\n    state: queued\n    priority: 10\n    preferred_worker: fixture\n",
+        )
+        .unwrap();
+
+        must_succeed(&root, &binary, &["run", "--task", "YARD-001", "--execute"]);
+        let first_stdout = files_below(&root.join(".agents/runs"), "/stdout.log");
+        let first_stderr = files_below(&root.join(".agents/runs"), "/stderr.log");
+        assert_eq!(first_stdout.len(), 1);
+        assert_eq!(first_stderr.len(), 1);
+        assert_eq!(
+            fs::read_to_string(&first_stdout[0]).unwrap(),
+            "fixture first stdout\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&first_stderr[0]).unwrap(),
+            "fixture first stderr\n"
+        );
+
+        must_succeed(
+            &root,
+            &binary,
+            &[
+                "answer",
+                "A",
+                "--task",
+                "YARD-001",
+                "--action-id",
+                "act-fixture-answer",
+            ],
+        );
+
+        let channels = root.join(".agents/task-channels");
+        assert_eq!(files_below(&channels, ".terminal.yaml").len(), 1);
+        let attempts = files_below(&channels, ".yaml")
+            .into_iter()
+            .filter(|path| path.to_string_lossy().contains("/attempts/"))
+            .collect::<Vec<_>>();
+        assert_eq!(attempts.len(), 2);
+        let answers = files_below(&channels, ".yaml")
+            .into_iter()
+            .filter(|path| path.to_string_lossy().contains("/answers/"))
+            .collect::<Vec<_>>();
+        assert_eq!(answers.len(), 1);
+        assert_eq!(
+            fs::read_to_string(&first_stdout[0]).unwrap(),
+            "fixture first stdout\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&first_stderr[0]).unwrap(),
+            "fixture first stderr\n"
+        );
+        let packets = files_below(&root.join(".agents/runs"), "/task-packet.md");
+        assert!(packets.iter().any(|path| {
+            fs::read_to_string(path).is_ok_and(|text| text.contains("Explicit continuation packet"))
+        }));
+        must_succeed(&root, &binary, &["queue"]);
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+}

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -4,8 +4,8 @@ mod unix {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
-    use std::process::{Command, Output};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::process::{Command, Output, Stdio};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     struct FixtureWorkspace {
         root: PathBuf,
@@ -58,8 +58,8 @@ mod unix {
             fs::write(
                 root.join(".agents/workers.yaml"),
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
-                    worker.display()
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-ask\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: codex\n    invocation:\n      command: {0}\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    worker.display(),
                 ),
             )
             .unwrap();
@@ -153,6 +153,12 @@ mod unix {
             .unwrap_or_else(|| panic!("missing string key {key}: {value:?}"))
     }
 
+    fn number(value: &Value, key: &str) -> u64 {
+        value[key]
+            .as_u64()
+            .unwrap_or_else(|| panic!("missing integer key {key}: {value:?}"))
+    }
+
     fn channel_dir(root: &Path, task_id: &str) -> PathBuf {
         fs::read_dir(root.join(".agents/task-channels"))
             .unwrap()
@@ -186,6 +192,37 @@ mod unix {
                 })
             })
             .collect()
+    }
+
+    fn task_state(root: &Path, task_id: &str) -> String {
+        let queue = read_yaml(&root.join(".agents/work-queue.yaml"));
+        queue["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| string(task, "id") == task_id)
+            .map(|task| string(task, "state").to_string())
+            .unwrap_or_else(|| panic!("task {task_id} not found"))
+    }
+
+    fn action_attempt_id(action_id: &str) -> String {
+        let mut hash = 0xcbf29ce484222325_u64;
+        for byte in action_id.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        format!("att-action-{hash:016x}")
+    }
+
+    fn wait_until(timeout: Duration, mut predicate: impl FnMut() -> bool) -> bool {
+        let started = Instant::now();
+        while started.elapsed() < timeout {
+            if predicate() {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        false
     }
 
     #[test]
@@ -281,6 +318,47 @@ mod unix {
             .filter(|path| path.to_string_lossy().contains("/answers/"))
             .collect::<Vec<_>>();
         assert_eq!(answers.len(), 1);
+        let channel = channel_dir(&root, "YARD-001");
+        let channel_attempts = yaml_dir(&channel.join("attempts"));
+        let first_attempt = channel_attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "fresh")
+            .unwrap();
+        let continued_attempt = channel_attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "explicit_packet")
+            .unwrap();
+        assert_eq!(string(first_attempt, "worker_id"), "fixture");
+        assert_eq!(string(continued_attempt, "worker_id"), "fixture");
+        assert!(first_attempt["worker_session_ref"].is_null());
+        assert!(continued_attempt["worker_session_ref"].is_null());
+
+        let questions = yaml_dir(&channel.join("questions"));
+        assert_eq!(questions.len(), 1);
+        let events = yaml_dir(&channel.join("events"));
+        let asked = events
+            .iter()
+            .find(|event| string(event, "event_type") == "question.asked")
+            .unwrap();
+        assert_eq!(
+            string(&questions[0], "asked_event_id"),
+            string(asked, "event_id")
+        );
+        assert_eq!(number(&questions[0], "asked_seq"), number(asked, "seq"));
+        assert_eq!(
+            string(continued_attempt, "caused_by_event_id"),
+            string(
+                events
+                    .iter()
+                    .find(|event| string(event, "event_type") == "user.answered")
+                    .unwrap(),
+                "event_id",
+            )
+        );
+        assert_eq!(
+            string(continued_attempt, "caused_by_action_id"),
+            "act-fixture-answer"
+        );
         assert_eq!(
             fs::read_to_string(&first_stdout[0]).unwrap(),
             "fixture first stdout\n"
@@ -302,22 +380,315 @@ mod unix {
     fn parallel_independent_task_records_validation_completion() {
         let fixture = FixtureWorkspace::new("parallel-validation");
         fixture.write_queue(
-            "  - id: YARD-ASK\n    title: ask in parallel\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n  - id: YARD-DRAIN\n    title: independent validated drain\n    state: queued\n    priority: 20\n    kind: implementation\n    preferred_worker: fixture\n    validation:\n      required: true\n      commands: [\"test -f drain-artifact.txt\"]\n",
+            "  - id: YARD-ASK\n    title: ask in parallel\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture-ask\n  - id: YARD-DRAIN\n    title: independent validated drain\n    state: queued\n    priority: 20\n    kind: implementation\n    preferred_worker: fixture-drain\n    validation:\n      required: true\n      commands: [\"test -f drain-artifact.txt\"]\n",
         );
 
         let output = fixture.run(&["run", "--auto", "--parallel", "2"]);
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            stdout.contains("parallel batch: YARD-ASK via fixture, YARD-DRAIN via fixture"),
+            stdout
+                .contains("parallel batch: YARD-ASK via fixture-ask, YARD-DRAIN via fixture-drain"),
             "configured validation removed YARD-DRAIN from the parallel batch:\n{stdout}"
         );
+        assert_eq!(task_state(&fixture.root, "YARD-ASK"), "needs_user");
+        assert_eq!(task_state(&fixture.root, "YARD-DRAIN"), "done");
+
+        let ask_channel = channel_dir(&fixture.root, "YARD-ASK");
         let drain_channel = channel_dir(&fixture.root, "YARD-DRAIN");
-        assert!(
-            yaml_dir(&drain_channel.join("events"))
-                .iter()
-                .any(|event| string(event, "event_type") == "validation.completed"),
-            "independent validated task has no validation.completed event"
+        let ask_attempts = yaml_dir(&ask_channel.join("attempts"));
+        let drain_attempts = yaml_dir(&drain_channel.join("attempts"));
+        assert_eq!(ask_attempts.len(), 1);
+        assert_eq!(drain_attempts.len(), 1);
+        assert_eq!(string(&ask_attempts[0], "worker_id"), "fixture-ask");
+        assert_eq!(string(&drain_attempts[0], "worker_id"), "fixture-drain");
+
+        let drain_events = yaml_dir(&drain_channel.join("events"));
+        for event_type in [
+            "worker.started",
+            "validation.started",
+            "validation.completed",
+            "completion.recorded",
+        ] {
+            assert!(
+                drain_events
+                    .iter()
+                    .any(|event| string(event, "event_type") == event_type),
+                "independent validated task has no {event_type} event"
+            );
+        }
+
+        let questions = yaml_dir(&ask_channel.join("questions"));
+        assert_eq!(questions.len(), 1);
+        let ask_events = yaml_dir(&ask_channel.join("events"));
+        let asked = ask_events
+            .iter()
+            .find(|event| string(event, "event_type") == "question.asked")
+            .unwrap();
+        assert_eq!(
+            string(&questions[0], "asked_event_id"),
+            string(asked, "event_id")
         );
+        assert_eq!(number(&questions[0], "asked_seq"), number(asked, "seq"));
+        assert!(number(&questions[0], "context_start_seq") <= number(asked, "seq"));
+        assert!(ask_events.iter().any(|event| {
+            number(event, "seq") >= number(&questions[0], "context_start_seq")
+                && number(event, "seq") < number(asked, "seq")
+                && event["payload"]["text"] == "ask worker public context before question"
+        }));
+
+        for path in attempt_paths(&fixture.root, &ask_channel) {
+            let raw = fs::read_to_string(path).unwrap();
+            assert!(raw.contains("ask worker"));
+            assert!(!raw.contains("drain worker"));
+        }
+        for path in attempt_paths(&fixture.root, &drain_channel) {
+            let raw = fs::read_to_string(path).unwrap();
+            assert!(raw.contains("drain worker"));
+            assert!(!raw.contains("ask worker"));
+        }
+
+        fixture.run(&["queue"]);
+        let restarted = channel_dir(&fixture.root, "YARD-ASK");
+        let restored_question = yaml_dir(&restarted.join("questions"));
+        assert_eq!(restored_question, questions);
+    }
+
+    #[test]
+    fn native_resume_preserves_session_ref_and_answer_causality() {
+        let fixture = FixtureWorkspace::new("native-resume");
+        fixture.write_queue(
+            "  - id: YARD-NATIVE\n    title: native worker asks then resumes\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-NATIVE", "--execute"]);
+        assert_eq!(task_state(&fixture.root, "YARD-NATIVE"), "needs_user");
+        fixture.run(&[
+            "answer",
+            "native answer",
+            "--task",
+            "YARD-NATIVE",
+            "--action-id",
+            "act-native-answer",
+        ]);
+
+        let channel = channel_dir(&fixture.root, "YARD-NATIVE");
+        let attempts = yaml_dir(&channel.join("attempts"));
+        assert_eq!(attempts.len(), 2);
+        let first = attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "fresh")
+            .unwrap();
+        let resumed = attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "native_resume")
+            .unwrap();
+        let session_ref = "11111111-1111-4111-8111-111111111111";
+        assert_eq!(string(first, "worker_id"), "codex");
+        assert!(first["worker_session_ref"].is_null());
+        assert_eq!(string(resumed, "worker_id"), "codex");
+        assert_eq!(string(resumed, "worker_session_ref"), session_ref);
+        assert_eq!(string(resumed, "caused_by_action_id"), "act-native-answer");
+
+        let events = yaml_dir(&channel.join("events"));
+        let answered = events
+            .iter()
+            .find(|event| string(event, "event_type") == "user.answered")
+            .unwrap();
+        let first_completed = events
+            .iter()
+            .find(|event| {
+                string(event, "event_type") == "worker.completed"
+                    && event["attempt_id"] == first["attempt_id"]
+            })
+            .unwrap();
+        assert_eq!(
+            string(&first_completed["payload"], "worker_session_ref"),
+            session_ref
+        );
+        assert_eq!(
+            string(resumed, "caused_by_event_id"),
+            string(answered, "event_id")
+        );
+        let invocation = files_below(&fixture.root.join(".agents/runs"), "/native-args.txt");
+        assert!(invocation.iter().any(|path| {
+            fs::read_to_string(path).is_ok_and(|args| {
+                args.contains("exec resume")
+                    && args.contains(session_ref)
+                    && args.trim().ends_with('-')
+            })
+        }));
+
+        let raw = attempt_paths(&fixture.root, &channel)
+            .into_iter()
+            .map(|path| fs::read_to_string(path).unwrap())
+            .collect::<Vec<_>>();
+        assert!(raw.iter().any(|text| text.contains("native first stdout")));
+        assert!(raw
+            .iter()
+            .any(|text| text.contains("native resumed stdout")));
+        assert_eq!(task_state(&fixture.root, "YARD-NATIVE"), "done");
+    }
+
+    #[test]
+    fn running_redirect_records_stop_checkpoint_guidance_and_restart_dedupe() {
+        let fixture = FixtureWorkspace::new("running-redirect");
+        fixture.write_queue(
+            "  - id: YARD-REDIRECT\n    title: running worker is redirected\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+
+        let mut running = Command::new(&fixture.binary)
+            .args(["run", "--task", "YARD-REDIRECT", "--execute"])
+            .current_dir(&fixture.root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let started = wait_until(Duration::from_secs(10), || {
+            task_state(&fixture.root, "YARD-REDIRECT") == "running"
+                && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
+        });
+        if !started {
+            let _ = running.kill();
+            let output = running.wait_with_output().unwrap();
+            panic!(
+                "redirect fixture never reached running\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        fixture.run(&[
+            "redirect",
+            "YARD-REDIRECT",
+            "finish with redirected guidance",
+            "--reason",
+            "scope changed during execution",
+            "--action-id",
+            "act-running-redirect",
+        ]);
+        let original = running.wait_with_output().unwrap();
+        assert!(original.status.success());
+
+        let channel = channel_dir(&fixture.root, "YARD-REDIRECT");
+        let attempts = yaml_dir(&channel.join("attempts"));
+        assert_eq!(attempts.len(), 2);
+        let redirected = attempts
+            .iter()
+            .find(|attempt| string(attempt, "continuation") == "redirect")
+            .unwrap();
+        assert_eq!(
+            string(redirected, "caused_by_action_id"),
+            "act-running-redirect"
+        );
+        let events = yaml_dir(&channel.join("events"));
+        let requested = events
+            .iter()
+            .find(|event| {
+                string(event, "event_type") == "action.requested"
+                    && event["payload"]["action"] == "redirect"
+            })
+            .unwrap();
+        assert_eq!(
+            requested["payload"]["reason"],
+            "scope changed during execution"
+        );
+        assert_eq!(
+            requested["payload"]["guidance"],
+            "finish with redirected guidance"
+        );
+        assert_eq!(requested["payload"]["observed_terminal_state"], "cancelled");
+        assert_eq!(requested["payload"]["live_message_delivered"], false);
+        let checkpoint = events
+            .iter()
+            .find(|event| string(event, "event_type") == "worker.checkpoint")
+            .unwrap();
+        assert_eq!(
+            string(redirected, "caused_by_event_id"),
+            string(checkpoint, "event_id")
+        );
+        assert_eq!(task_state(&fixture.root, "YARD-REDIRECT"), "done");
+
+        let before_restart = yaml_dir(&channel.join("attempts"));
+        let duplicate = command(
+            &fixture.root,
+            &fixture.binary,
+            &[
+                "redirect",
+                "YARD-REDIRECT",
+                "finish with redirected guidance",
+                "--reason",
+                "scope changed during execution",
+                "--action-id",
+                "act-running-redirect",
+            ],
+        );
+        assert!(!duplicate.status.success());
+        fixture.run(&["queue"]);
+        assert_eq!(yaml_dir(&channel.join("attempts")), before_restart);
+    }
+
+    #[test]
+    fn deleted_derived_index_rebuilds_from_canonical_facts_with_bounded_tail() {
+        let fixture = FixtureWorkspace::new("index-rebuild");
+        fixture.write_queue(
+            "  - id: YARD-INDEX\n    title: emit enough progress to compact the index\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-INDEX", "--execute"]);
+        let channel = channel_dir(&fixture.root, "YARD-INDEX");
+        let index_path = channel.join("index.yaml");
+        let before_events = files_below(&channel.join("events"), ".yaml")
+            .into_iter()
+            .map(|path| {
+                let bytes = fs::read(&path).unwrap();
+                (path, bytes)
+            })
+            .collect::<Vec<_>>();
+        assert!(before_events.len() > 128);
+        let first_raw = attempt_paths(&fixture.root, &channel)
+            .into_iter()
+            .map(|path| (path.clone(), fs::read(path).unwrap()))
+            .collect::<Vec<_>>();
+        fs::remove_file(&index_path).unwrap();
+
+        fixture.run(&[
+            "answer",
+            "A",
+            "--task",
+            "YARD-INDEX",
+            "--action-id",
+            "act-index-answer",
+        ]);
+        assert!(index_path.is_file());
+        for (path, bytes) in before_events {
+            assert_eq!(
+                fs::read(path).unwrap(),
+                bytes,
+                "canonical event was rewritten"
+            );
+        }
+        for (path, bytes) in first_raw {
+            assert_eq!(fs::read(path).unwrap(), bytes, "raw evidence was rewritten");
+        }
+
+        let rebuilt = read_yaml(&index_path);
+        let events = yaml_dir(&channel.join("events"));
+        assert_eq!(number(&rebuilt, "event_count") as usize, events.len());
+        assert_eq!(
+            number(&rebuilt, "highest_applied_seq"),
+            events
+                .iter()
+                .map(|event| number(event, "seq"))
+                .max()
+                .unwrap()
+        );
+        let tail = rebuilt["tail_events"].as_sequence().unwrap();
+        assert!(tail.len() <= 128);
+        assert_eq!(
+            number(&rebuilt, "retained_from_seq"),
+            number(tail.first().unwrap(), "seq")
+        );
+        assert_eq!(task_state(&fixture.root, "YARD-INDEX"), "done");
     }
 
     #[test]
@@ -350,6 +721,20 @@ mod unix {
                 relative.display()
             );
         }
+
+        let harness_probe = fixture.root.join(".agents/skills/fixture-probe/SKILL.md");
+        fs::create_dir_all(harness_probe.parent().unwrap()).unwrap();
+        fs::write(&harness_probe, "# tracked harness probe\n").unwrap();
+        let relative = harness_probe.strip_prefix(&fixture.root).unwrap();
+        let output = command(
+            &fixture.root,
+            Path::new("git"),
+            &["check-ignore", "--quiet", relative.to_str().unwrap()],
+        );
+        assert!(
+            !output.status.success(),
+            "allowed tracked harness path was over-ignored"
+        );
     }
 
     #[test]
@@ -376,5 +761,30 @@ mod unix {
                 path.display()
             );
         }
+
+        let action_id = "act-overwrite-regression";
+        let overwrite_path = channel
+            .join("attempts")
+            .join(action_attempt_id(action_id))
+            .join("stdout.log");
+        fs::create_dir_all(overwrite_path.parent().unwrap()).unwrap();
+        fs::write(&overwrite_path, b"do not overwrite\n").unwrap();
+        let output = command(
+            &fixture.root,
+            &fixture.binary,
+            &[
+                "answer",
+                "A",
+                "--task",
+                "YARD-001",
+                "--action-id",
+                action_id,
+            ],
+        );
+        assert!(!output.status.success());
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("attempt raw stream already exists")
+        );
+        assert_eq!(fs::read(&overwrite_path).unwrap(), b"do not overwrite\n");
     }
 }

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -1,10 +1,100 @@
 #[cfg(unix)]
 mod unix {
+    use serde_yaml_ng::Value;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Output};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct FixtureWorkspace {
+        root: PathBuf,
+        binary: PathBuf,
+    }
+
+    impl FixtureWorkspace {
+        fn new(label: &str) -> Self {
+            let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "yardlet-v010-003-{label}-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).unwrap();
+
+            must_succeed(&root, Path::new("git"), &["init", "-q"]);
+            must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+            must_succeed(
+                &root,
+                Path::new("git"),
+                &["config", "user.email", "fixture@example.invalid"],
+            );
+            fs::write(root.join("README.md"), "fixture\n").unwrap();
+            must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+            must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+            must_succeed(&root, &binary, &["init"]);
+            fs::copy(manifest.join(".gitignore"), root.join(".gitignore")).unwrap();
+            fs::write(
+                root.join(".agents/intent-contract.yaml"),
+                "schema_version: 1\nid: intent-channel-process\nsummary: durable channel fixture\nstatus: accepted\n",
+            )
+            .unwrap();
+
+            let fixture_bin = root.join(".agents/fixture-bin");
+            fs::create_dir_all(&fixture_bin).unwrap();
+            let worker = fixture_bin.join("worker.sh");
+            fs::copy(
+                manifest.join("tests/fixtures/v010_003_task_channels/worker.sh"),
+                &worker,
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&worker).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&worker, permissions).unwrap();
+            fs::write(
+                root.join(".agents/workers.yaml"),
+                format!(
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    worker.display()
+                ),
+            )
+            .unwrap();
+
+            Self { root, binary }
+        }
+
+        fn write_queue(&self, body: &str) {
+            fs::write(
+                self.root.join(".agents/work-queue.yaml"),
+                format!(
+                    "schema_version: 1\nqueue_id: queue-channel-process\nintent_id: intent-channel-process\ntasks:\n{body}"
+                ),
+            )
+            .unwrap();
+        }
+
+        fn run(&self, args: &[&str]) -> Output {
+            must_succeed(&self.root, &self.binary, args)
+        }
+
+        fn run_with_umask_022(&self, args: &[&str]) -> Output {
+            let mut shell_args = vec!["-c", "umask 022; exec \"$@\"", "fixture"];
+            let binary = self.binary.to_string_lossy().into_owned();
+            shell_args.push(&binary);
+            shell_args.extend_from_slice(args);
+            must_succeed(&self.root, Path::new("sh"), &shell_args)
+        }
+    }
+
+    impl Drop for FixtureWorkspace {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
 
     fn command(root: &Path, program: &Path, args: &[&str]) -> Output {
         Command::new(program)
@@ -45,6 +135,57 @@ mod unix {
         walk(root, suffix, &mut out);
         out.sort();
         out
+    }
+
+    fn read_yaml(path: &Path) -> Value {
+        serde_yaml_ng::from_str(&fs::read_to_string(path).unwrap())
+            .unwrap_or_else(|error| panic!("invalid fixture yaml {}: {error}", path.display()))
+    }
+
+    fn string<'a>(value: &'a Value, key: &str) -> &'a str {
+        let field = if key == "event_type" && value["event_type"].is_null() {
+            &value["type"]
+        } else {
+            &value[key]
+        };
+        field
+            .as_str()
+            .unwrap_or_else(|| panic!("missing string key {key}: {value:?}"))
+    }
+
+    fn channel_dir(root: &Path, task_id: &str) -> PathBuf {
+        fs::read_dir(root.join(".agents/task-channels"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.join("channel.yaml").is_file()
+                    && string(&read_yaml(&path.join("channel.yaml")), "task_id") == task_id
+            })
+            .unwrap_or_else(|| panic!("channel for {task_id} not found"))
+    }
+
+    fn yaml_dir(path: &Path) -> Vec<Value> {
+        files_below(path, ".yaml")
+            .iter()
+            .map(|path| read_yaml(path))
+            .collect()
+    }
+
+    fn attempt_paths(root: &Path, channel: &Path) -> Vec<PathBuf> {
+        yaml_dir(&channel.join("attempts"))
+            .into_iter()
+            .flat_map(|attempt| {
+                ["raw_stdout_ref", "raw_stderr_ref"].map(|key| {
+                    let path = PathBuf::from(string(&attempt, key));
+                    if path.is_absolute() {
+                        path
+                    } else {
+                        root.join(".agents").join(path)
+                    }
+                })
+            })
+            .collect()
     }
 
     #[test]
@@ -155,5 +296,85 @@ mod unix {
         must_succeed(&root, &binary, &["queue"]);
 
         fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn parallel_independent_task_records_validation_completion() {
+        let fixture = FixtureWorkspace::new("parallel-validation");
+        fixture.write_queue(
+            "  - id: YARD-ASK\n    title: ask in parallel\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n  - id: YARD-DRAIN\n    title: independent validated drain\n    state: queued\n    priority: 20\n    kind: implementation\n    preferred_worker: fixture\n    validation:\n      required: true\n      commands: [\"test -f drain-artifact.txt\"]\n",
+        );
+
+        let output = fixture.run(&["run", "--auto", "--parallel", "2"]);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("parallel batch: YARD-ASK via fixture, YARD-DRAIN via fixture"),
+            "configured validation removed YARD-DRAIN from the parallel batch:\n{stdout}"
+        );
+        let drain_channel = channel_dir(&fixture.root, "YARD-DRAIN");
+        assert!(
+            yaml_dir(&drain_channel.join("events"))
+                .iter()
+                .any(|event| string(event, "event_type") == "validation.completed"),
+            "independent validated task has no validation.completed event"
+        );
+    }
+
+    #[test]
+    fn task_channel_and_raw_evidence_are_git_ignored() {
+        let fixture = FixtureWorkspace::new("raw-ignore");
+        fixture.write_queue(
+            "  - id: YARD-001\n    title: raw ignore boundary\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+        fixture.run(&["run", "--task", "YARD-001", "--execute"]);
+
+        let channel = channel_dir(&fixture.root, "YARD-001");
+        let mut evidence_paths = vec![channel.join("channel.yaml")];
+        evidence_paths.extend(attempt_paths(&fixture.root, &channel));
+        evidence_paths.extend(files_below(
+            &fixture.root.join(".agents/runs"),
+            "/worker-output.log",
+        ));
+        let canonical_root = fs::canonicalize(&fixture.root).unwrap();
+        for path in evidence_paths {
+            let canonical = fs::canonicalize(&path).unwrap();
+            let relative = canonical.strip_prefix(&canonical_root).unwrap();
+            let output = command(
+                &fixture.root,
+                Path::new("git"),
+                &["check-ignore", "--quiet", relative.to_str().unwrap()],
+            );
+            assert!(
+                output.status.success(),
+                "{} is not ignored and can be staged accidentally",
+                relative.display()
+            );
+        }
+    }
+
+    #[test]
+    fn task_channel_raw_evidence_files_are_private() {
+        let fixture = FixtureWorkspace::new("raw-mode");
+        fixture.write_queue(
+            "  - id: YARD-001\n    title: raw mode boundary\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+        fixture.run_with_umask_022(&["run", "--task", "YARD-001", "--execute"]);
+
+        let channel = channel_dir(&fixture.root, "YARD-001");
+        let mut evidence_paths = attempt_paths(&fixture.root, &channel);
+        evidence_paths.extend(files_below(
+            &fixture.root.join(".agents/runs"),
+            "/worker-output.log",
+        ));
+        assert_eq!(evidence_paths.len(), 3, "expected stdout, stderr, combined");
+        for path in evidence_paths {
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode,
+                0o600,
+                "{} has mode {mode:o}; raw and combined evidence must be 600",
+                path.display()
+            );
+        }
     }
 }


### PR DESCRIPTION
## 무엇이 바뀌었나\n\n- queue task별 durable channel과 attempt provenance를 추가했습니다.\n- worker progress, raw evidence, 질문과 답변, redirect/continuation을 재시작 후에도 복구할 수 있게 했습니다.\n- answer와 redirect의 action receipt, 경로 안전성, process identity 검증을 강화했습니다.\n- 실제 process/concurrency/restart dogfood와 독립 리뷰 및 remediation 증거를 추가했습니다.\n\n## 왜 필요한가\n\n기존 단일 질문 mailbox는 실행 중인 worker의 맥락과 attempt causality를 충분히 보존하지 못했습니다. V010-003은 사용자가 작업을 관찰하고 답변하거나 redirect해도 다른 독립 작업과 재시작 복구가 정직하게 이어지도록 durable task channel 계약을 만듭니다.\n\n## 영향\n\nYardlet core가 task별 진행 상황과 대화를 canonical event/action 기록으로 관리합니다. raw evidence는 private runtime artifact로 유지되고, queue/state의 canonical write 경계는 그대로 보존됩니다.\n\n## 검증\n\n- V010-003 independent review와 제한 remediation 완료\n- cargo fmt --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test\n- 최종 통합 브랜치에서 전체 489 tests passed