### PR TITLE
feat: add runtime and artifact resources

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,8 @@ pub enum Command {
     Worker(WorkerArgs),
     /// Gather cheap deterministic local evidence.
     Inspect(InspectArgs),
+    /// Discover and operate on task-owned runtime resources and artifacts.
+    Resource(ResourceArgs),
     /// Compile a worker-specific task packet.
     Packet(PacketArgs),
     /// Prepare (and optionally execute) the next bounded task.
@@ -92,6 +94,61 @@ pub enum Command {
 pub struct HarnessArgs {
     #[command(subcommand)]
     cmd: HarnessCmd,
+}
+
+#[derive(Args)]
+pub struct ResourceArgs {
+    #[command(subcommand)]
+    cmd: ResourceCmd,
+}
+
+#[derive(Subcommand)]
+enum ResourceCmd {
+    /// Discover bounded artifacts and runtime resources for one task.
+    Discover {
+        #[arg(long)]
+        task: String,
+        #[arg(long)]
+        action_id: Option<String>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Inspect one canonical artifact or runtime resource.
+    Inspect(ResourceTargetArgs),
+    /// Return the surface-neutral viewer target for an entry.
+    Open(ResourceTargetArgs),
+    /// Return the surface-neutral attachment target for a live-capable entry.
+    Attach(ResourceTargetArgs),
+    /// Stop an owned resource after a fresh identity probe.
+    Stop(ResourceLifecycleArgs),
+    /// Restart an owned resource when a typed restart command exists.
+    Restart(ResourceLifecycleArgs),
+    /// Detach Yardlet without killing the target.
+    Detach(ResourceLifecycleArgs),
+    /// Clean up an owned resource after a fresh identity probe.
+    Cleanup(ResourceLifecycleArgs),
+    /// Probe and append a current observation.
+    Reconcile(ResourceLifecycleArgs),
+}
+
+#[derive(Args)]
+struct ResourceTargetArgs {
+    target: String,
+    #[arg(long)]
+    action_id: Option<String>,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args)]
+struct ResourceLifecycleArgs {
+    target: String,
+    #[arg(long)]
+    action_id: Option<String>,
+    #[arg(long)]
+    expected_status: Option<String>,
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Subcommand)]
@@ -532,6 +589,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Tidy) => cmd_tidy(&cwd),
         Some(Command::Worker(a)) => cmd_worker(&cwd, a),
         Some(Command::Inspect(a)) => cmd_inspect(&cwd, a),
+        Some(Command::Resource(a)) => cmd_resource(&cwd, a),
         Some(Command::Packet(a)) => cmd_packet(&cwd, a),
         Some(Command::Run(a)) => cmd_run(&cwd, a),
         Some(Command::Answer(a)) => cmd_answer(&cwd, a),
@@ -553,6 +611,120 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Skill(a)) => cmd_skill(&cwd, a),
         Some(Command::Harness(a)) => cmd_harness(&cwd, a),
     }
+}
+
+fn generated_resource_action_id(operation: crate::schemas::ResourceOperationKind) -> String {
+    format!(
+        "resource-{}-{}-{}",
+        format!("{operation:?}").to_lowercase(),
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    )
+}
+
+fn parse_resource_status(value: Option<String>) -> Result<Option<crate::schemas::ResourceStatus>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let status = match value.as_str() {
+        "unknown" => crate::schemas::ResourceStatus::Unknown,
+        "available" => crate::schemas::ResourceStatus::Available,
+        "live" => crate::schemas::ResourceStatus::Live,
+        "dead" => crate::schemas::ResourceStatus::Dead,
+        "unavailable" => crate::schemas::ResourceStatus::Unavailable,
+        "expired" => crate::schemas::ResourceStatus::Expired,
+        "orphaned" => crate::schemas::ResourceStatus::Orphaned,
+        "unrecoverable" => crate::schemas::ResourceStatus::Unrecoverable,
+        "detached" => crate::schemas::ResourceStatus::Detached,
+        _ => anyhow::bail!("unknown resource status '{value}'"),
+    };
+    Ok(Some(status))
+}
+
+fn cmd_resource(cwd: &std::path::Path, args: ResourceArgs) -> Result<()> {
+    use crate::schemas::{ResourceOperationKind as Op, ResourceOperationRequest};
+
+    let ws = init::ensure_initialized(cwd)?.0;
+    let (request, json) = match args.cmd {
+        ResourceCmd::Discover {
+            task,
+            action_id,
+            json,
+        } => (
+            ResourceOperationRequest {
+                action_id: action_id.unwrap_or_else(|| generated_resource_action_id(Op::Discover)),
+                operation: Op::Discover,
+                task_id: task,
+                target_id: String::new(),
+                expected_status: None,
+            },
+            json,
+        ),
+        ResourceCmd::Inspect(args) => resource_target_request(Op::Inspect, args),
+        ResourceCmd::Open(args) => resource_target_request(Op::Open, args),
+        ResourceCmd::Attach(args) => resource_target_request(Op::Attach, args),
+        ResourceCmd::Stop(args) => resource_lifecycle_request(Op::Stop, args)?,
+        ResourceCmd::Restart(args) => resource_lifecycle_request(Op::Restart, args)?,
+        ResourceCmd::Detach(args) => resource_lifecycle_request(Op::Detach, args)?,
+        ResourceCmd::Cleanup(args) => resource_lifecycle_request(Op::Cleanup, args)?,
+        ResourceCmd::Reconcile(args) => resource_lifecycle_request(Op::Reconcile, args)?,
+    };
+    let receipt = crate::resource::dispatch(&ws, request)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&receipt)?);
+    } else {
+        println!(
+            "{:?} {}: {:?}",
+            receipt.operation, receipt.action_id, receipt.status
+        );
+        if !receipt.error.is_empty() {
+            println!("  {}", receipt.error);
+        }
+        for entry in &receipt.result.entries {
+            println!("  {}", serde_json::to_string(entry)?);
+        }
+        if let Some(target) = &receipt.result.open_target {
+            println!("  target: {}", serde_json::to_string(target)?);
+        }
+    }
+    Ok(())
+}
+
+fn resource_target_request(
+    operation: crate::schemas::ResourceOperationKind,
+    args: ResourceTargetArgs,
+) -> (crate::schemas::ResourceOperationRequest, bool) {
+    (
+        crate::schemas::ResourceOperationRequest {
+            action_id: args
+                .action_id
+                .unwrap_or_else(|| generated_resource_action_id(operation)),
+            operation,
+            task_id: String::new(),
+            target_id: args.target,
+            expected_status: None,
+        },
+        args.json,
+    )
+}
+
+fn resource_lifecycle_request(
+    operation: crate::schemas::ResourceOperationKind,
+    args: ResourceLifecycleArgs,
+) -> Result<(crate::schemas::ResourceOperationRequest, bool)> {
+    let expected_status = parse_resource_status(args.expected_status)?;
+    Ok((
+        crate::schemas::ResourceOperationRequest {
+            action_id: args
+                .action_id
+                .unwrap_or_else(|| generated_resource_action_id(operation)),
+            operation,
+            task_id: String::new(),
+            target_id: args.target,
+            expected_status,
+        },
+        args.json,
+    ))
 }
 
 fn cmd_eval(args: EvalArgs) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -107,6 +107,8 @@ enum ResourceCmd {
     /// Discover bounded artifacts and runtime resources for one task.
     Discover {
         #[arg(long)]
+        intent: String,
+        #[arg(long)]
         task: String,
         #[arg(long)]
         action_id: Option<String>,
@@ -146,7 +148,7 @@ struct ResourceLifecycleArgs {
     #[arg(long)]
     action_id: Option<String>,
     #[arg(long)]
-    expected_status: Option<String>,
+    expected_status: String,
     #[arg(long)]
     json: bool,
 }
@@ -622,11 +624,8 @@ fn generated_resource_action_id(operation: crate::schemas::ResourceOperationKind
     )
 }
 
-fn parse_resource_status(value: Option<String>) -> Result<Option<crate::schemas::ResourceStatus>> {
-    let Some(value) = value else {
-        return Ok(None);
-    };
-    let status = match value.as_str() {
+fn parse_resource_status(value: &str) -> Result<crate::schemas::ResourceStatus> {
+    let status = match value {
         "unknown" => crate::schemas::ResourceStatus::Unknown,
         "available" => crate::schemas::ResourceStatus::Available,
         "live" => crate::schemas::ResourceStatus::Live,
@@ -638,7 +637,7 @@ fn parse_resource_status(value: Option<String>) -> Result<Option<crate::schemas:
         "detached" => crate::schemas::ResourceStatus::Detached,
         _ => anyhow::bail!("unknown resource status '{value}'"),
     };
-    Ok(Some(status))
+    Ok(status)
 }
 
 fn cmd_resource(cwd: &std::path::Path, args: ResourceArgs) -> Result<()> {
@@ -647,6 +646,7 @@ fn cmd_resource(cwd: &std::path::Path, args: ResourceArgs) -> Result<()> {
     let ws = init::ensure_initialized(cwd)?.0;
     let (request, json) = match args.cmd {
         ResourceCmd::Discover {
+            intent,
             task,
             action_id,
             json,
@@ -654,9 +654,10 @@ fn cmd_resource(cwd: &std::path::Path, args: ResourceArgs) -> Result<()> {
             ResourceOperationRequest {
                 action_id: action_id.unwrap_or_else(|| generated_resource_action_id(Op::Discover)),
                 operation: Op::Discover,
+                intent_id: intent,
                 task_id: task,
                 target_id: String::new(),
-                expected_status: None,
+                expected_status: crate::schemas::ResourceStatus::Unknown,
             },
             json,
         ),
@@ -700,9 +701,10 @@ fn resource_target_request(
                 .action_id
                 .unwrap_or_else(|| generated_resource_action_id(operation)),
             operation,
+            intent_id: String::new(),
             task_id: String::new(),
             target_id: args.target,
-            expected_status: None,
+            expected_status: crate::schemas::ResourceStatus::Unknown,
         },
         args.json,
     )
@@ -712,13 +714,14 @@ fn resource_lifecycle_request(
     operation: crate::schemas::ResourceOperationKind,
     args: ResourceLifecycleArgs,
 ) -> Result<(crate::schemas::ResourceOperationRequest, bool)> {
-    let expected_status = parse_resource_status(args.expected_status)?;
+    let expected_status = parse_resource_status(&args.expected_status)?;
     Ok((
         crate::schemas::ResourceOperationRequest {
             action_id: args
                 .action_id
                 .unwrap_or_else(|| generated_resource_action_id(operation)),
             operation,
+            intent_id: String::new(),
             task_id: String::new(),
             target_id: args.target,
             expected_status,

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -93,6 +93,24 @@ pub fn evaluate(
             r.task_id == task.id && r.run_id == run_id,
             format!("result ids match run {run_id} / task {}", task.id),
         ));
+        let exact_attempt_id = std::fs::read_to_string(run_dir.join("latest-attempt"))
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| run_id.to_string());
+        let resource_errors = r.resource_provenance_errors(&exact_attempt_id);
+        checks.push(check(
+            "resource_provenance_valid",
+            resource_errors.is_empty(),
+            if resource_errors.is_empty() {
+                format!("resource proposals link to exact attempt {exact_attempt_id}")
+            } else {
+                format!(
+                    "invalid resource proposal provenance: {}",
+                    resource_errors.join("; ")
+                )
+            },
+        ));
         checks.push(check(
             "no_uncontrolled_drift",
             !r.intent_adherence.drift_detected,
@@ -600,6 +618,8 @@ mod tests {
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         }
     }
 
@@ -1314,6 +1334,8 @@ exit 89
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         std::fs::write(
             dir.join("result.json"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod parallel;
 mod planner;
 mod planning;
 mod report;
+mod resource;
 mod review;
 mod routing;
 mod rubric;

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -7,15 +7,17 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::path::{Component, Path};
 use std::process::{Command, Stdio};
-use std::time::Duration;
+#[cfg(debug_assertions)]
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 
 use crate::schemas::{
-    Artifact, ResourceActionReceipt, ResourceActionResult, ResourceActionStatus,
-    ResourceCapability, ResourceEntry, ResourceObservation, ResourceOpenTarget,
-    ResourceOperationKind, ResourceOperationRequest, ResourceOwnership, ResourceStatus, RunResult,
-    RuntimeResource, RuntimeResourceTarget,
+    Artifact, ResourceActionReceipt, ResourceActionRecoveryPhase, ResourceActionRecoveryReceipt,
+    ResourceActionResult, ResourceActionStatus, ResourceCapability, ResourceEntry,
+    ResourceObservation, ResourceOpenTarget, ResourceOperationKind, ResourceOperationRequest,
+    ResourceOwnership, ResourceStatus, RunResult, RuntimeResource, RuntimeResourceTarget,
 };
 use crate::state::{validate_action_id, Workspace};
 
@@ -30,6 +32,57 @@ fn digest_bytes(bytes: &[u8]) -> String {
 
 fn request_digest(request: &ResourceOperationRequest) -> Result<String> {
     Ok(digest_bytes(&serde_json::to_vec(request)?))
+}
+
+#[cfg(debug_assertions)]
+static TEST_RESOURCE_FAULT_FIRED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(debug_assertions)]
+fn test_resource_fault(action_id: &str, point: &str) -> Result<()> {
+    let expected = format!("{action_id}:{point}");
+    if std::env::var("YARDLET_TEST_RESOURCE_ACTION_FAULT")
+        .ok()
+        .as_deref()
+        != Some(expected.as_str())
+    {
+        return Ok(());
+    }
+    if point.starts_with("after_") {
+        if point == "after_spawn_before_recovery" {
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        std::process::exit(86);
+    }
+    if !TEST_RESOURCE_FAULT_FIRED.swap(true, Ordering::SeqCst) {
+        bail!("injected {point} failure");
+    }
+    Ok(())
+}
+
+#[cfg(debug_assertions)]
+fn test_resource_spawn_gap_fault(action_id: &str, pid: u32) -> Result<()> {
+    let point = "after_spawn_before_recovery";
+    let expected = format!("{action_id}:{point}");
+    if std::env::var("YARDLET_TEST_RESOURCE_ACTION_FAULT")
+        .ok()
+        .as_deref()
+        == Some(expected.as_str())
+    {
+        if let Ok(path) = std::env::var("YARDLET_TEST_RESOURCE_ACTION_TRACE") {
+            std::fs::write(path, format!("{pid}\n"))?;
+        }
+    }
+    test_resource_fault(action_id, point)
+}
+
+#[cfg(not(debug_assertions))]
+fn test_resource_spawn_gap_fault(_action_id: &str, _pid: u32) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(not(debug_assertions))]
+fn test_resource_fault(_action_id: &str, _point: &str) -> Result<()> {
+    Ok(())
 }
 
 fn safe_relative_path(path: &Path) -> bool {
@@ -225,17 +278,20 @@ fn effective_process(ws: &Workspace, resource: &RuntimeResource) -> Result<Optio
     if let Some(observation) = ws
         .load_resource_observations(&resource.resource_id)?
         .into_iter()
-        .rev()
-        .find(|observation| {
-            observation.status == ResourceStatus::Live
-                && observation.pid.is_some()
-                && !observation.start_identity.is_empty()
-        })
+        .last()
     {
-        return Ok(Some((
-            observation.pid.expect("filtered observation pid"),
-            observation.start_identity,
-        )));
+        if observation.status != ResourceStatus::Orphaned
+            && observation.pid.is_some()
+            && !observation.start_identity.is_empty()
+        {
+            return Ok(Some((
+                observation.pid.expect("checked observation pid"),
+                observation.start_identity,
+            )));
+        }
+        if observation.status == ResourceStatus::Unrecoverable {
+            return Ok(None);
+        }
     }
     Ok(match &resource.target {
         RuntimeResourceTarget::Terminal {
@@ -375,6 +431,59 @@ fn browser_session_attested(body: &str, session_id: &str) -> bool {
         == Some(session_id)
 }
 
+fn probe_service_semantics(
+    url: &str,
+    health_url: &str,
+    observed_pid: Option<u32>,
+    start_identity: String,
+) -> Probe {
+    if health_url.trim().is_empty() {
+        let Some(address) = url_socket(url) else {
+            return Probe {
+                status: ResourceStatus::Unrecoverable,
+                pid: observed_pid,
+                start_identity,
+                detail: "service URL cannot be parsed for a local probe".to_string(),
+            };
+        };
+        let reachable = TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok();
+        return Probe {
+            status: if reachable {
+                ResourceStatus::Unknown
+            } else {
+                ResourceStatus::Unavailable
+            },
+            pid: observed_pid,
+            start_identity,
+            detail: if reachable {
+                format!(
+                    "service port {address} is reachable but no semantic health_url was declared"
+                )
+            } else {
+                format!("service socket probe could not reach {address}")
+            },
+        };
+    }
+    let (status, detail) = match probe_http(health_url) {
+        HttpProbe::Response { status, .. } if (200..300).contains(&status) => (
+            ResourceStatus::Live,
+            format!("declared health URL returned HTTP {status}"),
+        ),
+        HttpProbe::Response { status, .. } => (
+            ResourceStatus::Unavailable,
+            format!("declared health URL returned HTTP {status}"),
+        ),
+        HttpProbe::Unavailable(detail) => (ResourceStatus::Unavailable, detail),
+        HttpProbe::Unrecoverable(detail) => (ResourceStatus::Unrecoverable, detail),
+    };
+    Probe {
+        status,
+        pid: observed_pid,
+        start_identity,
+        detail,
+    }
+}
+
 fn probe_resource(ws: &Workspace, resource: &RuntimeResource) -> Result<Probe> {
     match &resource.target {
         RuntimeResourceTarget::Terminal { .. } | RuntimeResourceTarget::Process { .. } => {
@@ -400,52 +509,12 @@ fn probe_resource(ws: &Workspace, resource: &RuntimeResource) -> Result<Probe> {
             let (observed_pid, start_identity) = process
                 .map(|(pid, identity)| (Some(pid), identity))
                 .unwrap_or_default();
-            if health_url.trim().is_empty() {
-                let Some(address) = url_socket(url) else {
-                    return Ok(Probe {
-                        status: ResourceStatus::Unrecoverable,
-                        pid: observed_pid,
-                        start_identity,
-                        detail: "service URL cannot be parsed for a local probe".to_string(),
-                    });
-                };
-                let reachable =
-                    TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok();
-                return Ok(Probe {
-                    status: if reachable {
-                        ResourceStatus::Unknown
-                    } else {
-                        ResourceStatus::Unavailable
-                    },
-                    pid: observed_pid,
-                    start_identity,
-                    detail: if reachable {
-                        format!(
-                            "service port {address} is reachable but no semantic health_url was declared"
-                        )
-                    } else {
-                        format!("service socket probe could not reach {address}")
-                    },
-                });
-            }
-            let (status, detail) = match probe_http(health_url) {
-                HttpProbe::Response { status, .. } if (200..300).contains(&status) => (
-                    ResourceStatus::Live,
-                    format!("declared health URL returned HTTP {status}"),
-                ),
-                HttpProbe::Response { status, .. } => (
-                    ResourceStatus::Unavailable,
-                    format!("declared health URL returned HTTP {status}"),
-                ),
-                HttpProbe::Unavailable(detail) => (ResourceStatus::Unavailable, detail),
-                HttpProbe::Unrecoverable(detail) => (ResourceStatus::Unrecoverable, detail),
-            };
-            Ok(Probe {
-                status,
-                pid: observed_pid,
+            Ok(probe_service_semantics(
+                url,
+                health_url,
+                observed_pid,
                 start_identity,
-                detail,
-            })
+            ))
         }
         RuntimeResourceTarget::Browser {
             session_id,
@@ -579,6 +648,74 @@ fn persist_probe(
     )
 }
 
+fn save_recovery_phase(
+    ws: &Workspace,
+    recovery: &mut ResourceActionRecoveryReceipt,
+    phase: ResourceActionRecoveryPhase,
+    pid: Option<u32>,
+    start_identity: String,
+) -> Result<()> {
+    recovery.phase = phase;
+    recovery.effect_pid = pid;
+    recovery.effect_start_identity = start_identity;
+    ws.save_resource_action_recovery(recovery)
+}
+
+fn probe_restarted_resource(
+    resource: &RuntimeResource,
+    pid: u32,
+    expected_identity: &str,
+) -> Probe {
+    let deadline = Instant::now() + Duration::from_secs(1);
+    loop {
+        let mut process = probe_process(pid, expected_identity);
+        if process.status != ResourceStatus::Live {
+            process.status = match process.status {
+                ResourceStatus::Dead => ResourceStatus::Unavailable,
+                ResourceStatus::Orphaned => ResourceStatus::Unrecoverable,
+                status => status,
+            };
+            process.detail = "restarted process is not live with its recorded identity".to_string();
+            return process;
+        }
+        let probe = match &resource.target {
+            RuntimeResourceTarget::Process { .. } => {
+                process.detail =
+                    "restart command spawned a process with a verified identity".to_string();
+                process
+            }
+            RuntimeResourceTarget::Service {
+                url, health_url, ..
+            } => probe_service_semantics(url, health_url, Some(pid), process.start_identity),
+            _ => Probe {
+                status: ResourceStatus::Unrecoverable,
+                pid: Some(pid),
+                start_identity: process.start_identity,
+                detail: "resource kind has no restart probe contract".to_string(),
+            },
+        };
+        let endpoint_responded = probe
+            .detail
+            .starts_with("declared health URL returned HTTP");
+        if probe.status != ResourceStatus::Unavailable
+            || endpoint_responded
+            || Instant::now() >= deadline
+        {
+            return probe;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn destructive_process_probe(resource: &RuntimeResource, observed: &Probe) -> Probe {
+    match (&resource.target, observed.pid) {
+        (RuntimeResourceTarget::Service { pid: Some(_), .. }, Some(pid)) => {
+            probe_process(pid, &observed.start_identity)
+        }
+        _ => observed.clone(),
+    }
+}
+
 fn lifecycle_result(
     ws: &Workspace,
     resource: &RuntimeResource,
@@ -586,9 +723,149 @@ fn lifecycle_result(
     expected_status: ResourceStatus,
     requested_event: &str,
     action_id: &str,
+    recovery: &mut ResourceActionRecoveryReceipt,
+    recovery_loaded: bool,
 ) -> Result<(ResourceActionStatus, ResourceActionResult, String)> {
+    if operation == ResourceOperationKind::Restart
+        && recovery.phase == ResourceActionRecoveryPhase::Spawned
+    {
+        test_resource_fault(action_id, "probe")?;
+        let pid = recovery
+            .effect_pid
+            .ok_or_else(|| anyhow!("spawn recovery is missing its pid"))?;
+        if recovery.effect_start_identity.is_empty() {
+            let identity = process_identity(pid)
+                .ok_or_else(|| anyhow!("spawned process disappeared before identity recovery"))?;
+            save_recovery_phase(
+                ws,
+                recovery,
+                ResourceActionRecoveryPhase::Spawned,
+                Some(pid),
+                identity,
+            )?;
+        }
+        let restarted = probe_restarted_resource(resource, pid, &recovery.effect_start_identity);
+        let observation = persist_probe(ws, resource, &restarted, requested_event, action_id)?;
+        let status = if restarted.status == ResourceStatus::Live {
+            ResourceActionStatus::Completed
+        } else {
+            ResourceActionStatus::Rejected
+        };
+        let error = if status == ResourceActionStatus::Completed {
+            String::new()
+        } else {
+            format!(
+                "restarted resource failed its current liveness gate: {}",
+                restarted.detail
+            )
+        };
+        return Ok((
+            status,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            error,
+        ));
+    }
+
+    if matches!(
+        operation,
+        ResourceOperationKind::Stop | ResourceOperationKind::Cleanup
+    ) && recovery.phase == ResourceActionRecoveryPhase::Terminated
+    {
+        let stopped = Probe {
+            status: ResourceStatus::Dead,
+            pid: recovery.effect_pid,
+            start_identity: recovery.effect_start_identity.clone(),
+            detail: "recovered durable termination effect without signalling again".to_string(),
+        };
+        let observation = persist_probe(ws, resource, &stopped, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Completed,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            String::new(),
+        ));
+    }
+
+    if operation == ResourceOperationKind::Restart
+        && recovery_loaded
+        && recovery.phase == ResourceActionRecoveryPhase::Terminated
+    {
+        let probe = Probe {
+            status: ResourceStatus::Unrecoverable,
+            pid: None,
+            start_identity: String::new(),
+            detail: "restart may have spawned a child before recovery identity was persisted"
+                .to_string(),
+        };
+        let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Rejected,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            "terminated restart recovery is ambiguous; refusing to spawn without a durably recorded child identity"
+                .to_string(),
+        ));
+    }
+
+    test_resource_fault(action_id, "probe")?;
     let probe = probe_resource(ws, resource)?;
-    if probe.status != expected_status {
+    if recovery_loaded
+        && recovery.phase == ResourceActionRecoveryPhase::Prepared
+        && matches!(
+            operation,
+            ResourceOperationKind::Stop
+                | ResourceOperationKind::Restart
+                | ResourceOperationKind::Cleanup
+        )
+        && owned_for_destructive_action(resource.ownership)
+    {
+        let mutation_probe = destructive_process_probe(resource, &probe);
+        if matches!(
+            operation,
+            ResourceOperationKind::Stop | ResourceOperationKind::Cleanup
+        ) && mutation_probe.status == ResourceStatus::Dead
+        {
+            save_recovery_phase(
+                ws,
+                recovery,
+                ResourceActionRecoveryPhase::Terminated,
+                mutation_probe.pid,
+                mutation_probe.start_identity.clone(),
+            )?;
+            let stopped = Probe {
+                detail: "recovered a prepared action by observing the exact process already dead"
+                    .to_string(),
+                ..mutation_probe
+            };
+            let observation = persist_probe(ws, resource, &stopped, requested_event, action_id)?;
+            return Ok((
+                ResourceActionStatus::Completed,
+                ResourceActionResult {
+                    observation: Some(observation),
+                    ..Default::default()
+                },
+                String::new(),
+            ));
+        }
+        let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Rejected,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            "prepared action recovery is ambiguous; refusing to repeat a destructive side effect"
+                .to_string(),
+        ));
+    }
+    if recovery.phase == ResourceActionRecoveryPhase::Prepared && probe.status != expected_status {
         let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
         return Ok((
             ResourceActionStatus::Rejected,
@@ -657,12 +934,14 @@ fn lifecycle_result(
             "process identity mismatch; refusing to signal the pid".to_string(),
         ));
     }
+    let mutation_probe = destructive_process_probe(resource, &probe);
 
     match operation {
         ResourceOperationKind::Stop | ResourceOperationKind::Cleanup => {
-            if probe.status == ResourceStatus::Live {
-                terminate_exact_process(&probe)?;
-            } else if probe.status != ResourceStatus::Dead {
+            if mutation_probe.status == ResourceStatus::Live {
+                test_resource_fault(action_id, "terminate")?;
+                terminate_exact_process(&mutation_probe)?;
+            } else if mutation_probe.status != ResourceStatus::Dead {
                 let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
                 return Ok((
                     ResourceActionStatus::Rejected,
@@ -676,6 +955,14 @@ fn lifecycle_result(
                     ),
                 ));
             }
+            save_recovery_phase(
+                ws,
+                recovery,
+                ResourceActionRecoveryPhase::Terminated,
+                mutation_probe.pid,
+                mutation_probe.start_identity.clone(),
+            )?;
+            test_resource_fault(action_id, "after_terminate")?;
             let stopped = Probe {
                 status: ResourceStatus::Dead,
                 detail: if operation == ResourceOperationKind::Cleanup {
@@ -683,7 +970,7 @@ fn lifecycle_result(
                 } else {
                     "owned resource stop confirmed process dead".to_string()
                 },
-                ..probe
+                ..mutation_probe
             };
             let observation = persist_probe(ws, resource, &stopped, requested_event, action_id)?;
             Ok((
@@ -708,19 +995,33 @@ fn lifecycle_result(
                     "resource has no typed restart command".to_string(),
                 ));
             }
-            if probe.status == ResourceStatus::Live {
-                terminate_exact_process(&probe)?;
-            } else if probe.status != ResourceStatus::Dead {
-                let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
-                return Ok((
-                    ResourceActionStatus::Rejected,
-                    ResourceActionResult {
-                        observation: Some(observation),
-                        ..Default::default()
-                    },
-                    format!("cannot restart resource in {:?} state", probe.status),
-                ));
+            if recovery.phase == ResourceActionRecoveryPhase::Prepared {
+                if mutation_probe.status == ResourceStatus::Live {
+                    test_resource_fault(action_id, "terminate")?;
+                    terminate_exact_process(&mutation_probe)?;
+                } else if mutation_probe.status != ResourceStatus::Dead {
+                    let observation =
+                        persist_probe(ws, resource, &probe, requested_event, action_id)?;
+                    return Ok((
+                        ResourceActionStatus::Rejected,
+                        ResourceActionResult {
+                            observation: Some(observation),
+                            ..Default::default()
+                        },
+                        format!("cannot restart resource in {:?} state", probe.status),
+                    ));
+                }
+                save_recovery_phase(
+                    ws,
+                    recovery,
+                    ResourceActionRecoveryPhase::Terminated,
+                    mutation_probe.pid,
+                    mutation_probe.start_identity,
+                )?;
+                test_resource_fault(action_id, "after_terminate")?;
             }
+
+            test_resource_fault(action_id, "spawn")?;
             let mut child = Command::new(&command[0]);
             child
                 .args(&command[1..])
@@ -731,6 +1032,14 @@ fn lifecycle_result(
             let child = child.spawn().context("starting owned resource")?;
             let pid = child.id();
             drop(child);
+            test_resource_spawn_gap_fault(action_id, pid)?;
+            save_recovery_phase(
+                ws,
+                recovery,
+                ResourceActionRecoveryPhase::Spawned,
+                Some(pid),
+                String::new(),
+            )?;
             let mut identity = None;
             for _ in 0..20 {
                 identity = process_identity(pid);
@@ -741,20 +1050,36 @@ fn lifecycle_result(
             }
             let identity =
                 identity.ok_or_else(|| anyhow!("restarted process could not be probed"))?;
-            let restarted = Probe {
-                status: ResourceStatus::Live,
-                pid: Some(pid),
-                start_identity: identity,
-                detail: "restart command spawned a process with a verified identity".to_string(),
-            };
+            save_recovery_phase(
+                ws,
+                recovery,
+                ResourceActionRecoveryPhase::Spawned,
+                Some(pid),
+                identity.clone(),
+            )?;
+            test_resource_fault(action_id, "after_spawn")?;
+            let restarted = probe_restarted_resource(resource, pid, &identity);
             let observation = persist_probe(ws, resource, &restarted, requested_event, action_id)?;
+            let status = if restarted.status == ResourceStatus::Live {
+                ResourceActionStatus::Completed
+            } else {
+                ResourceActionStatus::Rejected
+            };
+            let error = if status == ResourceActionStatus::Completed {
+                String::new()
+            } else {
+                format!(
+                    "restarted resource failed its current liveness gate: {}",
+                    restarted.detail
+                )
+            };
             Ok((
-                ResourceActionStatus::Completed,
+                status,
                 ResourceActionResult {
                     observation: Some(observation),
                     ..Default::default()
                 },
-                String::new(),
+                error,
             ))
         }
         _ => unreachable!("non-lifecycle operation reached lifecycle dispatcher"),
@@ -844,6 +1169,14 @@ fn runtime_supports(resource: &RuntimeResource, operation: ResourceOperationKind
         .is_none_or(|capability| resource.capabilities.contains(&capability))
 }
 
+fn action_event_id(action_id: &str, suffix: &str) -> String {
+    format!(
+        "evt_resource_action_{}_{}",
+        digest_bytes(action_id.as_bytes()).trim_start_matches("fnv1a64:"),
+        suffix
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn record_action_event(
     ws: &Workspace,
@@ -862,11 +1195,7 @@ fn record_action_event(
         intent_id,
         crate::schemas::ChannelEvent {
             schema_version: 1,
-            event_id: format!(
-                "evt_resource_action_{}_{}",
-                digest_bytes(action_id.as_bytes()).trim_start_matches("fnv1a64:"),
-                suffix
-            ),
+            event_id: action_event_id(action_id, suffix),
             session_id: session_id.to_string(),
             seq: 0,
             event_type,
@@ -891,21 +1220,57 @@ fn record_action_event(
     Ok(event.event_id)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn ensure_receipt_events(
+    ws: &Workspace,
+    receipt: &ResourceActionReceipt,
+    session_id: &str,
+    intent_id: &str,
+    task_id: &str,
+) -> Result<()> {
+    let requested_event = record_action_event(
+        ws,
+        &receipt.action_id,
+        "requested",
+        crate::schemas::ChannelEventType::ActionRequested,
+        receipt.operation,
+        session_id,
+        intent_id,
+        task_id,
+        &receipt.target_id,
+        None,
+        "",
+    )?;
+    let (suffix, event_type) = if receipt.status == ResourceActionStatus::Completed {
+        (
+            "completed",
+            crate::schemas::ChannelEventType::ActionCompleted,
+        )
+    } else {
+        ("rejected", crate::schemas::ChannelEventType::ActionRejected)
+    };
+    record_action_event(
+        ws,
+        &receipt.action_id,
+        suffix,
+        event_type,
+        receipt.operation,
+        session_id,
+        intent_id,
+        task_id,
+        &receipt.target_id,
+        Some(requested_event),
+        &receipt.error,
+    )?;
+    Ok(())
+}
+
 pub fn dispatch(
     ws: &Workspace,
     request: ResourceOperationRequest,
 ) -> Result<ResourceActionReceipt> {
     validate_action_id(&request.action_id)?;
     let digest = request_digest(&request)?;
-    if let Some(existing) = ws.load_resource_action(&request.action_id)? {
-        if existing.request_digest == digest {
-            return Ok(existing);
-        }
-        bail!(
-            "idempotency_conflict: action {} changed request",
-            request.action_id
-        );
-    }
 
     let (entries, context_entry) = match request.operation {
         ResourceOperationKind::Discover => {
@@ -938,6 +1303,16 @@ pub fn dispatch(
     if !request.task_id.is_empty() && request.task_id != actual_task_id {
         bail!("resource task linkage conflict");
     }
+    if let Some(existing) = ws.load_resource_action(&request.action_id)? {
+        if existing.request_digest != digest {
+            bail!(
+                "idempotency_conflict: action {} changed request",
+                request.action_id
+            );
+        }
+        ensure_receipt_events(ws, &existing, &session_id, &intent_id, &actual_task_id)?;
+        return Ok(existing);
+    }
     let requested_event = record_action_event(
         ws,
         &request.action_id,
@@ -951,12 +1326,50 @@ pub fn dispatch(
         None,
         "",
     )?;
+    test_resource_fault(&request.action_id, "after_requested")?;
+
+    let prepared = ResourceActionRecoveryReceipt {
+        schema_version: 1,
+        action_id: request.action_id.clone(),
+        request_digest: digest.clone(),
+        operation: request.operation,
+        intent_id: intent_id.clone(),
+        task_id: actual_task_id.clone(),
+        target_id: request.target_id.clone(),
+        expected_status: request.expected_status,
+        requested_event_id: requested_event.clone(),
+        phase: ResourceActionRecoveryPhase::Prepared,
+        effect_pid: None,
+        effect_start_identity: String::new(),
+    };
+    let (mut recovery, recovery_loaded) =
+        if let Some(existing) = ws.load_resource_action_recovery(&request.action_id)? {
+            let same_action = existing.action_id == prepared.action_id
+                && existing.request_digest == prepared.request_digest
+                && existing.operation == prepared.operation
+                && existing.intent_id == prepared.intent_id
+                && existing.task_id == prepared.task_id
+                && existing.target_id == prepared.target_id
+                && existing.expected_status == prepared.expected_status
+                && existing.requested_event_id == prepared.requested_event_id;
+            if !same_action {
+                bail!(
+                    "idempotency_conflict: action {} changed recovery request",
+                    request.action_id
+                );
+            }
+            (existing, true)
+        } else {
+            ws.save_resource_action_recovery(&prepared)?;
+            (prepared, false)
+        };
+    test_resource_fault(&request.action_id, "after_prepared")?;
 
     let (status, result, error) = match request.operation {
         ResourceOperationKind::Discover | ResourceOperationKind::Inspect => (
             ResourceActionStatus::Completed,
             ResourceActionResult {
-                entries,
+                entries: entries.clone(),
                 ..Default::default()
             },
             String::new(),
@@ -974,7 +1387,7 @@ pub fn dispatch(
             _ => (
                 ResourceActionStatus::Completed,
                 ResourceActionResult {
-                    entries,
+                    entries: entries.clone(),
                     open_target: Some(open_target(&context_entry)),
                     observation: None,
                 },
@@ -998,7 +1411,7 @@ pub fn dispatch(
                 (
                     ResourceActionStatus::Completed,
                     ResourceActionResult {
-                        entries,
+                        entries: entries.clone(),
                         open_target: Some(target),
                         observation: None,
                     },
@@ -1033,55 +1446,86 @@ pub fn dispatch(
                         ),
                     )
                 } else {
-                    let (status, mut result, error) = lifecycle_result(
+                    let lifecycle = lifecycle_result(
                         ws,
                         resource,
                         operation,
                         request.expected_status,
                         &requested_event,
                         &request.action_id,
-                    )?;
-                    result.entries = entries;
-                    (status, result, error)
+                        &mut recovery,
+                        recovery_loaded,
+                    );
+                    match lifecycle {
+                        Ok((status, mut result, error)) => {
+                            result.entries = entries.clone();
+                            (status, result, error)
+                        }
+                        Err(error) => (
+                            ResourceActionStatus::Rejected,
+                            ResourceActionResult {
+                                entries: entries.clone(),
+                                ..Default::default()
+                            },
+                            format!("{error:#}"),
+                        ),
+                    }
                 }
             }
         },
     };
-    let terminal_type = if status == ResourceActionStatus::Completed {
-        crate::schemas::ChannelEventType::ActionCompleted
+    let terminal_suffix = if status == ResourceActionStatus::Completed {
+        "completed"
     } else {
-        crate::schemas::ChannelEventType::ActionRejected
+        "rejected"
     };
-    let terminal_event = record_action_event(
+    let mut receipt = ResourceActionReceipt {
+        schema_version: 1,
+        action_id: request.action_id.clone(),
+        operation: request.operation,
+        intent_id: intent_id.clone(),
+        task_id: actual_task_id.clone(),
+        target_id: request.target_id.clone(),
+        request_digest: digest,
+        status,
+        result,
+        result_event_ids: vec![
+            requested_event.clone(),
+            action_event_id(&request.action_id, terminal_suffix),
+        ],
+        error,
+    };
+
+    if let Err(persistence_error) = test_resource_fault(&request.action_id, "receipt")
+        .and_then(|()| ws.save_resource_action(&receipt))
+    {
+        receipt.status = ResourceActionStatus::Rejected;
+        receipt.error = format!("receipt persistence failure: {persistence_error:#}");
+        receipt.result_event_ids[1] = action_event_id(&request.action_id, "rejected");
+        ws.save_resource_action(&receipt)?;
+    }
+
+    let (terminal_suffix, terminal_type) = if receipt.status == ResourceActionStatus::Completed {
+        (
+            "completed",
+            crate::schemas::ChannelEventType::ActionCompleted,
+        )
+    } else {
+        ("rejected", crate::schemas::ChannelEventType::ActionRejected)
+    };
+    record_action_event(
         ws,
         &request.action_id,
-        if status == ResourceActionStatus::Completed {
-            "completed"
-        } else {
-            "rejected"
-        },
+        terminal_suffix,
         terminal_type,
         request.operation,
         &session_id,
         &intent_id,
         &actual_task_id,
         &request.target_id,
-        Some(requested_event.clone()),
-        &error,
+        Some(requested_event),
+        &receipt.error,
     )?;
-    let receipt = ResourceActionReceipt {
-        schema_version: 1,
-        action_id: request.action_id,
-        operation: request.operation,
-        intent_id,
-        task_id: actual_task_id,
-        target_id: request.target_id,
-        request_digest: digest,
-        status,
-        result,
-        result_event_ids: vec![requested_event, terminal_event],
-        error,
-    };
-    ws.save_resource_action(&receipt)?;
+    test_resource_fault(&request.action_id, "after_terminal_event")?;
     Ok(receipt)
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -41,6 +41,7 @@ fn safe_relative_path(path: &Path) -> bool {
         })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn ingest_run_proposals(
     ws: &Workspace,
     session_id: &str,
@@ -662,6 +663,7 @@ fn open_target(entry: &ResourceEntry) -> ResourceOpenTarget {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn record_action_event(
     ws: &Workspace,
     action_id: &str,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1020,6 +1020,13 @@ fn lifecycle_result(
             }
 
             test_resource_fault(action_id, "spawn")?;
+            #[cfg(unix)]
+            let mut child = {
+                let mut child = Command::new("nohup");
+                child.arg(&command[0]);
+                child
+            };
+            #[cfg(not(unix))]
             let mut child = Command::new(&command[0]);
             child
                 .args(&command[1..])

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -603,16 +603,30 @@ fn lifecycle_result(
 fn discover_entries(ws: &Workspace, task_id: &str) -> Result<Vec<ResourceEntry>> {
     let index = ws.load_or_rebuild_resource_index()?;
     let mut entries = Vec::new();
-    for artifact_id in index.artifacts {
-        if let Some(artifact) = ws.load_artifact(&artifact_id)? {
-            if artifact.task_id == task_id {
+    let task_index = index.tasks.iter().find(|entry| entry.task_id == task_id);
+    if task_index.is_none_or(|entry| entry.truncated) {
+        for artifact in ws
+            .load_artifacts()?
+            .into_iter()
+            .filter(|artifact| artifact.task_id == task_id)
+        {
+            entries.push(artifact_entry(ws, artifact));
+        }
+        for resource in ws
+            .load_runtime_resources()?
+            .into_iter()
+            .filter(|resource| resource.task_id == task_id)
+        {
+            entries.push(runtime_entry(ws, resource)?);
+        }
+    } else if let Some(task_index) = task_index {
+        for artifact_id in &task_index.artifacts {
+            if let Some(artifact) = ws.load_artifact(artifact_id)? {
                 entries.push(artifact_entry(ws, artifact));
             }
         }
-    }
-    for resource_id in index.resources {
-        if let Some(resource) = ws.load_runtime_resource(&resource_id)? {
-            if resource.task_id == task_id {
+        for resource_id in &task_index.resources {
+            if let Some(resource) = ws.load_runtime_resource(resource_id)? {
                 entries.push(runtime_entry(ws, resource)?);
             }
         }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,857 @@
+//! Surface-neutral runtime resource and artifact operations.
+//!
+//! Workers author proposals. This module validates content and live targets;
+//! `state.rs` remains the only canonical `.agents/` writer.
+
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::path::{Component, Path};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::schemas::{
+    Artifact, ResourceActionReceipt, ResourceActionResult, ResourceActionStatus, ResourceEntry,
+    ResourceObservation, ResourceOpenTarget, ResourceOperationKind, ResourceOperationRequest,
+    ResourceOwnership, ResourceStatus, RunResult, RuntimeResource, RuntimeResourceTarget,
+};
+use crate::state::{validate_action_id, Workspace};
+
+fn digest_bytes(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("fnv1a64:{hash:016x}")
+}
+
+fn request_digest(request: &ResourceOperationRequest) -> Result<String> {
+    Ok(digest_bytes(&serde_json::to_vec(request)?))
+}
+
+fn safe_relative_path(path: &Path) -> bool {
+    !path.as_os_str().is_empty()
+        && !path.is_absolute()
+        && path.components().all(|component| {
+            !matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+}
+
+pub(crate) fn ingest_run_proposals(
+    ws: &Workspace,
+    session_id: &str,
+    intent_id: &str,
+    task_id: &str,
+    attempt_id: &str,
+    worker_id: &str,
+    worker_root: &Path,
+    result: &RunResult,
+) -> Result<()> {
+    let errors = result.resource_provenance_errors(attempt_id);
+    if !errors.is_empty() {
+        bail!(
+            "invalid resource proposal provenance: {}",
+            errors.join("; ")
+        );
+    }
+    let canonical_root = std::fs::canonicalize(worker_root)
+        .with_context(|| format!("canonicalizing worker root {}", worker_root.display()))?;
+    for proposal in &result.artifacts {
+        if proposal.task_id != task_id || proposal.producer.worker_id != worker_id {
+            bail!(
+                "artifact proposal producer linkage conflict: {}",
+                proposal.proposal_id
+            );
+        }
+        let relative = Path::new(&proposal.path);
+        if !safe_relative_path(relative) {
+            bail!("artifact path is not workspace-relative: {}", proposal.path);
+        }
+        let path = worker_root.join(relative);
+        let canonical_path = std::fs::canonicalize(&path)
+            .with_context(|| format!("opening proposed artifact {}", path.display()))?;
+        if canonical_path.strip_prefix(&canonical_root).is_err() || !canonical_path.is_file() {
+            bail!(
+                "artifact path escapes worker root or is not a file: {}",
+                proposal.path
+            );
+        }
+        let bytes = std::fs::read(&canonical_path)
+            .with_context(|| format!("reading proposed artifact {}", canonical_path.display()))?;
+        let actual_digest = digest_bytes(&bytes);
+        if actual_digest != proposal.digest {
+            bail!(
+                "artifact digest mismatch for {}: expected {}, got {}",
+                proposal.proposal_id,
+                proposal.digest,
+                actual_digest
+            );
+        }
+        ws.publish_artifact(
+            session_id,
+            intent_id,
+            proposal,
+            &canonical_path.display().to_string(),
+        )?;
+    }
+    for proposal in &result.resources {
+        if proposal.task_id != task_id || proposal.producer.worker_id != worker_id {
+            bail!(
+                "resource proposal producer linkage conflict: {}",
+                proposal.proposal_id
+            );
+        }
+        ws.publish_runtime_resource(session_id, intent_id, proposal)?;
+    }
+    ws.load_or_rebuild_resource_index()?;
+    Ok(())
+}
+
+fn artifact_entry(ws: &Workspace, artifact: Artifact) -> ResourceEntry {
+    let preferred = if artifact.source_path.is_empty() {
+        &artifact.path
+    } else {
+        &artifact.source_path
+    };
+    let path = Path::new(preferred);
+    let resolved = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        ws.root.join(path)
+    };
+    let fallback = ws.root.join(&artifact.path);
+    let resolved = if resolved.is_file() || !fallback.is_file() {
+        resolved
+    } else {
+        fallback
+    };
+    let available = std::fs::read(&resolved)
+        .ok()
+        .is_some_and(|bytes| digest_bytes(&bytes) == artifact.digest);
+    let status = if available {
+        ResourceStatus::Available
+    } else {
+        ResourceStatus::Unavailable
+    };
+    let open_target = if available {
+        ResourceOpenTarget::File {
+            path: resolved.display().to_string(),
+            media_type: artifact.media_type.clone(),
+        }
+    } else {
+        ResourceOpenTarget::Unavailable {
+            reason: format!(
+                "artifact is missing or digest-mismatched: {}",
+                artifact.path
+            ),
+        }
+    };
+    ResourceEntry::Artifact {
+        artifact,
+        status,
+        open_target,
+    }
+}
+
+fn resource_open_target(resource: &RuntimeResource) -> ResourceOpenTarget {
+    match &resource.target {
+        RuntimeResourceTarget::Terminal {
+            terminal_id,
+            attach_hint,
+            ..
+        } => ResourceOpenTarget::TerminalSession {
+            terminal_id: terminal_id.clone(),
+            attach_hint: attach_hint.clone(),
+        },
+        RuntimeResourceTarget::Process { pid, .. } => {
+            ResourceOpenTarget::ProcessMonitor { pid: *pid }
+        }
+        RuntimeResourceTarget::Service { url, .. } | RuntimeResourceTarget::Browser { url, .. } => {
+            ResourceOpenTarget::Url { url: url.clone() }
+        }
+    }
+}
+
+fn runtime_entry(ws: &Workspace, resource: RuntimeResource) -> Result<ResourceEntry> {
+    let last_observation = ws
+        .load_resource_observations(&resource.resource_id)?
+        .into_iter()
+        .last();
+    Ok(ResourceEntry::RuntimeResource {
+        open_target: resource_open_target(&resource),
+        resource,
+        // A persisted observation is last-observed evidence, not a current
+        // claim in a fresh CLI/core process. `reconcile` returns its new probe
+        // result directly and appends a new canonical observation.
+        status: ResourceStatus::Unknown,
+        last_observation,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct Probe {
+    status: ResourceStatus,
+    pid: Option<u32>,
+    start_identity: String,
+    detail: String,
+}
+
+fn process_identity(pid: u32) -> Option<String> {
+    if pid == 0 {
+        return None;
+    }
+    let output = Command::new("ps")
+        .args(["-o", "lstart=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let normalized = String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn effective_process(ws: &Workspace, resource: &RuntimeResource) -> Result<Option<(u32, String)>> {
+    if let Some(observation) = ws
+        .load_resource_observations(&resource.resource_id)?
+        .into_iter()
+        .rev()
+        .find(|observation| {
+            observation.status == ResourceStatus::Live
+                && observation.pid.is_some()
+                && !observation.start_identity.is_empty()
+        })
+    {
+        return Ok(Some((
+            observation.pid.expect("filtered observation pid"),
+            observation.start_identity,
+        )));
+    }
+    Ok(match &resource.target {
+        RuntimeResourceTarget::Terminal {
+            pid,
+            start_identity,
+            ..
+        }
+        | RuntimeResourceTarget::Process {
+            pid,
+            start_identity,
+            ..
+        } => Some((*pid, start_identity.clone())),
+        RuntimeResourceTarget::Service {
+            pid: Some(pid),
+            start_identity,
+            ..
+        }
+        | RuntimeResourceTarget::Browser {
+            pid: Some(pid),
+            start_identity,
+            ..
+        } => Some((*pid, start_identity.clone())),
+        _ => None,
+    })
+}
+
+fn probe_process(pid: u32, expected_identity: &str) -> Probe {
+    match process_identity(pid) {
+        None => Probe {
+            status: ResourceStatus::Dead,
+            pid: Some(pid),
+            start_identity: expected_identity.to_string(),
+            detail: "process is not present".to_string(),
+        },
+        Some(actual) if actual != expected_identity => Probe {
+            status: ResourceStatus::Orphaned,
+            pid: Some(pid),
+            start_identity: actual,
+            detail: "pid exists but process start identity does not match".to_string(),
+        },
+        Some(actual) => Probe {
+            status: ResourceStatus::Live,
+            pid: Some(pid),
+            start_identity: actual,
+            detail: "process identity probe matched".to_string(),
+        },
+    }
+}
+
+fn url_socket(url: &str) -> Option<SocketAddr> {
+    let (scheme, rest) = url.split_once("://")?;
+    let authority = rest.split('/').next()?;
+    let default_port = if scheme.eq_ignore_ascii_case("https") {
+        443
+    } else {
+        80
+    };
+    let (host, port) = authority
+        .rsplit_once(':')
+        .and_then(|(host, port)| port.parse::<u16>().ok().map(|port| (host, port)))
+        .unwrap_or((authority, default_port));
+    (host, port).to_socket_addrs().ok()?.next()
+}
+
+fn probe_resource(ws: &Workspace, resource: &RuntimeResource) -> Result<Probe> {
+    match &resource.target {
+        RuntimeResourceTarget::Terminal { .. } | RuntimeResourceTarget::Process { .. } => {
+            let (pid, identity) = effective_process(ws, resource)?
+                .ok_or_else(|| anyhow!("process resource lacks identity"))?;
+            Ok(probe_process(pid, &identity))
+        }
+        RuntimeResourceTarget::Service { url, pid, .. } => {
+            if pid.is_some() {
+                let (pid, identity) = effective_process(ws, resource)?
+                    .ok_or_else(|| anyhow!("service process lacks identity"))?;
+                let process = probe_process(pid, &identity);
+                if process.status != ResourceStatus::Live {
+                    return Ok(process);
+                }
+            }
+            let Some(address) = url_socket(url) else {
+                return Ok(Probe {
+                    status: ResourceStatus::Unrecoverable,
+                    pid: effective_process(ws, resource)?.map(|(pid, _)| pid),
+                    start_identity: effective_process(ws, resource)?
+                        .map(|(_, identity)| identity)
+                        .unwrap_or_default(),
+                    detail: "service url cannot be parsed for a local probe".to_string(),
+                });
+            };
+            let live = TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok();
+            Ok(Probe {
+                status: if live {
+                    ResourceStatus::Live
+                } else {
+                    ResourceStatus::Unavailable
+                },
+                pid: effective_process(ws, resource)?.map(|(pid, _)| pid),
+                start_identity: effective_process(ws, resource)?
+                    .map(|(_, identity)| identity)
+                    .unwrap_or_default(),
+                detail: if live {
+                    format!("service socket probe reached {address}")
+                } else {
+                    format!("service socket probe could not reach {address}")
+                },
+            })
+        }
+        RuntimeResourceTarget::Browser { pid: None, .. } => Ok(Probe {
+            status: ResourceStatus::Expired,
+            pid: None,
+            start_identity: String::new(),
+            detail: "browser session has no probeable process identity".to_string(),
+        }),
+        RuntimeResourceTarget::Browser { .. } => {
+            let (pid, identity) = effective_process(ws, resource)?
+                .ok_or_else(|| anyhow!("browser process lacks identity"))?;
+            let mut process = probe_process(pid, &identity);
+            if process.status == ResourceStatus::Dead {
+                process.status = ResourceStatus::Expired;
+                process.detail = "browser session process expired".to_string();
+            }
+            Ok(process)
+        }
+    }
+}
+
+fn owned_for_destructive_action(ownership: ResourceOwnership) -> bool {
+    matches!(
+        ownership,
+        ResourceOwnership::Yardlet | ResourceOwnership::Worker
+    )
+}
+
+fn terminate_exact_process(probe: &Probe) -> Result<()> {
+    if probe.status != ResourceStatus::Live {
+        bail!("process is not live with a matching identity");
+    }
+    let pid = probe.pid.ok_or_else(|| anyhow!("process pid is missing"))?;
+    // SAFETY: the current probe matched both pid and start identity. The caller
+    // separately verified canonical ownership before reaching this function.
+    let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error()).context("stopping owned resource process");
+    }
+    for _ in 0..40 {
+        if process_identity(pid).is_none() {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    bail!("owned process did not stop after SIGTERM")
+}
+
+fn restart_command(resource: &RuntimeResource) -> &[String] {
+    match &resource.target {
+        RuntimeResourceTarget::Process { command, .. } => command,
+        RuntimeResourceTarget::Service {
+            restart_command, ..
+        } => restart_command,
+        _ => &[],
+    }
+}
+
+fn persist_probe(
+    ws: &Workspace,
+    resource: &RuntimeResource,
+    probe: &Probe,
+    requested_event: &str,
+    action_id: &str,
+) -> Result<ResourceObservation> {
+    ws.record_resource_observation(
+        resource,
+        probe.status,
+        true,
+        probe.pid,
+        &probe.start_identity,
+        &probe.detail,
+        requested_event,
+        action_id,
+    )
+}
+
+fn lifecycle_result(
+    ws: &Workspace,
+    resource: &RuntimeResource,
+    operation: ResourceOperationKind,
+    expected_status: Option<ResourceStatus>,
+    requested_event: &str,
+    action_id: &str,
+) -> Result<(ResourceActionStatus, ResourceActionResult, String)> {
+    let probe = probe_resource(ws, resource)?;
+    if let Some(expected) = expected_status {
+        if probe.status != expected {
+            let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+            return Ok((
+                ResourceActionStatus::Rejected,
+                ResourceActionResult {
+                    observation: Some(observation),
+                    ..Default::default()
+                },
+                format!(
+                    "expected status {:?}, current probe found {:?}",
+                    expected, probe.status
+                ),
+            ));
+        }
+    }
+
+    if operation == ResourceOperationKind::Reconcile {
+        let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Completed,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            String::new(),
+        ));
+    }
+
+    if operation == ResourceOperationKind::Detach {
+        let detached = Probe {
+            status: ResourceStatus::Detached,
+            detail: "detached without changing the target process".to_string(),
+            ..probe
+        };
+        let observation = persist_probe(ws, resource, &detached, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Completed,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            String::new(),
+        ));
+    }
+
+    if !owned_for_destructive_action(resource.ownership) {
+        let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Rejected,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            format!(
+                "ownership {:?} forbids destructive resource operations",
+                resource.ownership
+            ),
+        ));
+    }
+    if probe.status == ResourceStatus::Orphaned {
+        let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Rejected,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            "process identity mismatch; refusing to signal the pid".to_string(),
+        ));
+    }
+
+    match operation {
+        ResourceOperationKind::Stop | ResourceOperationKind::Cleanup => {
+            if probe.status == ResourceStatus::Live {
+                terminate_exact_process(&probe)?;
+            } else if probe.status != ResourceStatus::Dead {
+                let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+                return Ok((
+                    ResourceActionStatus::Rejected,
+                    ResourceActionResult {
+                        observation: Some(observation),
+                        ..Default::default()
+                    },
+                    format!(
+                        "cannot {:?} resource in {:?} state",
+                        operation, probe.status
+                    ),
+                ));
+            }
+            let stopped = Probe {
+                status: ResourceStatus::Dead,
+                detail: if operation == ResourceOperationKind::Cleanup {
+                    "owned resource cleanup confirmed process dead".to_string()
+                } else {
+                    "owned resource stop confirmed process dead".to_string()
+                },
+                ..probe
+            };
+            let observation = persist_probe(ws, resource, &stopped, requested_event, action_id)?;
+            Ok((
+                ResourceActionStatus::Completed,
+                ResourceActionResult {
+                    observation: Some(observation),
+                    ..Default::default()
+                },
+                String::new(),
+            ))
+        }
+        ResourceOperationKind::Restart => {
+            let command = restart_command(resource);
+            if command.is_empty() {
+                let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+                return Ok((
+                    ResourceActionStatus::Rejected,
+                    ResourceActionResult {
+                        observation: Some(observation),
+                        ..Default::default()
+                    },
+                    "resource has no typed restart command".to_string(),
+                ));
+            }
+            if probe.status == ResourceStatus::Live {
+                terminate_exact_process(&probe)?;
+            } else if probe.status != ResourceStatus::Dead {
+                let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+                return Ok((
+                    ResourceActionStatus::Rejected,
+                    ResourceActionResult {
+                        observation: Some(observation),
+                        ..Default::default()
+                    },
+                    format!("cannot restart resource in {:?} state", probe.status),
+                ));
+            }
+            let mut child = Command::new(&command[0]);
+            child
+                .args(&command[1..])
+                .current_dir(&ws.root)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            let child = child.spawn().context("starting owned resource")?;
+            let pid = child.id();
+            drop(child);
+            let mut identity = None;
+            for _ in 0..20 {
+                identity = process_identity(pid);
+                if identity.is_some() {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            let identity =
+                identity.ok_or_else(|| anyhow!("restarted process could not be probed"))?;
+            let restarted = Probe {
+                status: ResourceStatus::Live,
+                pid: Some(pid),
+                start_identity: identity,
+                detail: "restart command spawned a process with a verified identity".to_string(),
+            };
+            let observation = persist_probe(ws, resource, &restarted, requested_event, action_id)?;
+            Ok((
+                ResourceActionStatus::Completed,
+                ResourceActionResult {
+                    observation: Some(observation),
+                    ..Default::default()
+                },
+                String::new(),
+            ))
+        }
+        _ => unreachable!("non-lifecycle operation reached lifecycle dispatcher"),
+    }
+}
+
+fn discover_entries(ws: &Workspace, task_id: &str) -> Result<Vec<ResourceEntry>> {
+    let index = ws.load_or_rebuild_resource_index()?;
+    let mut entries = Vec::new();
+    for artifact_id in index.artifacts {
+        if let Some(artifact) = ws.load_artifact(&artifact_id)? {
+            if artifact.task_id == task_id {
+                entries.push(artifact_entry(ws, artifact));
+            }
+        }
+    }
+    for resource_id in index.resources {
+        if let Some(resource) = ws.load_runtime_resource(&resource_id)? {
+            if resource.task_id == task_id {
+                entries.push(runtime_entry(ws, resource)?);
+            }
+        }
+    }
+    Ok(entries)
+}
+
+fn inspect_entry(ws: &Workspace, target_id: &str) -> Result<ResourceEntry> {
+    if let Some(artifact) = ws.load_artifact(target_id)? {
+        return Ok(artifact_entry(ws, artifact));
+    }
+    if let Some(resource) = ws.load_runtime_resource(target_id)? {
+        return runtime_entry(ws, resource);
+    }
+    bail!("resource target not found: {target_id}")
+}
+
+fn entry_task_context(entry: &ResourceEntry) -> (&str, &str, &str) {
+    match entry {
+        ResourceEntry::Artifact { artifact, .. } => {
+            (&artifact.session_id, &artifact.intent_id, &artifact.task_id)
+        }
+        ResourceEntry::RuntimeResource { resource, .. } => {
+            (&resource.session_id, &resource.intent_id, &resource.task_id)
+        }
+    }
+}
+
+fn open_target(entry: &ResourceEntry) -> ResourceOpenTarget {
+    match entry {
+        ResourceEntry::Artifact { open_target, .. }
+        | ResourceEntry::RuntimeResource { open_target, .. } => open_target.clone(),
+    }
+}
+
+fn record_action_event(
+    ws: &Workspace,
+    action_id: &str,
+    suffix: &str,
+    event_type: crate::schemas::ChannelEventType,
+    operation: ResourceOperationKind,
+    session_id: &str,
+    intent_id: &str,
+    task_id: &str,
+    target_id: &str,
+    causation_id: Option<String>,
+    error: &str,
+) -> Result<String> {
+    let event = ws.record_task_event(
+        intent_id,
+        crate::schemas::ChannelEvent {
+            schema_version: 1,
+            event_id: format!(
+                "evt_resource_action_{}_{}",
+                digest_bytes(action_id.as_bytes()).trim_start_matches("fnv1a64:"),
+                suffix
+            ),
+            session_id: session_id.to_string(),
+            seq: 0,
+            event_type,
+            recorded_at: String::new(),
+            actor: crate::schemas::EventActor {
+                kind: crate::schemas::EventActorKind::Surface,
+                id: "cli".to_string(),
+            },
+            action_id: Some(action_id.to_string()),
+            causation_id,
+            correlation_id: format!("cor_resource_{task_id}"),
+            task_id: task_id.to_string(),
+            attempt_id: None,
+            payload: serde_json::json!({
+                "operation": operation,
+                "target_id": target_id,
+                "error": error
+            }),
+            raw_ref: None,
+        },
+    )?;
+    Ok(event.event_id)
+}
+
+pub fn dispatch(
+    ws: &Workspace,
+    request: ResourceOperationRequest,
+) -> Result<ResourceActionReceipt> {
+    validate_action_id(&request.action_id)?;
+    let digest = request_digest(&request)?;
+    if let Some(existing) = ws.load_resource_action(&request.action_id)? {
+        if existing.request_digest == digest {
+            return Ok(existing);
+        }
+        bail!(
+            "idempotency_conflict: action {} changed request",
+            request.action_id
+        );
+    }
+
+    let (entries, context_entry) = match request.operation {
+        ResourceOperationKind::Discover => {
+            if request.task_id.trim().is_empty() {
+                bail!("discover requires task_id");
+            }
+            let entries = discover_entries(ws, &request.task_id)?;
+            let context = entries.first().cloned();
+            (entries, context)
+        }
+        _ => {
+            if request.target_id.trim().is_empty() {
+                bail!(
+                    "{} requires target_id",
+                    format!("{:?}", request.operation).to_lowercase()
+                );
+            }
+            let entry = inspect_entry(ws, &request.target_id)?;
+            (vec![entry.clone()], Some(entry))
+        }
+    };
+    let context_entry = context_entry.ok_or_else(|| anyhow!("task has no published resources"))?;
+    let (session_id, intent_id, actual_task_id) = entry_task_context(&context_entry);
+    let session_id = session_id.to_string();
+    let intent_id = intent_id.to_string();
+    let actual_task_id = actual_task_id.to_string();
+    if !request.task_id.is_empty() && request.task_id != actual_task_id {
+        bail!("resource task linkage conflict");
+    }
+    let requested_event = record_action_event(
+        ws,
+        &request.action_id,
+        "requested",
+        crate::schemas::ChannelEventType::ActionRequested,
+        request.operation,
+        &session_id,
+        &intent_id,
+        &actual_task_id,
+        &request.target_id,
+        None,
+        "",
+    )?;
+
+    let (status, result, error) = match request.operation {
+        ResourceOperationKind::Discover | ResourceOperationKind::Inspect => (
+            ResourceActionStatus::Completed,
+            ResourceActionResult {
+                entries,
+                ..Default::default()
+            },
+            String::new(),
+        ),
+        ResourceOperationKind::Open => (
+            ResourceActionStatus::Completed,
+            ResourceActionResult {
+                entries,
+                open_target: Some(open_target(&context_entry)),
+                observation: None,
+            },
+            String::new(),
+        ),
+        ResourceOperationKind::Attach => {
+            let target = open_target(&context_entry);
+            if matches!(
+                target,
+                ResourceOpenTarget::TerminalSession { .. }
+                    | ResourceOpenTarget::ProcessMonitor { .. }
+            ) {
+                (
+                    ResourceActionStatus::Completed,
+                    ResourceActionResult {
+                        entries,
+                        open_target: Some(target),
+                        observation: None,
+                    },
+                    String::new(),
+                )
+            } else {
+                (
+                    ResourceActionStatus::Rejected,
+                    ResourceActionResult::default(),
+                    "attach is unsupported for this target".to_string(),
+                )
+            }
+        }
+        operation @ (ResourceOperationKind::Stop
+        | ResourceOperationKind::Restart
+        | ResourceOperationKind::Detach
+        | ResourceOperationKind::Cleanup
+        | ResourceOperationKind::Reconcile) => match &context_entry {
+            ResourceEntry::Artifact { .. } => (
+                ResourceActionStatus::Rejected,
+                ResourceActionResult::default(),
+                "lifecycle operation is unsupported for artifacts".to_string(),
+            ),
+            ResourceEntry::RuntimeResource { resource, .. } => {
+                let (status, mut result, error) = lifecycle_result(
+                    ws,
+                    resource,
+                    operation,
+                    request.expected_status,
+                    &requested_event,
+                    &request.action_id,
+                )?;
+                result.entries = entries;
+                (status, result, error)
+            }
+        },
+    };
+    let terminal_type = if status == ResourceActionStatus::Completed {
+        crate::schemas::ChannelEventType::ActionCompleted
+    } else {
+        crate::schemas::ChannelEventType::ActionRejected
+    };
+    let terminal_event = record_action_event(
+        ws,
+        &request.action_id,
+        if status == ResourceActionStatus::Completed {
+            "completed"
+        } else {
+            "rejected"
+        },
+        terminal_type,
+        request.operation,
+        &session_id,
+        &intent_id,
+        &actual_task_id,
+        &request.target_id,
+        Some(requested_event.clone()),
+        &error,
+    )?;
+    let receipt = ResourceActionReceipt {
+        schema_version: 1,
+        action_id: request.action_id,
+        operation: request.operation,
+        task_id: actual_task_id,
+        target_id: request.target_id,
+        request_digest: digest,
+        status,
+        result,
+        result_event_ids: vec![requested_event, terminal_event],
+        error,
+    };
+    ws.save_resource_action(&receipt)?;
+    Ok(receipt)
+}

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -663,7 +663,7 @@ fn probe_restarted_resource(
     pid: u32,
     expected_identity: &str,
 ) -> Probe {
-    let deadline = Instant::now() + Duration::from_secs(1);
+    let deadline = Instant::now() + Duration::from_secs(5);
     loop {
         let mut process = probe_process(pid, expected_identity);
         if process.status != ResourceStatus::Live {
@@ -1526,4 +1526,90 @@ pub fn dispatch(
     )?;
     test_resource_fault(&request.action_id, "after_terminal_event")?;
     Ok(receipt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::process::{Command, Stdio};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+
+    #[cfg(unix)]
+    #[test]
+    fn restarted_service_waits_for_a_slow_but_healthy_local_endpoint() {
+        let mut child = Command::new("/bin/sleep")
+            .arg("10")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn restart target");
+        let pid = child.id();
+        let identity = process_identity(pid).expect("restart target identity");
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind delayed health server");
+        let address = listener.local_addr().expect("delayed health address");
+        listener
+            .set_nonblocking(true)
+            .expect("set delayed health server nonblocking");
+        let finished = Arc::new(AtomicBool::new(false));
+        let server_finished = Arc::clone(&finished);
+        let server = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(1_200));
+            while !server_finished.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = [0_u8; 1_024];
+                        let _ = stream.read(&mut request);
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                        );
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept delayed health request: {error}"),
+                }
+            }
+        });
+
+        let health_url = format!("http://{address}/health");
+        let resource = RuntimeResource {
+            schema_version: 1,
+            resource_id: "res-delayed-health".to_string(),
+            proposal_id: "proposal-delayed-health".to_string(),
+            session_id: "session-delayed-health".to_string(),
+            intent_id: "intent-delayed-health".to_string(),
+            task_id: "YARD-DELAYED-HEALTH".to_string(),
+            attempt_id: "attempt-delayed-health".to_string(),
+            producer: crate::schemas::ResourceProducer {
+                worker_id: "fixture".to_string(),
+            },
+            causation_id: "attempt-delayed-health".to_string(),
+            ownership: ResourceOwnership::Yardlet,
+            capabilities: vec![ResourceCapability::Restart],
+            target: RuntimeResourceTarget::Service {
+                url: health_url.clone(),
+                health_url,
+                pid: Some(pid),
+                start_identity: identity.clone(),
+                restart_command: vec!["/bin/sleep".to_string(), "10".to_string()],
+            },
+            created_event_id: "evt-delayed-health".to_string(),
+            published_seq: 1,
+            recorded_at: "2026-07-15T00:00:00Z".to_string(),
+        };
+
+        let probe = probe_restarted_resource(&resource, pid, &identity);
+        finished.store(true, Ordering::SeqCst);
+        server.join().expect("join delayed health server");
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(probe.status, ResourceStatus::Live, "{}", probe.detail);
+    }
 }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -280,14 +280,11 @@ fn effective_process(ws: &Workspace, resource: &RuntimeResource) -> Result<Optio
         .into_iter()
         .last()
     {
-        if observation.status != ResourceStatus::Orphaned
-            && observation.pid.is_some()
-            && !observation.start_identity.is_empty()
+        if observation.status != ResourceStatus::Orphaned && !observation.start_identity.is_empty()
         {
-            return Ok(Some((
-                observation.pid.expect("checked observation pid"),
-                observation.start_identity,
-            )));
+            if let Some(pid) = observation.pid {
+                return Ok(Some((pid, observation.start_identity)));
+            }
         }
         if observation.status == ResourceStatus::Unrecoverable {
             return Ok(None);
@@ -716,6 +713,7 @@ fn destructive_process_probe(resource: &RuntimeResource, observed: &Probe) -> Pr
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn lifecycle_result(
     ws: &Workspace,
     resource: &RuntimeResource,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -3,6 +3,7 @@
 //! Workers author proposals. This module validates content and live targets;
 //! `state.rs` remains the only canonical `.agents/` writer.
 
+use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::path::{Component, Path};
 use std::process::{Command, Stdio};
@@ -11,9 +12,10 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context, Result};
 
 use crate::schemas::{
-    Artifact, ResourceActionReceipt, ResourceActionResult, ResourceActionStatus, ResourceEntry,
-    ResourceObservation, ResourceOpenTarget, ResourceOperationKind, ResourceOperationRequest,
-    ResourceOwnership, ResourceStatus, RunResult, RuntimeResource, RuntimeResourceTarget,
+    Artifact, ResourceActionReceipt, ResourceActionResult, ResourceActionStatus,
+    ResourceCapability, ResourceEntry, ResourceObservation, ResourceOpenTarget,
+    ResourceOperationKind, ResourceOperationRequest, ResourceOwnership, ResourceStatus, RunResult,
+    RuntimeResource, RuntimeResourceTarget,
 };
 use crate::state::{validate_action_id, Workspace};
 
@@ -298,6 +300,81 @@ fn url_socket(url: &str) -> Option<SocketAddr> {
     (host, port).to_socket_addrs().ok()?.next()
 }
 
+enum HttpProbe {
+    Response { status: u16, body: String },
+    Unavailable(String),
+    Unrecoverable(String),
+}
+
+fn probe_http(url: &str) -> HttpProbe {
+    let Some((scheme, rest)) = url.split_once("://") else {
+        return HttpProbe::Unrecoverable("URL has no scheme".to_string());
+    };
+    if !scheme.eq_ignore_ascii_case("http") {
+        return HttpProbe::Unrecoverable(format!("unsupported semantic probe scheme {scheme}"));
+    }
+    let (authority, path) = rest
+        .split_once('/')
+        .map(|(authority, path)| (authority, format!("/{path}")))
+        .unwrap_or((rest, "/".to_string()));
+    if authority.is_empty() {
+        return HttpProbe::Unrecoverable("URL has no authority".to_string());
+    }
+    let Some(address) = url_socket(url) else {
+        return HttpProbe::Unrecoverable("URL cannot be resolved".to_string());
+    };
+    let mut stream = match TcpStream::connect_timeout(&address, Duration::from_millis(300)) {
+        Ok(stream) => stream,
+        Err(error) => {
+            return HttpProbe::Unavailable(format!(
+                "HTTP probe could not connect to {address}: {error}"
+            ))
+        }
+    };
+    let timeout = Some(Duration::from_millis(500));
+    let _ = stream.set_read_timeout(timeout);
+    let _ = stream.set_write_timeout(timeout);
+    if let Err(error) = write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: {authority}\r\nConnection: close\r\nAccept: application/json\r\n\r\n"
+    ) {
+        return HttpProbe::Unavailable(format!("HTTP probe write failed: {error}"));
+    }
+    let mut bytes = Vec::new();
+    if let Err(error) = stream.take(64 * 1024).read_to_end(&mut bytes) {
+        return HttpProbe::Unavailable(format!("HTTP probe read failed: {error}"));
+    }
+    let response = String::from_utf8_lossy(&bytes);
+    let Some(head_end) = response.find("\r\n\r\n") else {
+        return HttpProbe::Unrecoverable("HTTP probe returned a malformed response".to_string());
+    };
+    let status = response
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|status| status.parse::<u16>().ok());
+    let Some(status) = status else {
+        return HttpProbe::Unrecoverable("HTTP probe returned no status code".to_string());
+    };
+    HttpProbe::Response {
+        status,
+        body: response[head_end + 4..].to_string(),
+    }
+}
+
+fn browser_session_attested(body: &str, session_id: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("session_id")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .as_deref()
+        == Some(session_id)
+}
+
 fn probe_resource(ws: &Workspace, resource: &RuntimeResource) -> Result<Probe> {
     match &resource.target {
         RuntimeResourceTarget::Terminal { .. } | RuntimeResourceTarget::Process { .. } => {
@@ -305,7 +382,12 @@ fn probe_resource(ws: &Workspace, resource: &RuntimeResource) -> Result<Probe> {
                 .ok_or_else(|| anyhow!("process resource lacks identity"))?;
             Ok(probe_process(pid, &identity))
         }
-        RuntimeResourceTarget::Service { url, pid, .. } => {
+        RuntimeResourceTarget::Service {
+            url,
+            health_url,
+            pid,
+            ..
+        } => {
             if pid.is_some() {
                 let (pid, identity) = effective_process(ws, resource)?
                     .ok_or_else(|| anyhow!("service process lacks identity"))?;
@@ -314,49 +396,129 @@ fn probe_resource(ws: &Workspace, resource: &RuntimeResource) -> Result<Probe> {
                     return Ok(process);
                 }
             }
-            let Some(address) = url_socket(url) else {
+            let process = effective_process(ws, resource)?;
+            let (observed_pid, start_identity) = process
+                .map(|(pid, identity)| (Some(pid), identity))
+                .unwrap_or_default();
+            if health_url.trim().is_empty() {
+                let Some(address) = url_socket(url) else {
+                    return Ok(Probe {
+                        status: ResourceStatus::Unrecoverable,
+                        pid: observed_pid,
+                        start_identity,
+                        detail: "service URL cannot be parsed for a local probe".to_string(),
+                    });
+                };
+                let reachable =
+                    TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok();
                 return Ok(Probe {
-                    status: ResourceStatus::Unrecoverable,
-                    pid: effective_process(ws, resource)?.map(|(pid, _)| pid),
-                    start_identity: effective_process(ws, resource)?
-                        .map(|(_, identity)| identity)
-                        .unwrap_or_default(),
-                    detail: "service url cannot be parsed for a local probe".to_string(),
+                    status: if reachable {
+                        ResourceStatus::Unknown
+                    } else {
+                        ResourceStatus::Unavailable
+                    },
+                    pid: observed_pid,
+                    start_identity,
+                    detail: if reachable {
+                        format!(
+                            "service port {address} is reachable but no semantic health_url was declared"
+                        )
+                    } else {
+                        format!("service socket probe could not reach {address}")
+                    },
                 });
+            }
+            let (status, detail) = match probe_http(health_url) {
+                HttpProbe::Response { status, .. } if (200..300).contains(&status) => (
+                    ResourceStatus::Live,
+                    format!("declared health URL returned HTTP {status}"),
+                ),
+                HttpProbe::Response { status, .. } => (
+                    ResourceStatus::Unavailable,
+                    format!("declared health URL returned HTTP {status}"),
+                ),
+                HttpProbe::Unavailable(detail) => (ResourceStatus::Unavailable, detail),
+                HttpProbe::Unrecoverable(detail) => (ResourceStatus::Unrecoverable, detail),
             };
-            let live = TcpStream::connect_timeout(&address, Duration::from_millis(200)).is_ok();
             Ok(Probe {
-                status: if live {
-                    ResourceStatus::Live
-                } else {
-                    ResourceStatus::Unavailable
-                },
-                pid: effective_process(ws, resource)?.map(|(pid, _)| pid),
-                start_identity: effective_process(ws, resource)?
-                    .map(|(_, identity)| identity)
-                    .unwrap_or_default(),
-                detail: if live {
-                    format!("service socket probe reached {address}")
-                } else {
-                    format!("service socket probe could not reach {address}")
-                },
+                status,
+                pid: observed_pid,
+                start_identity,
+                detail,
             })
         }
-        RuntimeResourceTarget::Browser { pid: None, .. } => Ok(Probe {
-            status: ResourceStatus::Expired,
-            pid: None,
-            start_identity: String::new(),
-            detail: "browser session has no probeable process identity".to_string(),
-        }),
-        RuntimeResourceTarget::Browser { .. } => {
-            let (pid, identity) = effective_process(ws, resource)?
-                .ok_or_else(|| anyhow!("browser process lacks identity"))?;
-            let mut process = probe_process(pid, &identity);
-            if process.status == ResourceStatus::Dead {
-                process.status = ResourceStatus::Expired;
-                process.detail = "browser session process expired".to_string();
+        RuntimeResourceTarget::Browser {
+            session_id,
+            session_probe_url,
+            pid,
+            ..
+        } => {
+            let process = if pid.is_some() {
+                let (pid, identity) = effective_process(ws, resource)?
+                    .ok_or_else(|| anyhow!("browser process lacks identity"))?;
+                let mut process = probe_process(pid, &identity);
+                if process.status == ResourceStatus::Dead {
+                    process.status = ResourceStatus::Expired;
+                    process.detail = "browser session process expired".to_string();
+                    return Ok(process);
+                }
+                if process.status != ResourceStatus::Live {
+                    return Ok(process);
+                }
+                Some(process)
+            } else {
+                None
+            };
+            let observed_pid = process.as_ref().and_then(|process| process.pid);
+            let start_identity = process
+                .as_ref()
+                .map(|process| process.start_identity.clone())
+                .unwrap_or_default();
+            if session_id.trim().is_empty() {
+                return Ok(Probe {
+                    status: ResourceStatus::Unrecoverable,
+                    pid: observed_pid,
+                    start_identity,
+                    detail: "browser target has no session identity to probe".to_string(),
+                });
             }
-            Ok(process)
+            if session_probe_url.trim().is_empty() {
+                return Ok(Probe {
+                    status: if process.is_some() {
+                        ResourceStatus::Unknown
+                    } else {
+                        ResourceStatus::Expired
+                    },
+                    pid: observed_pid,
+                    start_identity,
+                    detail: "browser session has no semantic session probe".to_string(),
+                });
+            }
+            let (status, detail) = match probe_http(session_probe_url) {
+                HttpProbe::Response { status, body }
+                    if (200..300).contains(&status)
+                        && browser_session_attested(&body, session_id) =>
+                {
+                    (
+                        ResourceStatus::Live,
+                        "browser session probe attested the declared session".to_string(),
+                    )
+                }
+                HttpProbe::Response { status, .. } => (
+                    ResourceStatus::Expired,
+                    format!(
+                        "browser session probe HTTP {status} did not attest the declared session"
+                    ),
+                ),
+                HttpProbe::Unavailable(detail) => (ResourceStatus::Unknown, detail),
+                HttpProbe::Unrecoverable(detail) => (ResourceStatus::Unrecoverable, detail),
+            };
+            Ok(Probe {
+                status,
+                pid: observed_pid,
+                start_identity,
+                detail,
+            })
         }
     }
 }
@@ -421,26 +583,24 @@ fn lifecycle_result(
     ws: &Workspace,
     resource: &RuntimeResource,
     operation: ResourceOperationKind,
-    expected_status: Option<ResourceStatus>,
+    expected_status: ResourceStatus,
     requested_event: &str,
     action_id: &str,
 ) -> Result<(ResourceActionStatus, ResourceActionResult, String)> {
     let probe = probe_resource(ws, resource)?;
-    if let Some(expected) = expected_status {
-        if probe.status != expected {
-            let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
-            return Ok((
-                ResourceActionStatus::Rejected,
-                ResourceActionResult {
-                    observation: Some(observation),
-                    ..Default::default()
-                },
-                format!(
-                    "expected status {:?}, current probe found {:?}",
-                    expected, probe.status
-                ),
-            ));
-        }
+    if probe.status != expected_status {
+        let observation = persist_probe(ws, resource, &probe, requested_event, action_id)?;
+        return Ok((
+            ResourceActionStatus::Rejected,
+            ResourceActionResult {
+                observation: Some(observation),
+                ..Default::default()
+            },
+            format!(
+                "expected status {:?}, current probe found {:?}",
+                expected_status, probe.status
+            ),
+        ));
     }
 
     if operation == ResourceOperationKind::Reconcile {
@@ -601,22 +761,25 @@ fn lifecycle_result(
     }
 }
 
-fn discover_entries(ws: &Workspace, task_id: &str) -> Result<Vec<ResourceEntry>> {
+fn discover_entries(ws: &Workspace, intent_id: &str, task_id: &str) -> Result<Vec<ResourceEntry>> {
     let index = ws.load_or_rebuild_resource_index()?;
     let mut entries = Vec::new();
-    let task_index = index.tasks.iter().find(|entry| entry.task_id == task_id);
+    let task_index = index
+        .tasks
+        .iter()
+        .find(|entry| entry.intent_id == intent_id && entry.task_id == task_id);
     if task_index.is_none_or(|entry| entry.truncated) {
         for artifact in ws
             .load_artifacts()?
             .into_iter()
-            .filter(|artifact| artifact.task_id == task_id)
+            .filter(|artifact| artifact.intent_id == intent_id && artifact.task_id == task_id)
         {
             entries.push(artifact_entry(ws, artifact));
         }
         for resource in ws
             .load_runtime_resources()?
             .into_iter()
-            .filter(|resource| resource.task_id == task_id)
+            .filter(|resource| resource.intent_id == intent_id && resource.task_id == task_id)
         {
             entries.push(runtime_entry(ws, resource)?);
         }
@@ -661,6 +824,24 @@ fn open_target(entry: &ResourceEntry) -> ResourceOpenTarget {
         ResourceEntry::Artifact { open_target, .. }
         | ResourceEntry::RuntimeResource { open_target, .. } => open_target.clone(),
     }
+}
+
+fn operation_capability(operation: ResourceOperationKind) -> Option<ResourceCapability> {
+    match operation {
+        ResourceOperationKind::Discover | ResourceOperationKind::Inspect => None,
+        ResourceOperationKind::Open => Some(ResourceCapability::Open),
+        ResourceOperationKind::Attach => Some(ResourceCapability::Attach),
+        ResourceOperationKind::Stop => Some(ResourceCapability::Stop),
+        ResourceOperationKind::Restart => Some(ResourceCapability::Restart),
+        ResourceOperationKind::Detach => Some(ResourceCapability::Detach),
+        ResourceOperationKind::Cleanup => Some(ResourceCapability::Cleanup),
+        ResourceOperationKind::Reconcile => Some(ResourceCapability::Reconcile),
+    }
+}
+
+fn runtime_supports(resource: &RuntimeResource, operation: ResourceOperationKind) -> bool {
+    operation_capability(operation)
+        .is_none_or(|capability| resource.capabilities.contains(&capability))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -728,10 +909,10 @@ pub fn dispatch(
 
     let (entries, context_entry) = match request.operation {
         ResourceOperationKind::Discover => {
-            if request.task_id.trim().is_empty() {
-                bail!("discover requires task_id");
+            if request.intent_id.trim().is_empty() || request.task_id.trim().is_empty() {
+                bail!("discover requires intent_id and task_id");
             }
-            let entries = discover_entries(ws, &request.task_id)?;
+            let entries = discover_entries(ws, &request.intent_id, &request.task_id)?;
             let context = entries.first().cloned();
             (entries, context)
         }
@@ -751,6 +932,9 @@ pub fn dispatch(
     let session_id = session_id.to_string();
     let intent_id = intent_id.to_string();
     let actual_task_id = actual_task_id.to_string();
+    if !request.intent_id.is_empty() && request.intent_id != intent_id {
+        bail!("resource intent linkage conflict");
+    }
     if !request.task_id.is_empty() && request.task_id != actual_task_id {
         bail!("resource task linkage conflict");
     }
@@ -777,22 +961,40 @@ pub fn dispatch(
             },
             String::new(),
         ),
-        ResourceOperationKind::Open => (
-            ResourceActionStatus::Completed,
-            ResourceActionResult {
-                entries,
-                open_target: Some(open_target(&context_entry)),
-                observation: None,
-            },
-            String::new(),
-        ),
+        ResourceOperationKind::Open => match &context_entry {
+            ResourceEntry::RuntimeResource { resource, .. }
+                if !runtime_supports(resource, ResourceOperationKind::Open) =>
+            {
+                (
+                    ResourceActionStatus::Rejected,
+                    ResourceActionResult::default(),
+                    "open is unsupported for this runtime resource".to_string(),
+                )
+            }
+            _ => (
+                ResourceActionStatus::Completed,
+                ResourceActionResult {
+                    entries,
+                    open_target: Some(open_target(&context_entry)),
+                    observation: None,
+                },
+                String::new(),
+            ),
+        },
         ResourceOperationKind::Attach => {
             let target = open_target(&context_entry);
-            if matches!(
-                target,
-                ResourceOpenTarget::TerminalSession { .. }
-                    | ResourceOpenTarget::ProcessMonitor { .. }
-            ) {
+            let supported = matches!(
+                &context_entry,
+                ResourceEntry::RuntimeResource { resource, .. }
+                    if runtime_supports(resource, ResourceOperationKind::Attach)
+            );
+            if supported
+                && matches!(
+                    target,
+                    ResourceOpenTarget::TerminalSession { .. }
+                        | ResourceOpenTarget::ProcessMonitor { .. }
+                )
+            {
                 (
                     ResourceActionStatus::Completed,
                     ResourceActionResult {
@@ -821,16 +1023,27 @@ pub fn dispatch(
                 "lifecycle operation is unsupported for artifacts".to_string(),
             ),
             ResourceEntry::RuntimeResource { resource, .. } => {
-                let (status, mut result, error) = lifecycle_result(
-                    ws,
-                    resource,
-                    operation,
-                    request.expected_status,
-                    &requested_event,
-                    &request.action_id,
-                )?;
-                result.entries = entries;
-                (status, result, error)
+                if !runtime_supports(resource, operation) {
+                    (
+                        ResourceActionStatus::Rejected,
+                        ResourceActionResult::default(),
+                        format!(
+                            "{} is unsupported for this runtime resource",
+                            format!("{operation:?}").to_lowercase()
+                        ),
+                    )
+                } else {
+                    let (status, mut result, error) = lifecycle_result(
+                        ws,
+                        resource,
+                        operation,
+                        request.expected_status,
+                        &requested_event,
+                        &request.action_id,
+                    )?;
+                    result.entries = entries;
+                    (status, result, error)
+                }
             }
         },
     };
@@ -860,6 +1073,7 @@ pub fn dispatch(
         schema_version: 1,
         action_id: request.action_id,
         operation: request.operation,
+        intent_id,
         task_id: actual_task_id,
         target_id: request.target_id,
         request_digest: digest,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1027,6 +1027,11 @@ fn lifecycle_result(
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
                 .stderr(Stdio::null());
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::CommandExt;
+                child.process_group(0);
+            }
             let child = child.spawn().context("starting owned resource")?;
             let pid = child.id();
             drop(child);

--- a/src/run.rs
+++ b/src/run.rs
@@ -4494,6 +4494,25 @@ fn artifact_media_type(path: &std::path::Path) -> &'static str {
     }
 }
 
+fn finalization_artifact_causation(
+    events: &[ChannelEvent],
+    attempt_id: &str,
+) -> Option<String> {
+    for event_type in [
+        ChannelEventType::ValidationCompleted,
+        ChannelEventType::WorkerCompleted,
+        ChannelEventType::AttemptPrepared,
+    ] {
+        if let Some(event) = events.iter().rev().find(|event| {
+            event.attempt_id.as_deref() == Some(attempt_id)
+                && event.event_type == event_type
+        }) {
+            return Some(event.event_id.clone());
+        }
+    }
+    None
+}
+
 fn record_artifact_created(
     ws: &Workspace,
     context: &ChannelRunContext,
@@ -4509,59 +4528,42 @@ fn record_artifact_created(
     let bytes = std::fs::read(path)
         .with_context(|| format!("reading artifact for channel event {}", path.display()))?;
     let content_digest = artifact_content_digest(&bytes);
-    let seed = format!("{attempt_id}\0{role}\0{recorded_path}\0{content_digest}");
-    let artifact_id = format!(
-        "art_{}",
-        artifact_content_digest(seed.as_bytes()).trim_start_matches("fnv1a64:")
-    );
     let channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
-    if let Some(existing) = channel.events.iter().find(|event| {
-        event.event_type == ChannelEventType::ArtifactCreated
-            && event.payload["artifact_id"] == artifact_id
-    }) {
-        if existing.payload["content_digest"] == content_digest
-            && existing.attempt_id.as_deref() == Some(attempt_id)
-        {
-            return Ok(());
-        }
-        bail!("artifact event conflict for {artifact_id}");
-    }
     let worker_id = channel
         .attempts
         .iter()
         .find(|attempt| attempt.attempt_id == attempt_id)
         .map(|attempt| attempt.worker_id.clone())
         .ok_or_else(|| anyhow!("artifact producer attempt missing: {attempt_id}"))?;
-    let causation_id = channel.events.last().map(|event| event.event_id.clone());
-    record_channel_event(
-        ws,
-        None,
-        context,
-        ChannelEventType::ArtifactCreated,
-        if worker_authored {
-            EventActor {
-                kind: EventActorKind::Worker,
-                id: worker_id.clone(),
-            }
-        } else {
-            EventActor {
-                kind: EventActorKind::System,
-                id: String::new(),
-            }
-        },
-        Some(attempt_id),
+    let causation_id = finalization_artifact_causation(&channel.events, attempt_id)
+        .unwrap_or_else(|| format!("attempt:{attempt_id}"));
+    let artifact_role = match role {
+        "handoff" | "checkpoint" => crate::schemas::ArtifactRole::Handoff,
+        "evaluation" => crate::schemas::ArtifactRole::ValidationOutput,
+        _ => crate::schemas::ArtifactRole::File,
+    };
+    let proposal = crate::schemas::ArtifactProposal {
+        proposal_id: format!(
+            "core-{}",
+            artifact_content_digest(format!("{attempt_id}\0{role}\0{recorded_path}").as_bytes())
+                .trim_start_matches("fnv1a64:")
+        ),
+        task_id: context.task_id.clone(),
+        attempt_id: attempt_id.to_string(),
+        producer: crate::schemas::ResourceProducer { worker_id },
         causation_id,
-        serde_json::json!({
-            "artifact_id": artifact_id,
-            "path": recorded_path,
-            "content_digest": content_digest,
-            "media_type": artifact_media_type(path),
-            "role": role,
-            "producer_attempt_id": attempt_id,
-            "producer_worker_id": worker_id
-        }),
-        None,
+        path: recorded_path.to_string(),
+        digest: content_digest,
+        media_type: artifact_media_type(path).to_string(),
+        role: artifact_role,
+    };
+    ws.publish_artifact(
+        &context.session_id,
+        &context.intent_id,
+        &proposal,
+        &path.display().to_string(),
     )?;
+    let _ = worker_authored;
     Ok(())
 }
 
@@ -4606,6 +4608,23 @@ fn record_finalization_artifacts(
         ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
         return Ok(());
     };
+    if result.resource_provenance_errors(&attempt_id).is_empty() {
+        crate::resource::ingest_run_proposals(
+            ws,
+            &context.session_id,
+            &context.intent_id,
+            &context.task_id,
+            &attempt_id,
+            &ws.load_task_channel(&context.intent_id, &context.task_id)?
+                .attempts
+                .into_iter()
+                .find(|attempt| attempt.attempt_id == attempt_id)
+                .ok_or_else(|| anyhow!("resource producer attempt missing: {attempt_id}"))?
+                .worker_id,
+            worker_root,
+            result,
+        )?;
+    }
     let Ok(canonical_root) = std::fs::canonicalize(worker_root) else {
         return Ok(());
     };
@@ -5858,6 +5877,69 @@ pub fn latest_question_for(ws: &Workspace, task_id: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    fn channel_event(
+        event_id: &str,
+        event_type: ChannelEventType,
+        attempt_id: Option<&str>,
+    ) -> ChannelEvent {
+        ChannelEvent {
+            schema_version: 1,
+            event_id: event_id.into(),
+            session_id: "session-test".into(),
+            seq: 0,
+            event_type,
+            recorded_at: String::new(),
+            actor: EventActor {
+                kind: EventActorKind::System,
+                id: String::new(),
+            },
+            action_id: None,
+            causation_id: None,
+            correlation_id: "cor-test".into(),
+            task_id: "YARD-001".into(),
+            attempt_id: attempt_id.map(str::to_string),
+            payload: serde_json::Value::Null,
+            raw_ref: None,
+        }
+    }
+
+    #[test]
+    fn finalization_artifact_causation_is_stable_across_recovery_publications() {
+        let attempt_id = "run-test";
+        let mut events = vec![
+            channel_event(
+                "evt-attempt",
+                ChannelEventType::AttemptPrepared,
+                Some(attempt_id),
+            ),
+            channel_event(
+                "evt-worker",
+                ChannelEventType::WorkerCompleted,
+                Some(attempt_id),
+            ),
+            channel_event(
+                "evt-validation",
+                ChannelEventType::ValidationCompleted,
+                Some(attempt_id),
+            ),
+        ];
+
+        assert_eq!(
+            finalization_artifact_causation(&events, attempt_id),
+            Some("evt-validation".to_string())
+        );
+
+        events.push(channel_event(
+            "evt-artifact",
+            ChannelEventType::ArtifactCreated,
+            Some(attempt_id),
+        ));
+        assert_eq!(
+            finalization_artifact_causation(&events, attempt_id),
+            Some("evt-validation".to_string())
+        );
+    }
+
     #[test]
     fn every_invocation_ordinal_gets_a_distinct_attempt_identity() {
         assert_eq!(attempt_id_for_ordinal("run-1", 1), "run-1");
@@ -6041,6 +6123,8 @@ mod tests {
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &rd.join("result.json"),
@@ -6974,6 +7058,8 @@ mod tests {
             }],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
 
         let run1 = ws.runs_dir().join("run-1");
@@ -9483,6 +9569,8 @@ exit 1
                 verdict: vec![],
                 harness_suggestions: vec![],
                 follow_up_tasks: vec![],
+                artifacts: vec![],
+                resources: vec![],
             };
             write_str(
                 &run_dir.join("result.json"),
@@ -9696,6 +9784,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -9776,6 +9866,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -9886,6 +9978,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -9986,6 +10080,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &staged_run_dir.join("result.json"),
@@ -10170,6 +10266,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10401,6 +10499,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10463,6 +10563,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10540,6 +10642,8 @@ exit 1
                 insert: String::new(),
                 runs_before: vec![],
             }],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10603,6 +10707,8 @@ exit 1
                 risk: "low".into(),
                 ..Default::default()
             }],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10683,6 +10789,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10771,6 +10879,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -10893,6 +11003,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         write_str(
             &run_dir.join("result.json"),
@@ -11035,6 +11147,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         result.validation.passed = true;
         write_str(
@@ -11231,6 +11345,8 @@ exit 1
             verdict: vec![],
             harness_suggestions: vec![],
             follow_up_tasks: vec![],
+            artifacts: vec![],
+            resources: vec![],
         };
         result.validation.passed = true;
         write_str(
@@ -11469,6 +11585,8 @@ exit 1
                 verdict: vec![],
                 harness_suggestions: vec![],
                 follow_up_tasks: vec![],
+                artifacts: vec![],
+                resources: vec![],
             };
             result.validation.passed = true;
             write_str(

--- a/src/run.rs
+++ b/src/run.rs
@@ -1454,7 +1454,11 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         .unwrap_or_else(|_| candidate_id.clone());
 
     // ---- run directory ---------------------------------------------------
-    let base_run_id = format!("run-{}", Local::now().format("%Y%m%d-%H%M%S"));
+    let base_run_id = format!(
+        "run-{}-{}",
+        Local::now().format("%Y%m%d-%H%M%S%9f"),
+        std::process::id()
+    );
     let (run_id, run_dir) = ws.claim_run_dir(&base_run_id)?;
     std::fs::create_dir_all(run_dir.join("evidence"))?;
     let serial_worktree = if opts.execute {

--- a/src/run.rs
+++ b/src/run.rs
@@ -4494,18 +4494,14 @@ fn artifact_media_type(path: &std::path::Path) -> &'static str {
     }
 }
 
-fn finalization_artifact_causation(
-    events: &[ChannelEvent],
-    attempt_id: &str,
-) -> Option<String> {
+fn finalization_artifact_causation(events: &[ChannelEvent], attempt_id: &str) -> Option<String> {
     for event_type in [
         ChannelEventType::ValidationCompleted,
         ChannelEventType::WorkerCompleted,
         ChannelEventType::AttemptPrepared,
     ] {
         if let Some(event) = events.iter().rev().find(|event| {
-            event.attempt_id.as_deref() == Some(attempt_id)
-                && event.event_type == event_type
+            event.attempt_id.as_deref() == Some(attempt_id) && event.event_type == event_type
         }) {
             return Some(event.event_id.clone());
         }
@@ -4536,7 +4532,7 @@ fn record_artifact_created(
         .map(|attempt| attempt.worker_id.clone())
         .ok_or_else(|| anyhow!("artifact producer attempt missing: {attempt_id}"))?;
     let causation_id = finalization_artifact_causation(&channel.events, attempt_id)
-        .unwrap_or_else(|| format!("attempt:{attempt_id}"));
+        .unwrap_or_else(|| attempt_id.to_string());
     let artifact_role = match role {
         "handoff" | "checkpoint" => crate::schemas::ArtifactRole::Handoff,
         "evaluation" => crate::schemas::ArtifactRole::ValidationOutput,
@@ -4545,8 +4541,10 @@ fn record_artifact_created(
     let proposal = crate::schemas::ArtifactProposal {
         proposal_id: format!(
             "core-{}",
-            artifact_content_digest(format!("{attempt_id}\0{role}\0{recorded_path}").as_bytes())
-                .trim_start_matches("fnv1a64:")
+            artifact_content_digest(
+                format!("{attempt_id}\0{role}\0{recorded_path}\0{content_digest}").as_bytes(),
+            )
+            .trim_start_matches("fnv1a64:")
         ),
         task_id: context.task_id.clone(),
         attempt_id: attempt_id.to_string(),
@@ -4556,6 +4554,7 @@ fn record_artifact_created(
         digest: content_digest,
         media_type: artifact_media_type(path).to_string(),
         role: artifact_role,
+        channel_role: role.to_string(),
     };
     ws.publish_artifact(
         &context.session_id,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1563,12 +1563,12 @@ impl RunResult {
     pub fn resource_provenance_errors(&self, attempt_id: &str) -> Vec<String> {
         let mut errors = Vec::new();
         for proposal in &self.artifacts {
-            if let Err(error) = proposal.validate_provenance(&self.task_id, attempt_id) {
+            if let Err(error) = proposal.validate_worker_provenance(&self.task_id, attempt_id) {
                 errors.push(format!("artifact {}: {error}", proposal.proposal_id));
             }
         }
         for proposal in &self.resources {
-            if let Err(error) = proposal.validate_provenance(&self.task_id, attempt_id) {
+            if let Err(error) = proposal.validate_worker_provenance(&self.task_id, attempt_id) {
                 errors.push(format!("resource {}: {error}", proposal.proposal_id));
             }
         }
@@ -1616,6 +1616,10 @@ pub struct ArtifactProposal {
     #[serde(default)]
     pub media_type: String,
     pub role: ArtifactRole,
+    /// More specific existing task-channel projection label for core-generated
+    /// run artifacts. Worker proposals leave this empty and use `role`.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub channel_role: String,
 }
 
 impl ArtifactProposal {
@@ -1630,6 +1634,18 @@ impl ArtifactProposal {
             || self.media_type.trim().is_empty()
         {
             return Err("artifact proposal lacks exact task/attempt/producer evidence".into());
+        }
+        Ok(())
+    }
+
+    pub fn validate_worker_provenance(
+        &self,
+        task_id: &str,
+        attempt_id: &str,
+    ) -> Result<(), String> {
+        self.validate_provenance(task_id, attempt_id)?;
+        if self.causation_id != attempt_id {
+            return Err("artifact proposal causation must name its exact attempt".into());
         }
         Ok(())
     }
@@ -1652,6 +1668,8 @@ pub struct Artifact {
     pub digest: String,
     pub media_type: String,
     pub role: ArtifactRole,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub channel_role: String,
     pub created_event_id: String,
     pub published_seq: u64,
     pub recorded_at: String,
@@ -1791,6 +1809,18 @@ impl RuntimeResourceProposal {
         }
         self.target.validate()
     }
+
+    pub fn validate_worker_provenance(
+        &self,
+        task_id: &str,
+        attempt_id: &str,
+    ) -> Result<(), String> {
+        self.validate_provenance(task_id, attempt_id)?;
+        if self.causation_id != attempt_id {
+            return Err("resource proposal causation must name its exact attempt".into());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1848,12 +1878,26 @@ pub struct ResourceObservation {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceTaskIndex {
+    pub task_id: String,
+    pub artifacts: Vec<String>,
+    pub resources: Vec<String>,
+    pub attempts: Vec<String>,
+    #[serde(default)]
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResourceIndex {
     pub schema_version: u32,
     pub canonical_digest: String,
     pub artifacts: Vec<String>,
     pub resources: Vec<String>,
     pub attempts: Vec<String>,
+    #[serde(default)]
+    pub tasks: Vec<ResourceTaskIndex>,
+    #[serde(default)]
+    pub tasks_truncated: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1675,20 +1675,15 @@ pub struct Artifact {
     pub recorded_at: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResourceOwnership {
     Yardlet,
     Worker,
     User,
     External,
+    #[default]
     Unknown,
-}
-
-impl Default for ResourceOwnership {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1957,6 +1952,7 @@ pub enum ResourceOpenTarget {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "entry_type", rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum ResourceEntry {
     Artifact {
         artifact: Artifact,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1549,6 +1549,411 @@ pub struct RunResult {
     /// Yardlet assigns ids/priority and is the sole writer of the queue.
     #[serde(default)]
     pub follow_up_tasks: Vec<FollowUpTask>,
+    /// Durable evidence proposals authored by the worker. Yardlet validates
+    /// exact task/attempt/producer linkage and writes canonical declarations.
+    #[serde(default)]
+    pub artifacts: Vec<ArtifactProposal>,
+    /// Live target proposals authored by the worker. These are declarations,
+    /// never current-liveness claims; the core records probe observations.
+    #[serde(default)]
+    pub resources: Vec<RuntimeResourceProposal>,
+}
+
+impl RunResult {
+    pub fn resource_provenance_errors(&self, attempt_id: &str) -> Vec<String> {
+        let mut errors = Vec::new();
+        for proposal in &self.artifacts {
+            if let Err(error) = proposal.validate_provenance(&self.task_id, attempt_id) {
+                errors.push(format!("artifact {}: {error}", proposal.proposal_id));
+            }
+        }
+        for proposal in &self.resources {
+            if let Err(error) = proposal.validate_provenance(&self.task_id, attempt_id) {
+                errors.push(format!("resource {}: {error}", proposal.proposal_id));
+            }
+        }
+        errors
+    }
+}
+
+// ---------------------------------------------------------------------------
+// V010-004 runtime resources and durable artifacts
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceProducer {
+    #[serde(default)]
+    pub worker_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRole {
+    File,
+    Screenshot,
+    GitDiff,
+    ValidationOutput,
+    ReviewReport,
+    Handoff,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactProposal {
+    #[serde(default)]
+    pub proposal_id: String,
+    #[serde(default)]
+    pub task_id: String,
+    #[serde(default)]
+    pub attempt_id: String,
+    #[serde(default)]
+    pub producer: ResourceProducer,
+    #[serde(default)]
+    pub causation_id: String,
+    #[serde(default)]
+    pub path: String,
+    #[serde(default)]
+    pub digest: String,
+    #[serde(default)]
+    pub media_type: String,
+    pub role: ArtifactRole,
+}
+
+impl ArtifactProposal {
+    pub fn validate_provenance(&self, task_id: &str, attempt_id: &str) -> Result<(), String> {
+        if self.proposal_id.trim().is_empty()
+            || self.task_id != task_id
+            || self.attempt_id != attempt_id
+            || self.producer.worker_id.trim().is_empty()
+            || self.causation_id.trim().is_empty()
+            || self.path.trim().is_empty()
+            || self.digest.trim().is_empty()
+            || self.media_type.trim().is_empty()
+        {
+            return Err("artifact proposal lacks exact task/attempt/producer evidence".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Artifact {
+    pub schema_version: u32,
+    pub artifact_id: String,
+    pub proposal_id: String,
+    pub session_id: String,
+    pub intent_id: String,
+    pub task_id: String,
+    pub attempt_id: String,
+    pub producer: ResourceProducer,
+    pub causation_id: String,
+    pub path: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub source_path: String,
+    pub digest: String,
+    pub media_type: String,
+    pub role: ArtifactRole,
+    pub created_event_id: String,
+    pub published_seq: u64,
+    pub recorded_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceOwnership {
+    Yardlet,
+    Worker,
+    User,
+    External,
+    Unknown,
+}
+
+impl Default for ResourceOwnership {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RuntimeResourceTarget {
+    Terminal {
+        terminal_id: String,
+        pid: u32,
+        start_identity: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        attach_hint: String,
+    },
+    Process {
+        pid: u32,
+        start_identity: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        command: Vec<String>,
+    },
+    Service {
+        url: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        health_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pid: Option<u32>,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        start_identity: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        restart_command: Vec<String>,
+    },
+    Browser {
+        url: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        session_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pid: Option<u32>,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        start_identity: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        screenshot_artifact_id: String,
+    },
+}
+
+impl RuntimeResourceTarget {
+    pub fn validate(&self) -> Result<(), String> {
+        match self {
+            Self::Terminal {
+                terminal_id,
+                pid,
+                start_identity,
+                ..
+            } => {
+                if terminal_id.trim().is_empty() || *pid == 0 || start_identity.trim().is_empty() {
+                    return Err(
+                        "terminal target requires terminal_id, pid, and start_identity".into(),
+                    );
+                }
+            }
+            Self::Process {
+                pid,
+                start_identity,
+                ..
+            } => {
+                if *pid == 0 || start_identity.trim().is_empty() {
+                    return Err("process target requires pid and start_identity".into());
+                }
+            }
+            Self::Service {
+                url,
+                pid,
+                start_identity,
+                ..
+            } => {
+                if url.trim().is_empty() || (pid.is_some() && start_identity.trim().is_empty()) {
+                    return Err("service target requires url and identity for any pid".into());
+                }
+            }
+            Self::Browser {
+                url,
+                pid,
+                start_identity,
+                ..
+            } => {
+                if url.trim().is_empty() || (pid.is_some() && start_identity.trim().is_empty()) {
+                    return Err("browser target requires url and identity for any pid".into());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeResourceProposal {
+    #[serde(default)]
+    pub proposal_id: String,
+    #[serde(default)]
+    pub task_id: String,
+    #[serde(default)]
+    pub attempt_id: String,
+    #[serde(default)]
+    pub producer: ResourceProducer,
+    #[serde(default)]
+    pub causation_id: String,
+    #[serde(default)]
+    pub ownership: ResourceOwnership,
+    pub target: RuntimeResourceTarget,
+}
+
+impl RuntimeResourceProposal {
+    pub fn validate_provenance(&self, task_id: &str, attempt_id: &str) -> Result<(), String> {
+        if self.proposal_id.trim().is_empty()
+            || self.task_id != task_id
+            || self.attempt_id != attempt_id
+            || self.producer.worker_id.trim().is_empty()
+            || self.causation_id.trim().is_empty()
+        {
+            return Err("resource proposal lacks exact task/attempt/producer evidence".into());
+        }
+        self.target.validate()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeResource {
+    pub schema_version: u32,
+    pub resource_id: String,
+    pub proposal_id: String,
+    pub session_id: String,
+    pub intent_id: String,
+    pub task_id: String,
+    pub attempt_id: String,
+    pub producer: ResourceProducer,
+    pub causation_id: String,
+    pub ownership: ResourceOwnership,
+    pub target: RuntimeResourceTarget,
+    pub created_event_id: String,
+    pub published_seq: u64,
+    pub recorded_at: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceStatus {
+    Unknown,
+    Available,
+    Live,
+    Dead,
+    Unavailable,
+    Expired,
+    Orphaned,
+    Unrecoverable,
+    Detached,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceObservation {
+    pub schema_version: u32,
+    pub observation_id: String,
+    pub resource_id: String,
+    pub task_id: String,
+    pub attempt_id: String,
+    pub status: ResourceStatus,
+    pub observed_at: String,
+    #[serde(default)]
+    pub current: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub start_identity: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub detail: String,
+    pub causation_id: String,
+    pub event_id: String,
+    pub seq: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceIndex {
+    pub schema_version: u32,
+    pub canonical_digest: String,
+    pub artifacts: Vec<String>,
+    pub resources: Vec<String>,
+    pub attempts: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceOperationKind {
+    Discover,
+    Inspect,
+    Open,
+    Attach,
+    Stop,
+    Restart,
+    Detach,
+    Cleanup,
+    Reconcile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceOperationRequest {
+    pub action_id: String,
+    pub operation: ResourceOperationKind,
+    #[serde(default)]
+    pub task_id: String,
+    #[serde(default)]
+    pub target_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_status: Option<ResourceStatus>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceActionStatus {
+    Completed,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "target_type", rename_all = "snake_case")]
+pub enum ResourceOpenTarget {
+    File {
+        path: String,
+        media_type: String,
+    },
+    Url {
+        url: String,
+    },
+    TerminalSession {
+        terminal_id: String,
+        attach_hint: String,
+    },
+    ProcessMonitor {
+        pid: u32,
+    },
+    Unavailable {
+        reason: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "entry_type", rename_all = "snake_case")]
+pub enum ResourceEntry {
+    Artifact {
+        artifact: Artifact,
+        status: ResourceStatus,
+        open_target: ResourceOpenTarget,
+    },
+    RuntimeResource {
+        resource: RuntimeResource,
+        status: ResourceStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        last_observation: Option<ResourceObservation>,
+        open_target: ResourceOpenTarget,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceActionResult {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entries: Vec<ResourceEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_target: Option<ResourceOpenTarget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observation: Option<ResourceObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceActionReceipt {
+    pub schema_version: u32,
+    pub action_id: String,
+    pub operation: ResourceOperationKind,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub target_id: String,
+    pub request_digest: String,
+    pub status: ResourceActionStatus,
+    #[serde(default)]
+    pub result: ResourceActionResult,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub result_event_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub error: String,
 }
 
 /// A follow-up task a worker PROPOSES in its result (propose -> ingest). A
@@ -1681,6 +2086,9 @@ pub enum ChannelEventType {
     QuestionClosed,
     UserAnswered,
     ArtifactCreated,
+    ResourceDeclared,
+    ResourceObserved,
+    ResourceStateChanged,
     ValidationStarted,
     ValidationCompleted,
     WorkerCompleted,
@@ -1705,6 +2113,9 @@ impl ChannelEventType {
             Self::QuestionClosed => "question.closed",
             Self::UserAnswered => "user.answered",
             Self::ArtifactCreated => "artifact.created",
+            Self::ResourceDeclared => "resource.declared",
+            Self::ResourceObserved => "resource.observed",
+            Self::ResourceStateChanged => "resource.state.changed",
             Self::ValidationStarted => "validation.started",
             Self::ValidationCompleted => "validation.completed",
             Self::WorkerCompleted => "worker.completed",
@@ -1728,6 +2139,9 @@ impl ChannelEventType {
                 | Self::QuestionAsked
                 | Self::QuestionClosed
                 | Self::ArtifactCreated
+                | Self::ResourceDeclared
+                | Self::ResourceObserved
+                | Self::ResourceStateChanged
                 | Self::ValidationStarted
                 | Self::ValidationCompleted
                 | Self::WorkerCompleted
@@ -1763,6 +2177,9 @@ impl<'de> Deserialize<'de> for ChannelEventType {
             "question.closed" => Self::QuestionClosed,
             "user.answered" => Self::UserAnswered,
             "artifact.created" => Self::ArtifactCreated,
+            "resource.declared" => Self::ResourceDeclared,
+            "resource.observed" => Self::ResourceObserved,
+            "resource.state.changed" => Self::ResourceStateChanged,
             "validation.started" => Self::ValidationStarted,
             "validation.completed" => Self::ValidationCompleted,
             "worker.completed" => Self::WorkerCompleted,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -2018,6 +2018,46 @@ pub enum ResourceActionStatus {
     Rejected,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceActionRecoveryPhase {
+    Prepared,
+    Terminated,
+    Spawned,
+}
+
+impl ResourceActionRecoveryPhase {
+    pub fn rank(self) -> u8 {
+        match self {
+            Self::Prepared => 0,
+            Self::Terminated => 1,
+            Self::Spawned => 2,
+        }
+    }
+}
+
+/// Durable, non-terminal action progress. The terminal receipt remains an
+/// immutable `ResourceActionReceipt`; this snapshot only prevents a recovered
+/// stop/restart action from repeating an external side effect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceActionRecoveryReceipt {
+    pub schema_version: u32,
+    pub action_id: String,
+    pub request_digest: String,
+    pub operation: ResourceOperationKind,
+    pub intent_id: String,
+    pub task_id: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub target_id: String,
+    pub expected_status: ResourceStatus,
+    pub requested_event_id: String,
+    pub phase: ResourceActionRecoveryPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effect_pid: Option<u32>,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub effect_start_identity: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "target_type", rename_all = "snake_case")]
 pub enum ResourceOpenTarget {

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1686,6 +1686,18 @@ pub enum ResourceOwnership {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceCapability {
+    Open,
+    Attach,
+    Stop,
+    Restart,
+    Detach,
+    Cleanup,
+    Reconcile,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum RuntimeResourceTarget {
@@ -1717,6 +1729,8 @@ pub enum RuntimeResourceTarget {
         url: String,
         #[serde(default, skip_serializing_if = "String::is_empty")]
         session_id: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        session_probe_url: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pid: Option<u32>,
         #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -1727,6 +1741,73 @@ pub enum RuntimeResourceTarget {
 }
 
 impl RuntimeResourceTarget {
+    pub fn inferred_capabilities(&self) -> Vec<ResourceCapability> {
+        use ResourceCapability as Capability;
+
+        let mut capabilities = match self {
+            Self::Terminal { .. } => vec![
+                Capability::Open,
+                Capability::Attach,
+                Capability::Stop,
+                Capability::Detach,
+                Capability::Cleanup,
+                Capability::Reconcile,
+            ],
+            Self::Process { command, .. } => {
+                let mut capabilities = vec![
+                    Capability::Open,
+                    Capability::Attach,
+                    Capability::Stop,
+                    Capability::Cleanup,
+                    Capability::Reconcile,
+                ];
+                if !command.is_empty() {
+                    capabilities.push(Capability::Restart);
+                }
+                capabilities
+            }
+            Self::Service {
+                pid,
+                restart_command,
+                ..
+            } => {
+                let mut capabilities = vec![Capability::Open, Capability::Reconcile];
+                if pid.is_some() {
+                    capabilities.extend([Capability::Stop, Capability::Cleanup]);
+                    if !restart_command.is_empty() {
+                        capabilities.push(Capability::Restart);
+                    }
+                }
+                capabilities
+            }
+            Self::Browser { .. } => vec![Capability::Open, Capability::Reconcile],
+        };
+        capabilities.sort_unstable();
+        capabilities
+    }
+
+    pub fn normalize_capabilities(
+        &self,
+        declared: &[ResourceCapability],
+    ) -> Result<Vec<ResourceCapability>, String> {
+        let supported = self.inferred_capabilities();
+        if declared.is_empty() {
+            return Ok(supported);
+        }
+        let mut normalized = declared.to_vec();
+        normalized.sort_unstable();
+        normalized.dedup();
+        if let Some(capability) = normalized
+            .iter()
+            .find(|capability| !supported.contains(capability))
+        {
+            return Err(format!(
+                "resource target cannot support declared capability {capability:?}"
+            ));
+        }
+        Ok(normalized)
+    }
+
     pub fn validate(&self) -> Result<(), String> {
         match self {
             Self::Terminal {
@@ -1789,6 +1870,8 @@ pub struct RuntimeResourceProposal {
     pub causation_id: String,
     #[serde(default)]
     pub ownership: ResourceOwnership,
+    #[serde(default)]
+    pub capabilities: Vec<ResourceCapability>,
     pub target: RuntimeResourceTarget,
 }
 
@@ -1802,7 +1885,10 @@ impl RuntimeResourceProposal {
         {
             return Err("resource proposal lacks exact task/attempt/producer evidence".into());
         }
-        self.target.validate()
+        self.target.validate()?;
+        self.target
+            .normalize_capabilities(&self.capabilities)
+            .map(|_| ())
     }
 
     pub fn validate_worker_provenance(
@@ -1830,6 +1916,8 @@ pub struct RuntimeResource {
     pub producer: ResourceProducer,
     pub causation_id: String,
     pub ownership: ResourceOwnership,
+    #[serde(default)]
+    pub capabilities: Vec<ResourceCapability>,
     pub target: RuntimeResourceTarget,
     pub created_event_id: String,
     pub published_seq: u64,
@@ -1874,6 +1962,7 @@ pub struct ResourceObservation {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResourceTaskIndex {
+    pub intent_id: String,
     pub task_id: String,
     pub artifacts: Vec<String>,
     pub resources: Vec<String>,
@@ -1914,11 +2003,12 @@ pub struct ResourceOperationRequest {
     pub action_id: String,
     pub operation: ResourceOperationKind,
     #[serde(default)]
+    pub intent_id: String,
+    #[serde(default)]
     pub task_id: String,
     #[serde(default)]
     pub target_id: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub expected_status: Option<ResourceStatus>,
+    pub expected_status: ResourceStatus,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1983,6 +2073,8 @@ pub struct ResourceActionReceipt {
     pub schema_version: u32,
     pub action_id: String,
     pub operation: ResourceOperationKind,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub intent_id: String,
     pub task_id: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub target_id: String,

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,12 +23,12 @@ use crate::schemas::{
     ChannelEvent, ChannelEventType, ContinuationMode, Conversation, ConversationTurn,
     DraftRevision, EventActor, EventActorKind, FollowUpTask, IntentContract, PlanningActionReceipt,
     PlanningEvent, PlanningProposal, PlanningSession, PreservedFollowUps, Question, QuestionState,
-    RedirectActionOutcome, RedirectActionRequest, ResourceActionReceipt, ResourceIndex,
-    ResourceObservation, ResourceStatus, ResourceTaskIndex, RuntimeCapabilityCommit,
-    RuntimeCapabilityReceipt, RuntimeResource, RuntimeResourceProposal, RuntimeTaskCommit,
-    RuntimeTaskReceipt, SelectionPolicy, Task, TaskChannel, TaskChannelIndex, TaskState,
-    TransitionActor, TransitionCause, TransitionLog, TransitionRecord, TurnRole, WorkQueue,
-    WorkerAttempt, WorkersFile, YardConfig,
+    RedirectActionOutcome, RedirectActionRequest, ResourceActionReceipt,
+    ResourceActionRecoveryReceipt, ResourceIndex, ResourceObservation, ResourceStatus,
+    ResourceTaskIndex, RuntimeCapabilityCommit, RuntimeCapabilityReceipt, RuntimeResource,
+    RuntimeResourceProposal, RuntimeTaskCommit, RuntimeTaskReceipt, SelectionPolicy, Task,
+    TaskChannel, TaskChannelIndex, TaskState, TransitionActor, TransitionCause, TransitionLog,
+    TransitionRecord, TurnRole, WorkQueue, WorkerAttempt, WorkersFile, YardConfig,
 };
 use crate::yaml;
 
@@ -2891,6 +2891,57 @@ impl Workspace {
             bail!("resource_action_conflict: {}", receipt.action_id);
         }
         save_immutable_yaml(&path, receipt)
+    }
+
+    pub fn load_resource_action_recovery(
+        &self,
+        action_id: &str,
+    ) -> Result<Option<ResourceActionRecoveryReceipt>> {
+        validate_action_id(action_id)?;
+        let path = contained_action_path(
+            &self.resource_actions_dir(),
+            &format!("{action_id}.recovery.yaml"),
+        )?;
+        if !path.is_file() {
+            return Ok(None);
+        }
+        load_yaml(&path).map(Some)
+    }
+
+    pub fn save_resource_action_recovery(
+        &self,
+        recovery: &ResourceActionRecoveryReceipt,
+    ) -> Result<()> {
+        validate_action_id(&recovery.action_id)?;
+        let path = contained_action_path(
+            &self.resource_actions_dir(),
+            &format!("{}.recovery.yaml", recovery.action_id),
+        )?;
+        if path.is_file() {
+            let existing: ResourceActionRecoveryReceipt = load_yaml(&path)?;
+            if existing == *recovery {
+                return Ok(());
+            }
+            let same_action = existing.action_id == recovery.action_id
+                && existing.request_digest == recovery.request_digest
+                && existing.operation == recovery.operation
+                && existing.intent_id == recovery.intent_id
+                && existing.task_id == recovery.task_id
+                && existing.target_id == recovery.target_id
+                && existing.expected_status == recovery.expected_status
+                && existing.requested_event_id == recovery.requested_event_id;
+            let fills_spawn_identity = existing.phase == recovery.phase
+                && existing.phase == crate::schemas::ResourceActionRecoveryPhase::Spawned
+                && existing.effect_pid == recovery.effect_pid
+                && existing.effect_start_identity.is_empty()
+                && !recovery.effect_start_identity.is_empty();
+            if !same_action
+                || (existing.phase.rank() >= recovery.phase.rank() && !fills_spawn_identity)
+            {
+                bail!("resource_action_recovery_conflict: {}", recovery.action_id);
+            }
+        }
+        write_str_atomic(&path, &yaml::to_string(recovery)?)
     }
 
     pub fn load_artifact(&self, artifact_id: &str) -> Result<Option<Artifact>> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -2520,6 +2520,10 @@ impl Workspace {
         proposal
             .validate_provenance(&proposal.task_id, &proposal.attempt_id)
             .map_err(anyhow::Error::msg)?;
+        let capabilities = proposal
+            .target
+            .normalize_capabilities(&proposal.capabilities)
+            .map_err(anyhow::Error::msg)?;
         self.validate_publication_attempt(
             intent_id,
             &proposal.task_id,
@@ -2541,6 +2545,7 @@ impl Workspace {
                 && existing.producer == proposal.producer
                 && existing.causation_id == causation_id
                 && existing.ownership == proposal.ownership
+                && existing.capabilities == capabilities
                 && existing.target == proposal.target;
             if same {
                 return Ok(existing);
@@ -2575,6 +2580,7 @@ impl Workspace {
                     "resource_id": resource_id,
                     "proposal_id": proposal.proposal_id,
                     "ownership": proposal.ownership,
+                    "capabilities": capabilities,
                     "target": proposal.target
                 }),
                 raw_ref: None,
@@ -2591,6 +2597,7 @@ impl Workspace {
             producer: proposal.producer.clone(),
             causation_id,
             ownership: proposal.ownership,
+            capabilities,
             target: proposal.target.clone(),
             created_event_id: event.event_id,
             published_seq: event.seq,
@@ -2790,11 +2797,12 @@ impl Workspace {
         if attempts.len() > RESOURCE_INDEX_ENTRY_LIMIT {
             attempts = attempts.split_off(attempts.len() - RESOURCE_INDEX_ENTRY_LIMIT);
         }
-        let mut task_entries = BTreeMap::<String, ResourceTaskIndex>::new();
+        let mut task_entries = BTreeMap::<(String, String), ResourceTaskIndex>::new();
         for artifact in &artifacts {
             let entry = task_entries
-                .entry(artifact.task_id.clone())
+                .entry((artifact.intent_id.clone(), artifact.task_id.clone()))
                 .or_insert_with(|| ResourceTaskIndex {
+                    intent_id: artifact.intent_id.clone(),
                     task_id: artifact.task_id.clone(),
                     artifacts: Vec::new(),
                     resources: Vec::new(),
@@ -2808,8 +2816,9 @@ impl Workspace {
         }
         for resource in &resources {
             let entry = task_entries
-                .entry(resource.task_id.clone())
+                .entry((resource.intent_id.clone(), resource.task_id.clone()))
                 .or_insert_with(|| ResourceTaskIndex {
+                    intent_id: resource.intent_id.clone(),
                     task_id: resource.task_id.clone(),
                     artifacts: Vec::new(),
                     resources: Vec::new(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,15 +18,17 @@ use serde::{Deserialize, Serialize};
 
 use crate::schemas::{
     ActionReceipt, ActivatedIntent, ActivatedQueue, ActivatedTask, ActivationReceipt,
-    ActivationRequirement, Answer, AnswerActionOutcome, AnswerActionRequest, AttemptState,
-    BillingPolicy, ChannelActionKind, ChannelActionStatus, ChannelEvent, ChannelEventType,
-    ContinuationMode, Conversation, ConversationTurn, DraftRevision, EventActor, EventActorKind,
-    FollowUpTask, IntentContract, PlanningActionReceipt, PlanningEvent, PlanningProposal,
-    PlanningSession, PreservedFollowUps, Question, QuestionState, RedirectActionOutcome,
-    RedirectActionRequest, RuntimeCapabilityCommit, RuntimeCapabilityReceipt, RuntimeTaskCommit,
-    RuntimeTaskReceipt, SelectionPolicy, Task, TaskChannel, TaskChannelIndex, TaskState,
-    TransitionActor, TransitionCause, TransitionLog, TransitionRecord, TurnRole, WorkQueue,
-    WorkerAttempt, WorkersFile, YardConfig,
+    ActivationRequirement, Answer, AnswerActionOutcome, AnswerActionRequest, Artifact,
+    ArtifactProposal, AttemptState, BillingPolicy, ChannelActionKind, ChannelActionStatus,
+    ChannelEvent, ChannelEventType, ContinuationMode, Conversation, ConversationTurn,
+    DraftRevision, EventActor, EventActorKind, FollowUpTask, IntentContract, PlanningActionReceipt,
+    PlanningEvent, PlanningProposal, PlanningSession, PreservedFollowUps, Question, QuestionState,
+    RedirectActionOutcome, RedirectActionRequest, ResourceActionReceipt, ResourceIndex,
+    ResourceObservation, ResourceStatus, RuntimeCapabilityCommit, RuntimeCapabilityReceipt,
+    RuntimeResource, RuntimeResourceProposal, RuntimeTaskCommit, RuntimeTaskReceipt,
+    SelectionPolicy, Task, TaskChannel, TaskChannelIndex, TaskState, TransitionActor,
+    TransitionCause, TransitionLog, TransitionRecord, TurnRole, WorkQueue, WorkerAttempt,
+    WorkersFile, YardConfig,
 };
 use crate::yaml;
 
@@ -36,6 +38,7 @@ pub const STATE_DIR: &str = ".agents";
 pub const CONFIG_FILE: &str = "yardlet.yaml";
 pub const LEGACY_CONFIG_FILE: &str = "yard.yaml";
 pub const CHANNEL_INDEX_EVENT_LIMIT: usize = 128;
+pub const RESOURCE_INDEX_ENTRY_LIMIT: usize = 128;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct TaskChannelIdentity {
@@ -267,6 +270,30 @@ impl Workspace {
 
     pub fn task_channel_index_path(&self, intent_id: &str, task_id: &str) -> PathBuf {
         self.task_channel_dir(intent_id, task_id).join("index.yaml")
+    }
+
+    pub fn resources_dir(&self) -> PathBuf {
+        self.agents_dir().join("resources")
+    }
+
+    pub fn resource_index_path(&self) -> PathBuf {
+        self.resources_dir().join("index.yaml")
+    }
+
+    fn artifacts_dir(&self) -> PathBuf {
+        self.resources_dir().join("artifacts")
+    }
+
+    fn runtime_resources_dir(&self) -> PathBuf {
+        self.resources_dir().join("runtime")
+    }
+
+    fn resource_observations_dir(&self, resource_id: &str) -> PathBuf {
+        self.resources_dir().join("observations").join(resource_id)
+    }
+
+    fn resource_actions_dir(&self) -> PathBuf {
+        self.resources_dir().join("actions")
     }
 
     pub fn is_initialized(&self) -> bool {
@@ -2285,6 +2312,484 @@ impl Workspace {
                 .join(format!("{}.yaml", attempt.attempt_id)),
             attempt,
         )
+    }
+
+    fn validate_publication_attempt(
+        &self,
+        intent_id: &str,
+        task_id: &str,
+        attempt_id: &str,
+        worker_id: &str,
+    ) -> Result<WorkerAttempt> {
+        let Some((identity, attempt)) = self.find_worker_attempt(attempt_id)? else {
+            bail!("publication_attempt_missing: {attempt_id}");
+        };
+        if identity.intent_id != intent_id
+            || identity.task_id != task_id
+            || attempt.intent_id != intent_id
+            || attempt.task_id != task_id
+            || attempt.worker_id != worker_id
+        {
+            bail!("publication_attempt_linkage_conflict: {attempt_id}");
+        }
+        Ok(attempt)
+    }
+
+    fn find_artifact_by_proposal(&self, proposal_id: &str) -> Result<Option<Artifact>> {
+        let mut found = None;
+        for artifact in load_yaml_dir::<Artifact>(&self.artifacts_dir())? {
+            if artifact.proposal_id != proposal_id {
+                continue;
+            }
+            if found.is_some() {
+                bail!("artifact_proposal_conflict: {proposal_id}");
+            }
+            found = Some(artifact);
+        }
+        Ok(found)
+    }
+
+    fn find_resource_by_proposal(&self, proposal_id: &str) -> Result<Option<RuntimeResource>> {
+        let mut found = None;
+        for resource in load_yaml_dir::<RuntimeResource>(&self.runtime_resources_dir())? {
+            if resource.proposal_id != proposal_id {
+                continue;
+            }
+            if found.is_some() {
+                bail!("resource_proposal_conflict: {proposal_id}");
+            }
+            found = Some(resource);
+        }
+        Ok(found)
+    }
+
+    pub fn publish_artifact(
+        &self,
+        session_id: &str,
+        intent_id: &str,
+        proposal: &ArtifactProposal,
+        source_path: &str,
+    ) -> Result<Artifact> {
+        proposal
+            .validate_provenance(&proposal.task_id, &proposal.attempt_id)
+            .map_err(anyhow::Error::msg)?;
+        self.validate_publication_attempt(
+            intent_id,
+            &proposal.task_id,
+            &proposal.attempt_id,
+            &proposal.producer.worker_id,
+        )?;
+        let _lock = self.acquire_planning_lock()?;
+        if let Some(existing) = self.find_artifact_by_proposal(&proposal.proposal_id)? {
+            let same = existing.session_id == session_id
+                && existing.intent_id == intent_id
+                && existing.task_id == proposal.task_id
+                && existing.attempt_id == proposal.attempt_id
+                && existing.producer == proposal.producer
+                && existing.causation_id == proposal.causation_id
+                && existing.path == proposal.path
+                && existing.source_path == source_path
+                && existing.digest == proposal.digest
+                && existing.media_type == proposal.media_type
+                && existing.role == proposal.role;
+            if same {
+                return Ok(existing);
+            }
+            bail!("artifact_proposal_conflict: {}", proposal.proposal_id);
+        }
+        let artifact_id = format!(
+            "art_{}",
+            stable_digest_bytes(
+                format!("{}\0{}", proposal.attempt_id, proposal.proposal_id).as_bytes()
+            )
+        );
+        let event = self.record_task_event_locked(
+            intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_publish_{artifact_id}"),
+                session_id: session_id.to_string(),
+                seq: 0,
+                event_type: ChannelEventType::ArtifactCreated,
+                recorded_at: String::new(),
+                actor: EventActor {
+                    kind: EventActorKind::Worker,
+                    id: proposal.producer.worker_id.clone(),
+                },
+                action_id: None,
+                causation_id: Some(proposal.causation_id.clone()),
+                correlation_id: format!("cor_{}", task_channel_id(intent_id, &proposal.task_id)),
+                task_id: proposal.task_id.clone(),
+                attempt_id: Some(proposal.attempt_id.clone()),
+                payload: serde_json::json!({
+                    "artifact_id": artifact_id,
+                    "proposal_id": proposal.proposal_id,
+                    "path": proposal.path,
+                    "source_path": source_path,
+                    "content_digest": proposal.digest,
+                    "media_type": proposal.media_type,
+                    "role": proposal.role,
+                    "producer_attempt_id": proposal.attempt_id,
+                    "producer_worker_id": proposal.producer.worker_id
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let artifact = Artifact {
+            schema_version: 1,
+            artifact_id: artifact_id.clone(),
+            proposal_id: proposal.proposal_id.clone(),
+            session_id: session_id.to_string(),
+            intent_id: intent_id.to_string(),
+            task_id: proposal.task_id.clone(),
+            attempt_id: proposal.attempt_id.clone(),
+            producer: proposal.producer.clone(),
+            causation_id: proposal.causation_id.clone(),
+            path: proposal.path.clone(),
+            source_path: source_path.to_string(),
+            digest: proposal.digest.clone(),
+            media_type: proposal.media_type.clone(),
+            role: proposal.role,
+            created_event_id: event.event_id,
+            published_seq: event.seq,
+            recorded_at: event.recorded_at,
+        };
+        save_immutable_yaml(
+            &self.artifacts_dir().join(format!("{artifact_id}.yaml")),
+            &artifact,
+        )?;
+        Ok(artifact)
+    }
+
+    pub fn publish_runtime_resource(
+        &self,
+        session_id: &str,
+        intent_id: &str,
+        proposal: &RuntimeResourceProposal,
+    ) -> Result<RuntimeResource> {
+        proposal
+            .validate_provenance(&proposal.task_id, &proposal.attempt_id)
+            .map_err(anyhow::Error::msg)?;
+        self.validate_publication_attempt(
+            intent_id,
+            &proposal.task_id,
+            &proposal.attempt_id,
+            &proposal.producer.worker_id,
+        )?;
+        let _lock = self.acquire_planning_lock()?;
+        if let Some(existing) = self.find_resource_by_proposal(&proposal.proposal_id)? {
+            let same = existing.session_id == session_id
+                && existing.intent_id == intent_id
+                && existing.task_id == proposal.task_id
+                && existing.attempt_id == proposal.attempt_id
+                && existing.producer == proposal.producer
+                && existing.causation_id == proposal.causation_id
+                && existing.ownership == proposal.ownership
+                && existing.target == proposal.target;
+            if same {
+                return Ok(existing);
+            }
+            bail!("resource_proposal_conflict: {}", proposal.proposal_id);
+        }
+        let resource_id = format!(
+            "res_{}",
+            stable_digest_bytes(
+                format!("{}\0{}", proposal.attempt_id, proposal.proposal_id).as_bytes()
+            )
+        );
+        let event = self.record_task_event_locked(
+            intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_publish_{resource_id}"),
+                session_id: session_id.to_string(),
+                seq: 0,
+                event_type: ChannelEventType::ResourceDeclared,
+                recorded_at: String::new(),
+                actor: EventActor {
+                    kind: EventActorKind::Worker,
+                    id: proposal.producer.worker_id.clone(),
+                },
+                action_id: None,
+                causation_id: Some(proposal.causation_id.clone()),
+                correlation_id: format!("cor_{}", task_channel_id(intent_id, &proposal.task_id)),
+                task_id: proposal.task_id.clone(),
+                attempt_id: Some(proposal.attempt_id.clone()),
+                payload: serde_json::json!({
+                    "resource_id": resource_id,
+                    "proposal_id": proposal.proposal_id,
+                    "ownership": proposal.ownership,
+                    "target": proposal.target
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let resource = RuntimeResource {
+            schema_version: 1,
+            resource_id: resource_id.clone(),
+            proposal_id: proposal.proposal_id.clone(),
+            session_id: session_id.to_string(),
+            intent_id: intent_id.to_string(),
+            task_id: proposal.task_id.clone(),
+            attempt_id: proposal.attempt_id.clone(),
+            producer: proposal.producer.clone(),
+            causation_id: proposal.causation_id.clone(),
+            ownership: proposal.ownership,
+            target: proposal.target.clone(),
+            created_event_id: event.event_id,
+            published_seq: event.seq,
+            recorded_at: event.recorded_at,
+        };
+        save_immutable_yaml(
+            &self
+                .runtime_resources_dir()
+                .join(format!("{resource_id}.yaml")),
+            &resource,
+        )?;
+        let _ = self.record_resource_observation_locked(
+            &resource,
+            ResourceStatus::Unknown,
+            false,
+            None,
+            "",
+            "declared; current liveness has not been probed",
+            &resource.created_event_id,
+            None,
+            &format!("obs_{resource_id}_declared"),
+        )?;
+        Ok(resource)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_resource_observation_locked(
+        &self,
+        resource: &RuntimeResource,
+        status: ResourceStatus,
+        current: bool,
+        pid: Option<u32>,
+        start_identity: &str,
+        detail: &str,
+        causation_id: &str,
+        action_id: Option<&str>,
+        observation_id: &str,
+    ) -> Result<ResourceObservation> {
+        let path = self
+            .resource_observations_dir(&resource.resource_id)
+            .join(format!("{observation_id}.yaml"));
+        if path.is_file() {
+            return load_yaml(&path);
+        }
+        let event = self.record_task_event_locked(
+            &resource.intent_id,
+            ChannelEvent {
+                schema_version: 1,
+                event_id: format!("evt_{observation_id}"),
+                session_id: resource.session_id.clone(),
+                seq: 0,
+                event_type: ChannelEventType::ResourceObserved,
+                recorded_at: String::new(),
+                actor: EventActor {
+                    kind: EventActorKind::System,
+                    id: String::new(),
+                },
+                action_id: action_id.map(str::to_string),
+                causation_id: Some(causation_id.to_string()),
+                correlation_id: format!(
+                    "cor_{}",
+                    task_channel_id(&resource.intent_id, &resource.task_id)
+                ),
+                task_id: resource.task_id.clone(),
+                attempt_id: Some(resource.attempt_id.clone()),
+                payload: serde_json::json!({
+                    "resource_id": resource.resource_id,
+                    "observation_id": observation_id,
+                    "status": status,
+                    "current": current,
+                    "pid": pid,
+                    "start_identity": start_identity,
+                    "detail": detail
+                }),
+                raw_ref: None,
+            },
+        )?;
+        let observation = ResourceObservation {
+            schema_version: 1,
+            observation_id: observation_id.to_string(),
+            resource_id: resource.resource_id.clone(),
+            task_id: resource.task_id.clone(),
+            attempt_id: resource.attempt_id.clone(),
+            status,
+            observed_at: event.recorded_at,
+            current,
+            pid,
+            start_identity: start_identity.to_string(),
+            detail: detail.to_string(),
+            causation_id: causation_id.to_string(),
+            event_id: event.event_id,
+            seq: event.seq,
+        };
+        save_immutable_yaml(&path, &observation)?;
+        Ok(observation)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_resource_observation(
+        &self,
+        resource: &RuntimeResource,
+        status: ResourceStatus,
+        current: bool,
+        pid: Option<u32>,
+        start_identity: &str,
+        detail: &str,
+        causation_id: &str,
+        action_id: &str,
+    ) -> Result<ResourceObservation> {
+        validate_action_id(action_id)?;
+        let _lock = self.acquire_planning_lock()?;
+        self.record_resource_observation_locked(
+            resource,
+            status,
+            current,
+            pid,
+            start_identity,
+            detail,
+            causation_id,
+            Some(action_id),
+            &format!(
+                "obs_{}_{}",
+                stable_digest_bytes(action_id.as_bytes()),
+                stable_digest_bytes(resource.resource_id.as_bytes())
+            ),
+        )
+    }
+
+    pub fn load_artifacts(&self) -> Result<Vec<Artifact>> {
+        let mut artifacts = load_yaml_dir::<Artifact>(&self.artifacts_dir())?;
+        artifacts.sort_by(|left, right| {
+            left.published_seq
+                .cmp(&right.published_seq)
+                .then_with(|| left.artifact_id.cmp(&right.artifact_id))
+        });
+        Ok(artifacts)
+    }
+
+    pub fn load_runtime_resources(&self) -> Result<Vec<RuntimeResource>> {
+        let mut resources = load_yaml_dir::<RuntimeResource>(&self.runtime_resources_dir())?;
+        resources.sort_by(|left, right| {
+            left.published_seq
+                .cmp(&right.published_seq)
+                .then_with(|| left.resource_id.cmp(&right.resource_id))
+        });
+        Ok(resources)
+    }
+
+    pub fn load_resource_observations(
+        &self,
+        resource_id: &str,
+    ) -> Result<Vec<ResourceObservation>> {
+        let mut observations =
+            load_yaml_dir::<ResourceObservation>(&self.resource_observations_dir(resource_id))?;
+        observations.sort_by(|left, right| {
+            left.seq
+                .cmp(&right.seq)
+                .then_with(|| left.observation_id.cmp(&right.observation_id))
+        });
+        Ok(observations)
+    }
+
+    pub fn load_or_rebuild_resource_index(&self) -> Result<ResourceIndex> {
+        let artifacts = self.load_artifacts()?;
+        let resources = self.load_runtime_resources()?;
+        let mut canonical = Vec::new();
+        for artifact in &artifacts {
+            canonical.extend(serde_json::to_vec(artifact)?);
+        }
+        for resource in &resources {
+            canonical.extend(serde_json::to_vec(resource)?);
+            for observation in self.load_resource_observations(&resource.resource_id)? {
+                canonical.extend(serde_json::to_vec(&observation)?);
+            }
+        }
+        let artifact_start = artifacts.len().saturating_sub(RESOURCE_INDEX_ENTRY_LIMIT);
+        let resource_start = resources.len().saturating_sub(RESOURCE_INDEX_ENTRY_LIMIT);
+        let artifact_ids = artifacts[artifact_start..]
+            .iter()
+            .map(|artifact| artifact.artifact_id.clone())
+            .collect::<Vec<_>>();
+        let resource_ids = resources[resource_start..]
+            .iter()
+            .map(|resource| resource.resource_id.clone())
+            .collect::<Vec<_>>();
+        let mut attempts = artifacts[artifact_start..]
+            .iter()
+            .map(|artifact| artifact.attempt_id.clone())
+            .chain(
+                resources[resource_start..]
+                    .iter()
+                    .map(|resource| resource.attempt_id.clone()),
+            )
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        if attempts.len() > RESOURCE_INDEX_ENTRY_LIMIT {
+            attempts = attempts.split_off(attempts.len() - RESOURCE_INDEX_ENTRY_LIMIT);
+        }
+        let index = ResourceIndex {
+            schema_version: 1,
+            canonical_digest: format!("fnv1a64:{}", stable_digest_bytes(&canonical)),
+            artifacts: artifact_ids,
+            resources: resource_ids,
+            attempts,
+        };
+        let current = if self.resource_index_path().is_file() {
+            load_yaml::<ResourceIndex>(&self.resource_index_path()).ok()
+        } else {
+            None
+        };
+        if current.as_ref() != Some(&index) {
+            write_str_atomic(&self.resource_index_path(), &yaml::to_string(&index)?)?;
+        }
+        Ok(index)
+    }
+
+    pub fn load_resource_action(&self, action_id: &str) -> Result<Option<ResourceActionReceipt>> {
+        validate_action_id(action_id)?;
+        let path =
+            contained_action_path(&self.resource_actions_dir(), &format!("{action_id}.yaml"))?;
+        if !path.is_file() {
+            return Ok(None);
+        }
+        load_yaml(&path).map(Some)
+    }
+
+    pub fn save_resource_action(&self, receipt: &ResourceActionReceipt) -> Result<()> {
+        validate_action_id(&receipt.action_id)?;
+        let path = contained_action_path(
+            &self.resource_actions_dir(),
+            &format!("{}.yaml", receipt.action_id),
+        )?;
+        if path.is_file() {
+            let existing: ResourceActionReceipt = load_yaml(&path)?;
+            if existing == *receipt {
+                return Ok(());
+            }
+            bail!("resource_action_conflict: {}", receipt.action_id);
+        }
+        save_immutable_yaml(&path, receipt)
+    }
+
+    pub fn load_artifact(&self, artifact_id: &str) -> Result<Option<Artifact>> {
+        Ok(self
+            .load_artifacts()?
+            .into_iter()
+            .find(|artifact| artifact.artifact_id == artifact_id))
+    }
+
+    pub fn load_runtime_resource(&self, resource_id: &str) -> Result<Option<RuntimeResource>> {
+        Ok(self
+            .load_runtime_resources()?
+            .into_iter()
+            .find(|resource| resource.resource_id == resource_id))
     }
 
     /// Replay the canonical event stream for one work session across every

--- a/src/state.rs
+++ b/src/state.rs
@@ -24,11 +24,11 @@ use crate::schemas::{
     DraftRevision, EventActor, EventActorKind, FollowUpTask, IntentContract, PlanningActionReceipt,
     PlanningEvent, PlanningProposal, PlanningSession, PreservedFollowUps, Question, QuestionState,
     RedirectActionOutcome, RedirectActionRequest, ResourceActionReceipt, ResourceIndex,
-    ResourceObservation, ResourceStatus, RuntimeCapabilityCommit, RuntimeCapabilityReceipt,
-    RuntimeResource, RuntimeResourceProposal, RuntimeTaskCommit, RuntimeTaskReceipt,
-    SelectionPolicy, Task, TaskChannel, TaskChannelIndex, TaskState, TransitionActor,
-    TransitionCause, TransitionLog, TransitionRecord, TurnRole, WorkQueue, WorkerAttempt,
-    WorkersFile, YardConfig,
+    ResourceObservation, ResourceStatus, ResourceTaskIndex, RuntimeCapabilityCommit,
+    RuntimeCapabilityReceipt, RuntimeResource, RuntimeResourceProposal, RuntimeTaskCommit,
+    RuntimeTaskReceipt, SelectionPolicy, Task, TaskChannel, TaskChannelIndex, TaskState,
+    TransitionActor, TransitionCause, TransitionLog, TransitionRecord, TurnRole, WorkQueue,
+    WorkerAttempt, WorkersFile, YardConfig,
 };
 use crate::yaml;
 
@@ -2335,6 +2335,43 @@ impl Workspace {
         Ok(attempt)
     }
 
+    fn resolve_publication_causation(
+        &self,
+        intent_id: &str,
+        task_id: &str,
+        attempt_id: &str,
+        proposed_causation_id: &str,
+    ) -> Result<String> {
+        let channel = self.load_task_channel(intent_id, task_id)?;
+        let cause = if proposed_causation_id == attempt_id {
+            channel
+                .events
+                .iter()
+                .rev()
+                .find(|event| {
+                    event.attempt_id.as_deref() == Some(attempt_id)
+                        && event.event_type == ChannelEventType::WorkerCompleted
+                })
+                .or_else(|| {
+                    channel
+                        .events
+                        .iter()
+                        .rev()
+                        .find(|event| event.attempt_id.as_deref() == Some(attempt_id))
+                })
+        } else {
+            channel
+                .events
+                .iter()
+                .find(|event| event.event_id == proposed_causation_id)
+        }
+        .ok_or_else(|| anyhow::anyhow!("publication_causation_missing: {proposed_causation_id}"))?;
+        if cause.attempt_id.as_deref() != Some(attempt_id) {
+            bail!("publication_causation_linkage_conflict: {proposed_causation_id}");
+        }
+        Ok(cause.event_id.clone())
+    }
+
     fn find_artifact_by_proposal(&self, proposal_id: &str) -> Result<Option<Artifact>> {
         let mut found = None;
         for artifact in load_yaml_dir::<Artifact>(&self.artifacts_dir())? {
@@ -2379,6 +2416,12 @@ impl Workspace {
             &proposal.attempt_id,
             &proposal.producer.worker_id,
         )?;
+        let causation_id = self.resolve_publication_causation(
+            intent_id,
+            &proposal.task_id,
+            &proposal.attempt_id,
+            &proposal.causation_id,
+        )?;
         let _lock = self.acquire_planning_lock()?;
         if let Some(existing) = self.find_artifact_by_proposal(&proposal.proposal_id)? {
             let same = existing.session_id == session_id
@@ -2386,12 +2429,13 @@ impl Workspace {
                 && existing.task_id == proposal.task_id
                 && existing.attempt_id == proposal.attempt_id
                 && existing.producer == proposal.producer
-                && existing.causation_id == proposal.causation_id
+                && existing.causation_id == causation_id
                 && existing.path == proposal.path
                 && existing.source_path == source_path
                 && existing.digest == proposal.digest
                 && existing.media_type == proposal.media_type
-                && existing.role == proposal.role;
+                && existing.role == proposal.role
+                && existing.channel_role == proposal.channel_role;
             if same {
                 return Ok(existing);
             }
@@ -2403,6 +2447,11 @@ impl Workspace {
                 format!("{}\0{}", proposal.attempt_id, proposal.proposal_id).as_bytes()
             )
         );
+        let event_role = if proposal.channel_role.is_empty() {
+            serde_json::to_value(proposal.role)?
+        } else {
+            serde_json::Value::String(proposal.channel_role.clone())
+        };
         let event = self.record_task_event_locked(
             intent_id,
             ChannelEvent {
@@ -2417,7 +2466,7 @@ impl Workspace {
                     id: proposal.producer.worker_id.clone(),
                 },
                 action_id: None,
-                causation_id: Some(proposal.causation_id.clone()),
+                causation_id: Some(causation_id.clone()),
                 correlation_id: format!("cor_{}", task_channel_id(intent_id, &proposal.task_id)),
                 task_id: proposal.task_id.clone(),
                 attempt_id: Some(proposal.attempt_id.clone()),
@@ -2428,7 +2477,7 @@ impl Workspace {
                     "source_path": source_path,
                     "content_digest": proposal.digest,
                     "media_type": proposal.media_type,
-                    "role": proposal.role,
+                    "role": event_role,
                     "producer_attempt_id": proposal.attempt_id,
                     "producer_worker_id": proposal.producer.worker_id
                 }),
@@ -2444,12 +2493,13 @@ impl Workspace {
             task_id: proposal.task_id.clone(),
             attempt_id: proposal.attempt_id.clone(),
             producer: proposal.producer.clone(),
-            causation_id: proposal.causation_id.clone(),
+            causation_id,
             path: proposal.path.clone(),
             source_path: source_path.to_string(),
             digest: proposal.digest.clone(),
             media_type: proposal.media_type.clone(),
             role: proposal.role,
+            channel_role: proposal.channel_role.clone(),
             created_event_id: event.event_id,
             published_seq: event.seq,
             recorded_at: event.recorded_at,
@@ -2476,6 +2526,12 @@ impl Workspace {
             &proposal.attempt_id,
             &proposal.producer.worker_id,
         )?;
+        let causation_id = self.resolve_publication_causation(
+            intent_id,
+            &proposal.task_id,
+            &proposal.attempt_id,
+            &proposal.causation_id,
+        )?;
         let _lock = self.acquire_planning_lock()?;
         if let Some(existing) = self.find_resource_by_proposal(&proposal.proposal_id)? {
             let same = existing.session_id == session_id
@@ -2483,7 +2539,7 @@ impl Workspace {
                 && existing.task_id == proposal.task_id
                 && existing.attempt_id == proposal.attempt_id
                 && existing.producer == proposal.producer
-                && existing.causation_id == proposal.causation_id
+                && existing.causation_id == causation_id
                 && existing.ownership == proposal.ownership
                 && existing.target == proposal.target;
             if same {
@@ -2511,7 +2567,7 @@ impl Workspace {
                     id: proposal.producer.worker_id.clone(),
                 },
                 action_id: None,
-                causation_id: Some(proposal.causation_id.clone()),
+                causation_id: Some(causation_id.clone()),
                 correlation_id: format!("cor_{}", task_channel_id(intent_id, &proposal.task_id)),
                 task_id: proposal.task_id.clone(),
                 attempt_id: Some(proposal.attempt_id.clone()),
@@ -2533,7 +2589,7 @@ impl Workspace {
             task_id: proposal.task_id.clone(),
             attempt_id: proposal.attempt_id.clone(),
             producer: proposal.producer.clone(),
-            causation_id: proposal.causation_id.clone(),
+            causation_id,
             ownership: proposal.ownership,
             target: proposal.target.clone(),
             created_event_id: event.event_id,
@@ -2734,12 +2790,62 @@ impl Workspace {
         if attempts.len() > RESOURCE_INDEX_ENTRY_LIMIT {
             attempts = attempts.split_off(attempts.len() - RESOURCE_INDEX_ENTRY_LIMIT);
         }
+        let mut task_entries = BTreeMap::<String, ResourceTaskIndex>::new();
+        for artifact in &artifacts {
+            let entry = task_entries
+                .entry(artifact.task_id.clone())
+                .or_insert_with(|| ResourceTaskIndex {
+                    task_id: artifact.task_id.clone(),
+                    artifacts: Vec::new(),
+                    resources: Vec::new(),
+                    attempts: Vec::new(),
+                    truncated: false,
+                });
+            entry.artifacts.push(artifact.artifact_id.clone());
+            if !entry.attempts.contains(&artifact.attempt_id) {
+                entry.attempts.push(artifact.attempt_id.clone());
+            }
+        }
+        for resource in &resources {
+            let entry = task_entries
+                .entry(resource.task_id.clone())
+                .or_insert_with(|| ResourceTaskIndex {
+                    task_id: resource.task_id.clone(),
+                    artifacts: Vec::new(),
+                    resources: Vec::new(),
+                    attempts: Vec::new(),
+                    truncated: false,
+                });
+            entry.resources.push(resource.resource_id.clone());
+            if !entry.attempts.contains(&resource.attempt_id) {
+                entry.attempts.push(resource.attempt_id.clone());
+            }
+        }
+        for entry in task_entries.values_mut() {
+            for values in [
+                &mut entry.artifacts,
+                &mut entry.resources,
+                &mut entry.attempts,
+            ] {
+                if values.len() > RESOURCE_INDEX_ENTRY_LIMIT {
+                    *values = values.split_off(values.len() - RESOURCE_INDEX_ENTRY_LIMIT);
+                    entry.truncated = true;
+                }
+            }
+        }
+        let tasks_truncated = task_entries.len() > RESOURCE_INDEX_ENTRY_LIMIT;
+        let mut tasks = task_entries.into_values().collect::<Vec<_>>();
+        if tasks_truncated {
+            tasks = tasks.split_off(tasks.len() - RESOURCE_INDEX_ENTRY_LIMIT);
+        }
         let index = ResourceIndex {
             schema_version: 1,
             canonical_digest: format!("fnv1a64:{}", stable_digest_bytes(&canonical)),
             artifacts: artifact_ids,
             resources: resource_ids,
             attempts,
+            tasks,
+            tasks_truncated,
         };
         let current = if self.resource_index_path().is_file() {
             load_yaml::<ResourceIndex>(&self.resource_index_path()).ok()

--- a/tests/fixtures/v010_004_local_app/app.py
+++ b/tests/fixtures/v010_004_local_app/app.py
@@ -5,12 +5,21 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
 MARKER = "yardlet-local-app"
+BROWSER_SESSION_ID = "local-active-browser-session"
 
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
+        status = 200
         if self.path == "/health":
             body = json.dumps({"status": "ok", "marker": MARKER}).encode()
+            content_type = "application/json"
+        elif self.path == "/unhealthy":
+            status = 503
+            body = json.dumps({"status": "unhealthy", "marker": MARKER}).encode()
+            content_type = "application/json"
+        elif self.path == "/browser/session":
+            body = json.dumps({"session_id": BROWSER_SESSION_ID, "marker": MARKER}).encode()
             content_type = "application/json"
         elif self.path == "/":
             body = f"""<!doctype html>
@@ -45,7 +54,7 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(body)
             return
 
-        self.send_response(200)
+        self.send_response(status)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")

--- a/tests/fixtures/v010_004_local_app/app.py
+++ b/tests/fixtures/v010_004_local_app/app.py
@@ -3,10 +3,19 @@ import argparse
 import json
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from socketserver import TCPServer
 
 
 MARKER = "yardlet-local-app"
 BROWSER_SESSION_ID = "local-active-browser-session"
+
+
+class LocalThreadingHTTPServer(ThreadingHTTPServer):
+    def server_bind(self):
+        TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -71,7 +80,7 @@ def main():
     parser.add_argument("--port", required=True, type=int)
     args = parser.parse_args()
     print(f"starting local app on 127.0.0.1:{args.port}", file=sys.stderr, flush=True)
-    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    server = LocalThreadingHTTPServer(("127.0.0.1", args.port), Handler)
     print(f"listening on 127.0.0.1:{args.port}", file=sys.stderr, flush=True)
     server.serve_forever()
 

--- a/tests/fixtures/v010_004_local_app/app.py
+++ b/tests/fixtures/v010_004_local_app/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 
@@ -69,7 +70,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", required=True, type=int)
     args = parser.parse_args()
+    print(f"starting local app on 127.0.0.1:{args.port}", file=sys.stderr, flush=True)
     server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    print(f"listening on 127.0.0.1:{args.port}", file=sys.stderr, flush=True)
     server.serve_forever()
 
 

--- a/tests/fixtures/v010_004_local_app/app.py
+++ b/tests/fixtures/v010_004_local_app/app.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+MARKER = "yardlet-local-app"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            body = json.dumps({"status": "ok", "marker": MARKER}).encode()
+            content_type = "application/json"
+        elif self.path == "/":
+            body = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Yardlet local resource fixture</title>
+  <style>
+    body {{ margin: 0; background: #101820; color: #f2f2f2; font-family: sans-serif; }}
+    main {{ width: 720px; margin: 96px auto; padding: 48px; border: 2px solid #f2aa4c; }}
+    h1 {{ color: #f2aa4c; font-size: 42px; }}
+    code {{ color: #8dd7cf; }}
+  </style>
+</head>
+<body>
+  <main id="{MARKER}">
+    <h1>Local app is live</h1>
+    <p>Rendered by a real localhost service for <code>{MARKER}</code>.</p>
+  </main>
+</body>
+</html>
+""".encode()
+            content_type = "text/html; charset=utf-8"
+        else:
+            body = b"not found\n"
+            content_type = "text/plain; charset=utf-8"
+            self.send_response(404)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", required=True, type=int)
+    args = parser.parse_args()
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/v010_004_local_app/capture_browser.py
+++ b/tests/fixtures/v010_004_local_app/capture_browser.py
@@ -80,6 +80,7 @@ def main():
         "--no-sandbox",
         f"--user-data-dir={profile}",
         "--window-size=960,720",
+        "--timeout=10000",
         f"--screenshot={screenshot}",
         args.url,
     ]

--- a/tests/fixtures/v010_004_local_app/capture_browser.py
+++ b/tests/fixtures/v010_004_local_app/capture_browser.py
@@ -64,6 +64,14 @@ def main():
     metadata.parent.mkdir(parents=True, exist_ok=True)
     profile = tempfile.mkdtemp(prefix="yardlet-local-browser-")
     executable = browser_binary()
+    version = subprocess.run(
+        [executable, "--version"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    stderr_path = metadata.with_suffix(".stderr.log")
     command = [
         executable,
         "--headless",
@@ -84,40 +92,41 @@ def main():
         f"--screenshot={screenshot}",
         args.url,
     ]
-    process = subprocess.Popen(
-        command,
-        stdin=subprocess.DEVNULL,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
-    identity = wait_for_identity(process.pid)
-    try:
-        deadline = time.monotonic() + 60
-        payload = b""
-        while time.monotonic() < deadline:
-            if screenshot.is_file():
-                payload = screenshot.read_bytes()
-                if payload.startswith(b"\x89PNG\r\n\x1a\n") and payload.endswith(
-                    b"\x00\x00\x00\x00IEND\xaeB\x60\x82"
-                ):
-                    break
-            if process.poll() is not None:
-                raise RuntimeError(
-                    f"headless Chromium exited with {process.returncode} before screenshot completion"
-                )
-            time.sleep(0.05)
-        else:
-            raise RuntimeError("headless Chromium screenshot timed out")
-    finally:
-        if process.poll() is None:
-            os.killpg(process.pid, signal.SIGTERM)
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGKILL)
-                process.wait(timeout=5)
-        shutil.rmtree(profile, ignore_errors=True)
+    with stderr_path.open("wb") as stderr_log:
+        process = subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=stderr_log,
+            start_new_session=True,
+        )
+        identity = wait_for_identity(process.pid)
+        try:
+            deadline = time.monotonic() + 60
+            payload = b""
+            while time.monotonic() < deadline:
+                if screenshot.is_file():
+                    payload = screenshot.read_bytes()
+                    if payload.startswith(b"\x89PNG\r\n\x1a\n") and payload.endswith(
+                        b"\x00\x00\x00\x00IEND\xaeB\x60\x82"
+                    ):
+                        break
+                if process.poll() is not None:
+                    raise RuntimeError(
+                        f"headless Chromium exited with {process.returncode} before screenshot completion"
+                    )
+                time.sleep(0.05)
+            else:
+                raise RuntimeError("headless Chromium screenshot timed out")
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGTERM)
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=5)
+            shutil.rmtree(profile, ignore_errors=True)
 
     metadata.write_text(
         json.dumps(
@@ -128,6 +137,7 @@ def main():
                 "exit_code": process.returncode,
                 "url": args.url,
                 "browser": executable,
+                "browser_version": (version.stdout or version.stderr).strip(),
             },
             indent=2,
         )

--- a/tests/fixtures/v010_004_local_app/capture_browser.py
+++ b/tests/fixtures/v010_004_local_app/capture_browser.py
@@ -13,10 +13,10 @@ from urllib.parse import urlparse
 
 def browser_binary():
     candidates = [
-        shutil.which("chromium"),
-        shutil.which("chromium-browser"),
         shutil.which("google-chrome"),
         shutil.which("google-chrome-stable"),
+        shutil.which("chromium"),
+        shutil.which("chromium-browser"),
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         "/Applications/Chromium.app/Contents/MacOS/Chromium",
     ]

--- a/tests/fixtures/v010_004_local_app/capture_browser.py
+++ b/tests/fixtures/v010_004_local_app/capture_browser.py
@@ -92,7 +92,7 @@ def main():
     )
     identity = wait_for_identity(process.pid)
     try:
-        deadline = time.monotonic() + 20
+        deadline = time.monotonic() + 60
         payload = b""
         while time.monotonic() < deadline:
             if screenshot.is_file():

--- a/tests/fixtures/v010_004_local_app/capture_browser.py
+++ b/tests/fixtures/v010_004_local_app/capture_browser.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import signal
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def browser_binary():
+    candidates = [
+        shutil.which("chromium"),
+        shutil.which("chromium-browser"),
+        shutil.which("google-chrome"),
+        shutil.which("google-chrome-stable"),
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    ]
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    raise RuntimeError("no headless Chromium executable is available")
+
+
+def process_identity(pid):
+    completed = subprocess.run(
+        ["ps", "-o", "lstart=", "-p", str(pid)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return ""
+    return " ".join(completed.stdout.split())
+
+
+def wait_for_identity(pid):
+    for _ in range(50):
+        identity = process_identity(pid)
+        if identity:
+            return identity
+        time.sleep(0.01)
+    raise RuntimeError(f"browser pid {pid} never exposed a process identity")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("url")
+    parser.add_argument("screenshot")
+    parser.add_argument("metadata")
+    args = parser.parse_args()
+
+    parsed = urlparse(args.url)
+    if parsed.scheme != "http" or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        raise RuntimeError("browser fixture accepts localhost HTTP URLs only")
+
+    screenshot = Path(args.screenshot).resolve()
+    metadata = Path(args.metadata).resolve()
+    screenshot.parent.mkdir(parents=True, exist_ok=True)
+    metadata.parent.mkdir(parents=True, exist_ok=True)
+    profile = tempfile.mkdtemp(prefix="yardlet-local-browser-")
+    executable = browser_binary()
+    command = [
+        executable,
+        "--headless",
+        "--disable-background-networking",
+        "--disable-component-update",
+        "--disable-default-apps",
+        "--disable-extensions",
+        "--disable-gpu",
+        "--disable-sync",
+        "--metrics-recording-only",
+        "--mute-audio",
+        "--no-first-run",
+        "--no-proxy-server",
+        "--no-sandbox",
+        f"--user-data-dir={profile}",
+        "--window-size=960,720",
+        f"--screenshot={screenshot}",
+        args.url,
+    ]
+    process = subprocess.Popen(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    identity = wait_for_identity(process.pid)
+    try:
+        deadline = time.monotonic() + 20
+        payload = b""
+        while time.monotonic() < deadline:
+            if screenshot.is_file():
+                payload = screenshot.read_bytes()
+                if payload.startswith(b"\x89PNG\r\n\x1a\n") and payload.endswith(
+                    b"\x00\x00\x00\x00IEND\xaeB\x60\x82"
+                ):
+                    break
+            if process.poll() is not None:
+                raise RuntimeError(
+                    f"headless Chromium exited with {process.returncode} before screenshot completion"
+                )
+            time.sleep(0.05)
+        else:
+            raise RuntimeError("headless Chromium screenshot timed out")
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+        shutil.rmtree(profile, ignore_errors=True)
+
+    metadata.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "pid": process.pid,
+                "start_identity": identity,
+                "exit_code": process.returncode,
+                "url": args.url,
+                "browser": executable,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    if not payload.startswith(b"\x89PNG\r\n\x1a\n") or len(payload) <= 1000:
+        raise RuntimeError("headless Chromium did not retain a valid rendered PNG")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/v010_004_local_app/restart_app.sh
+++ b/tests/fixtures/v010_004_local_app/restart_app.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python_bin="${1:?python executable is required}"
+app_script="${2:?app script is required}"
+port="${3:?port is required}"
+log_prefix="${4:?log prefix is required}"
+
+exec "$python_bin" "$app_script" --port "$port" \
+  >"${log_prefix}.stdout.log" 2>"${log_prefix}.stderr.log"

--- a/tests/fixtures/v010_004_local_app/worker.sh
+++ b/tests/fixtures/v010_004_local_app/worker.sh
@@ -35,6 +35,8 @@ process_identity() {
 port="$(tr -d '[:space:]' <fixture-port.txt)"
 url="http://127.0.0.1:${port}/"
 health_url="http://127.0.0.1:${port}/health"
+unhealthy_url="http://127.0.0.1:${port}/unhealthy"
+browser_session_url="http://127.0.0.1:${port}/browser/session"
 external_meta="$(cat external-sentinel.meta)"
 external_pid="${external_meta%%|*}"
 external_identity="${external_meta#*|}"
@@ -138,11 +140,15 @@ cat >"$run_dir/result.json" <<EOF
     {"proposal_id":"local-validation","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","path":"local-app-validation.json","digest":"$validation_digest","media_type":"application/json","role":"validation_output"}
   ],
   "resources": [
-    {"proposal_id":"local-terminal","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"terminal","terminal_id":"local-app-worker-terminal","pid":$$,"start_identity":"$terminal_identity","attach_hint":"worker process terminal"}},
-    {"proposal_id":"local-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"process","pid":$app_pid,"start_identity":"$app_identity","command":["$python_bin","$app_script","--port","$port"]}},
-    {"proposal_id":"local-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"service","url":"$url","health_url":"$health_url"}},
-    {"proposal_id":"local-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"browser","url":"$url","session_id":"local-browser-$browser_pid","pid":$browser_pid,"start_identity":"$browser_identity"}},
-    {"proposal_id":"local-external","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"external","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","120"]}}
+    {"proposal_id":"local-terminal","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","attach","detach","reconcile"],"target":{"kind":"terminal","terminal_id":"local-app-worker-terminal","pid":$$,"start_identity":"$terminal_identity","attach_hint":"worker process terminal"}},
+    {"proposal_id":"local-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","attach","stop","restart","cleanup","reconcile"],"target":{"kind":"process","pid":$app_pid,"start_identity":"$app_identity","command":["$python_bin","$app_script","--port","$port"]}},
+    {"proposal_id":"local-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"service","url":"$url","health_url":"$health_url"}},
+    {"proposal_id":"local-unhealthy-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"service","url":"$url","health_url":"$unhealthy_url"}},
+    {"proposal_id":"local-open-only-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open"],"target":{"kind":"browser","url":"$url","session_id":"local-open-only-browser"}},
+    {"proposal_id":"local-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-browser-$browser_pid","pid":$browser_pid,"start_identity":"$browser_identity"}},
+    {"proposal_id":"local-live-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-active-browser-session","session_probe_url":"$browser_session_url","pid":$app_pid,"start_identity":"$app_identity"}},
+    {"proposal_id":"local-stale-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-stale-browser-session","session_probe_url":"$browser_session_url","pid":$app_pid,"start_identity":"$app_identity"}},
+    {"proposal_id":"local-external","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"external","capabilities":["open","attach","stop","cleanup","reconcile"],"target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","120"]}}
   ],
   "verdict": [],
   "harness_suggestions": [],

--- a/tests/fixtures/v010_004_local_app/worker.sh
+++ b/tests/fixtures/v010_004_local_app/worker.sh
@@ -9,6 +9,7 @@ fi
 run_dir="${1:?run directory is required}"
 app_script="${2:?local app script is required}"
 capture_script="${3:?browser capture script is required}"
+restart_script="$(dirname "$0")/restart_app.sh"
 packet="$(cat)"
 task_id="$(sed -n 's/^# Yardlet task packet: //p' <<<"$packet" | head -n 1)"
 run_id="${run_dir##*/}"
@@ -134,7 +135,22 @@ printf 'state=after\n' >app-state.txt
 git diff -- app-state.txt >local-app.diff
 
 browser_meta="$run_dir/local-browser.json"
-"$python_bin" "$capture_script" "$url" local-app-screenshot.png "$browser_meta"
+if ! "$python_bin" "$capture_script" "$url" local-app-screenshot.png "$browser_meta"; then
+  printf 'browser capture failed\n' >&2
+  printf 'executable: ' >&2
+  command -v chromium chromium-browser google-chrome google-chrome-stable 2>/dev/null >&2 || true
+  printf 'versions:\n' >&2
+  for browser in chromium chromium-browser google-chrome google-chrome-stable; do
+    if command -v "$browser" >/dev/null 2>&1; then
+      "$browser" --version >&2 || true
+    fi
+  done
+  if [[ -f "${browser_meta%.json}.stderr.log" ]]; then
+    printf 'browser stderr:\n' >&2
+    tail -n 100 "${browser_meta%.json}.stderr.log" >&2
+  fi
+  exit 1
+fi
 browser_pid="$("$python_bin" -c 'import json,sys; print(json.load(open(sys.argv[1]))["pid"])' "$browser_meta")"
 browser_identity="$("$python_bin" -c 'import json,sys; print(json.load(open(sys.argv[1]))["start_identity"])' "$browser_meta")"
 
@@ -196,8 +212,8 @@ cat >"$run_dir/result.json" <<EOF
     {"proposal_id":"local-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","attach","stop","restart","cleanup","reconcile"],"target":{"kind":"process","pid":$app_pid,"start_identity":"$app_identity","command":["$python_bin","$app_script","--port","$port"]}},
     {"proposal_id":"local-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"service","url":"$url","health_url":"$health_url"}},
     {"proposal_id":"local-unhealthy-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"service","url":"$url","health_url":"$unhealthy_url"}},
-    {"proposal_id":"local-restart-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"yardlet","capabilities":["open","restart","cleanup","reconcile"],"target":{"kind":"service","url":"$restart_healthy_url","health_url":"$restart_healthy_url","pid":$restart_healthy_pid,"start_identity":"$restart_healthy_identity","restart_command":["$python_bin","$app_script","--port","$restart_healthy_port"]}},
-    {"proposal_id":"local-unhealthy-restart-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"yardlet","capabilities":["open","restart","cleanup","reconcile"],"target":{"kind":"service","url":"http://127.0.0.1:${restart_unhealthy_port}/","health_url":"$restart_unhealthy_url","pid":$restart_unhealthy_pid,"start_identity":"$restart_unhealthy_identity","restart_command":["$python_bin","$app_script","--port","$restart_unhealthy_port"]}},
+    {"proposal_id":"local-restart-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"yardlet","capabilities":["open","restart","cleanup","reconcile"],"target":{"kind":"service","url":"$restart_healthy_url","health_url":"$restart_healthy_url","pid":$restart_healthy_pid,"start_identity":"$restart_healthy_identity","restart_command":["$restart_script","$python_bin","$app_script","$restart_healthy_port","${app_script}.restart-healthy"]}},
+    {"proposal_id":"local-unhealthy-restart-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"yardlet","capabilities":["open","restart","cleanup","reconcile"],"target":{"kind":"service","url":"http://127.0.0.1:${restart_unhealthy_port}/","health_url":"$restart_unhealthy_url","pid":$restart_unhealthy_pid,"start_identity":"$restart_unhealthy_identity","restart_command":["$restart_script","$python_bin","$app_script","$restart_unhealthy_port","${app_script}.restart-unhealthy"]}},
     {"proposal_id":"local-open-only-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open"],"target":{"kind":"browser","url":"$url","session_id":"local-open-only-browser"}},
     {"proposal_id":"local-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-browser-$browser_pid","pid":$browser_pid,"start_identity":"$browser_identity"}},
     {"proposal_id":"local-live-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-active-browser-session","session_probe_url":"$browser_session_url","pid":$app_pid,"start_identity":"$app_identity"}},

--- a/tests/fixtures/v010_004_local_app/worker.sh
+++ b/tests/fixtures/v010_004_local_app/worker.sh
@@ -43,13 +43,26 @@ external_identity="${external_meta#*|}"
 external_identity="${external_identity%$'\n'}"
 app_pid=''
 app_identity=''
+restart_healthy_pid=''
+restart_healthy_identity=''
+restart_unhealthy_pid=''
+restart_unhealthy_identity=''
 published=0
 
 cleanup_failed_publication() {
-  if [[ "$published" -eq 0 && -n "$app_pid" ]]; then
-    if [[ "$(process_identity "$app_pid" 2>/dev/null || true)" == "$app_identity" ]]; then
-      kill "$app_pid" 2>/dev/null || true
-    fi
+  if [[ "$published" -eq 0 ]]; then
+    local pair pid identity
+    for pair in \
+      "$app_pid|$app_identity" \
+      "$restart_healthy_pid|$restart_healthy_identity" \
+      "$restart_unhealthy_pid|$restart_unhealthy_identity"
+    do
+      pid="${pair%%|*}"
+      identity="${pair#*|}"
+      if [[ -n "$pid" && "$(process_identity "$pid" 2>/dev/null || true)" == "$identity" ]]; then
+        kill "$pid" 2>/dev/null || true
+      fi
+    done
   fi
 }
 trap cleanup_failed_publication EXIT
@@ -75,6 +88,45 @@ PY
 done
 if [[ -z "$app_identity" || "$service_ready" -ne 1 ]]; then
   printf 'local app did not become probeable\n' >&2
+  exit 1
+fi
+
+restart_healthy_port="$(tr -d '[:space:]' <fixture-restart-healthy-port.txt)"
+restart_unhealthy_port="$(tr -d '[:space:]' <fixture-restart-unhealthy-port.txt)"
+restart_healthy_url="http://127.0.0.1:${restart_healthy_port}/health"
+restart_unhealthy_url="http://127.0.0.1:${restart_unhealthy_port}/unhealthy"
+
+nohup "$python_bin" "$app_script" --port "$restart_healthy_port" \
+  </dev/null >"$run_dir/restart-healthy.stdout.log" 2>"$run_dir/restart-healthy.stderr.log" &
+restart_healthy_pid=$!
+nohup "$python_bin" "$app_script" --port "$restart_unhealthy_port" \
+  </dev/null >"$run_dir/restart-unhealthy.stdout.log" 2>"$run_dir/restart-unhealthy.stderr.log" &
+restart_unhealthy_pid=$!
+
+for _ in $(seq 1 100); do
+  restart_healthy_identity="$(process_identity "$restart_healthy_pid" 2>/dev/null || true)"
+  restart_unhealthy_identity="$(process_identity "$restart_unhealthy_pid" 2>/dev/null || true)"
+  healthy_ready=0
+  unhealthy_ready=0
+  if [[ -n "$restart_healthy_identity" ]] && "$python_bin" - "http://127.0.0.1:${restart_healthy_port}/health" <<'PY' >/dev/null 2>&1
+import sys
+from urllib.request import urlopen
+with urlopen(sys.argv[1], timeout=0.2) as response:
+    assert response.status == 200
+PY
+  then healthy_ready=1; fi
+  if [[ -n "$restart_unhealthy_identity" ]] && "$python_bin" - "http://127.0.0.1:${restart_unhealthy_port}/health" <<'PY' >/dev/null 2>&1
+import sys
+from urllib.request import urlopen
+with urlopen(sys.argv[1], timeout=0.2) as response:
+    assert response.status == 200
+PY
+  then unhealthy_ready=1; fi
+  if [[ "$healthy_ready" -eq 1 && "$unhealthy_ready" -eq 1 ]]; then break; fi
+  sleep 0.02
+done
+if [[ "${healthy_ready:-0}" -ne 1 || "${unhealthy_ready:-0}" -ne 1 ]]; then
+  printf 'restart service fixtures did not become probeable\n' >&2
   exit 1
 fi
 
@@ -144,6 +196,8 @@ cat >"$run_dir/result.json" <<EOF
     {"proposal_id":"local-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","attach","stop","restart","cleanup","reconcile"],"target":{"kind":"process","pid":$app_pid,"start_identity":"$app_identity","command":["$python_bin","$app_script","--port","$port"]}},
     {"proposal_id":"local-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"service","url":"$url","health_url":"$health_url"}},
     {"proposal_id":"local-unhealthy-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"service","url":"$url","health_url":"$unhealthy_url"}},
+    {"proposal_id":"local-restart-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"yardlet","capabilities":["open","restart","cleanup","reconcile"],"target":{"kind":"service","url":"$restart_healthy_url","health_url":"$restart_healthy_url","pid":$restart_healthy_pid,"start_identity":"$restart_healthy_identity","restart_command":["$python_bin","$app_script","--port","$restart_healthy_port"]}},
+    {"proposal_id":"local-unhealthy-restart-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"yardlet","capabilities":["open","restart","cleanup","reconcile"],"target":{"kind":"service","url":"http://127.0.0.1:${restart_unhealthy_port}/","health_url":"$restart_unhealthy_url","pid":$restart_unhealthy_pid,"start_identity":"$restart_unhealthy_identity","restart_command":["$python_bin","$app_script","--port","$restart_unhealthy_port"]}},
     {"proposal_id":"local-open-only-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open"],"target":{"kind":"browser","url":"$url","session_id":"local-open-only-browser"}},
     {"proposal_id":"local-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-browser-$browser_pid","pid":$browser_pid,"start_identity":"$browser_identity"}},
     {"proposal_id":"local-live-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","capabilities":["open","reconcile"],"target":{"kind":"browser","url":"$url","session_id":"local-active-browser-session","session_probe_url":"$browser_session_url","pid":$app_pid,"start_identity":"$app_identity"}},

--- a/tests/fixtures/v010_004_local_app/worker.sh
+++ b/tests/fixtures/v010_004_local_app/worker.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'v010-004-local-app-fixture 1.0\n'
+  exit 0
+fi
+
+run_dir="${1:?run directory is required}"
+app_script="${2:?local app script is required}"
+capture_script="${3:?browser capture script is required}"
+packet="$(cat)"
+task_id="$(sed -n 's/^# Yardlet task packet: //p' <<<"$packet" | head -n 1)"
+run_id="${run_dir##*/}"
+python_bin="$(command -v python3)"
+
+if [[ "$task_id" != "YARD-LOCAL-APP" ]]; then
+  printf 'unexpected task %s\n' "$task_id" >&2
+  exit 64
+fi
+
+fnv_digest() {
+  local file="$1" byte
+  local hash=$((0xcbf29ce484222325))
+  for byte in $(od -An -tu1 "$file"); do
+    hash=$(((hash ^ byte) * 1099511628211))
+  done
+  printf 'fnv1a64:%016x' "$hash"
+}
+
+process_identity() {
+  ps -o lstart= -p "$1" | xargs
+}
+
+port="$(tr -d '[:space:]' <fixture-port.txt)"
+url="http://127.0.0.1:${port}/"
+health_url="http://127.0.0.1:${port}/health"
+external_meta="$(cat external-sentinel.meta)"
+external_pid="${external_meta%%|*}"
+external_identity="${external_meta#*|}"
+external_identity="${external_identity%$'\n'}"
+app_pid=''
+app_identity=''
+published=0
+
+cleanup_failed_publication() {
+  if [[ "$published" -eq 0 && -n "$app_pid" ]]; then
+    if [[ "$(process_identity "$app_pid" 2>/dev/null || true)" == "$app_identity" ]]; then
+      kill "$app_pid" 2>/dev/null || true
+    fi
+  fi
+}
+trap cleanup_failed_publication EXIT
+
+nohup "$python_bin" "$app_script" --port "$port" \
+  </dev/null >"$run_dir/local-app.stdout.log" 2>"$run_dir/local-app.stderr.log" &
+app_pid=$!
+service_ready=0
+for _ in $(seq 1 100); do
+  app_identity="$(process_identity "$app_pid" 2>/dev/null || true)"
+  if [[ -n "$app_identity" ]] && "$python_bin" - "$health_url" <<'PY' >/dev/null 2>&1
+import sys
+from urllib.request import urlopen
+
+with urlopen(sys.argv[1], timeout=0.2) as response:
+    assert response.status == 200
+PY
+  then
+    service_ready=1
+    break
+  fi
+  sleep 0.02
+done
+if [[ -z "$app_identity" || "$service_ready" -ne 1 ]]; then
+  printf 'local app did not become probeable\n' >&2
+  exit 1
+fi
+
+printf 'state=after\n' >app-state.txt
+git diff -- app-state.txt >local-app.diff
+
+browser_meta="$run_dir/local-browser.json"
+"$python_bin" "$capture_script" "$url" local-app-screenshot.png "$browser_meta"
+browser_pid="$("$python_bin" -c 'import json,sys; print(json.load(open(sys.argv[1]))["pid"])' "$browser_meta")"
+browser_identity="$("$python_bin" -c 'import json,sys; print(json.load(open(sys.argv[1]))["start_identity"])' "$browser_meta")"
+
+"$python_bin" - "$url" "$health_url" >local-app-validation.json <<'PY'
+import json
+import sys
+from urllib.request import urlopen
+
+with urlopen(sys.argv[1], timeout=1) as response:
+    page = response.read().decode()
+    page_status = response.status
+with urlopen(sys.argv[2], timeout=1) as response:
+    health = json.loads(response.read())
+    health_status = response.status
+assert page_status == 200
+assert health_status == 200
+assert "yardlet-local-app" in page
+assert health == {"status": "ok", "marker": "yardlet-local-app"}
+print(json.dumps({"page_status": page_status, "health_status": health_status, "marker": health["marker"]}))
+PY
+
+terminal_identity="$(process_identity $$)"
+screenshot_digest="$(fnv_digest local-app-screenshot.png)"
+diff_digest="$(fnv_digest local-app.diff)"
+validation_digest="$(fnv_digest local-app-validation.json)"
+
+cat >"$run_dir/handoff.md" <<'EOF'
+# Local app fixture handoff
+
+실제 localhost app, headless browser screenshot, diff, validation evidence를 게시했다.
+EOF
+
+cat >"$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "$task_id",
+  "status": "done",
+  "intent_adherence": {"drift_detected": false, "notes": ""},
+  "changes": {
+    "files_modified": ["app-state.txt"],
+    "files_created": ["local-app-screenshot.png", "local-app.diff", "local-app-validation.json"],
+    "files_deleted": []
+  },
+  "validation": {
+    "commands_run": ["headless Chromium screenshot", "localhost page and health probe"],
+    "passed": true,
+    "failures": []
+  },
+  "question_for_user": null,
+  "compact_summary": "실제 local app resource와 retained browser evidence를 게시했다.",
+  "artifacts": [
+    {"proposal_id":"local-screenshot","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","path":"local-app-screenshot.png","digest":"$screenshot_digest","media_type":"image/png","role":"screenshot"},
+    {"proposal_id":"local-diff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","path":"local-app.diff","digest":"$diff_digest","media_type":"text/x-diff","role":"git_diff"},
+    {"proposal_id":"local-validation","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","path":"local-app-validation.json","digest":"$validation_digest","media_type":"application/json","role":"validation_output"}
+  ],
+  "resources": [
+    {"proposal_id":"local-terminal","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"terminal","terminal_id":"local-app-worker-terminal","pid":$$,"start_identity":"$terminal_identity","attach_hint":"worker process terminal"}},
+    {"proposal_id":"local-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"process","pid":$app_pid,"start_identity":"$app_identity","command":["$python_bin","$app_script","--port","$port"]}},
+    {"proposal_id":"local-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"service","url":"$url","health_url":"$health_url"}},
+    {"proposal_id":"local-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"browser","url":"$url","session_id":"local-browser-$browser_pid","pid":$browser_pid,"start_identity":"$browser_identity"}},
+    {"proposal_id":"local-external","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"local-app-fixture"},"causation_id":"$run_id","ownership":"external","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","120"]}}
+  ],
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+
+published=1

--- a/tests/fixtures/v010_004_resource_model/worker.sh
+++ b/tests/fixtures/v010_004_resource_model/worker.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'v010-004-resource-fixture 1.0\n'
+  exit 0
+fi
+
+run_dir="${1:?run directory is required}"
+packet="$(cat)"
+task_id="$(sed -n 's/^# Yardlet task packet: //p' <<<"$packet" | head -n 1)"
+run_id="${run_dir##*/}"
+
+fnv_digest() {
+  local file="$1" byte
+  local hash=$((0xcbf29ce484222325))
+  for byte in $(od -An -tu1 "$file"); do
+    hash=$(((hash ^ byte) * 1099511628211))
+  done
+  printf 'fnv1a64:%016x' "$hash"
+}
+
+write_handoff() {
+  printf '# Fixture handoff\n' >"$run_dir/handoff.md"
+}
+
+case "$task_id" in
+  YARD-OPS)
+    start_child() {
+      /bin/sleep 90 </dev/null >/dev/null 2>&1 &
+      local pid=$!
+      local identity
+      identity="$(ps -o lstart= -p "$pid" | xargs)"
+      printf '%s|%s\n' "$pid" "$identity"
+    }
+    stop_child="$(start_child)"
+    restart_child="$(start_child)"
+    cleanup_child="$(start_child)"
+    detach_child="$(start_child)"
+    external_child="$(start_child)"
+    dead_child="$(start_child)"
+    stop_pid="${stop_child%%|*}"; stop_identity="${stop_child#*|}"
+    restart_pid="${restart_child%%|*}"; restart_identity="${restart_child#*|}"
+    cleanup_pid="${cleanup_child%%|*}"; cleanup_identity="${cleanup_child#*|}"
+    detach_pid="${detach_child%%|*}"; detach_identity="${detach_child#*|}"
+    external_pid="${external_child%%|*}"; external_identity="${external_child#*|}"
+    dead_pid="${dead_child%%|*}"; dead_identity="${dead_child#*|}"
+    kill "$dead_pid"
+    wait "$dead_pid" 2>/dev/null || true
+    printf '%s\n' "$stop_pid" "$restart_pid" "$cleanup_pid" "$detach_pid" "$external_pid" >ops-pids.txt
+    printf 'open me\n' >ops-file.txt
+    file_digest="$(fnv_digest ops-file.txt)"
+    write_handoff
+    cat >"$run_dir/result.json" <<EOF
+{
+  "schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done",
+  "changes":{"files_created":["ops-pids.txt","ops-file.txt"]},
+  "validation":{"commands_run":[],"passed":true,"failures":[]},
+  "compact_summary":"resource operation fixture",
+  "artifacts":[
+    {"proposal_id":"ops-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"ops-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"}
+  ],
+  "resources":[
+    {"proposal_id":"ops-stop","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$stop_pid,"start_identity":"$stop_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-restart","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"yardlet","target":{"kind":"process","pid":$restart_pid,"start_identity":"$restart_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-cleanup","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"yardlet","target":{"kind":"process","pid":$cleanup_pid,"start_identity":"$cleanup_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-detach","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"terminal","terminal_id":"ops-terminal","pid":$detach_pid,"start_identity":"$detach_identity","attach_hint":"fixture attach"}},
+    {"proposal_id":"ops-external","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"external","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-unknown","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"unknown","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-mismatch","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$external_pid,"start_identity":"forged-start-identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-dead","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$dead_pid,"start_identity":"$dead_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"service","url":"http://127.0.0.1:9/health"}},
+    {"proposal_id":"ops-unrecoverable","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"service","url":"not-a-url"}},
+    {"proposal_id":"ops-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"browser","url":"http://127.0.0.1:9/","session_id":"expired-browser"}}
+  ]
+}
+EOF
+    ;;
+  YARD-001)
+    printf 'file artifact\n' >artifact-file.txt
+    printf 'screenshot bytes\n' >artifact-screenshot.png
+    printf 'diff --git a/a b/a\n' >artifact.diff
+    printf 'validation passed\n' >artifact-validation.log
+    printf '{"verdict":"pass"}\n' >artifact-review.json
+    printf '# durable handoff\n' >artifact-handoff.md
+
+    terminal_identity="$(ps -o lstart= -p $$ | xargs)"
+    file_digest="$(fnv_digest artifact-file.txt)"
+    screenshot_digest="$(fnv_digest artifact-screenshot.png)"
+    diff_digest="$(fnv_digest artifact.diff)"
+    validation_digest="$(fnv_digest artifact-validation.log)"
+    review_digest="$(fnv_digest artifact-review.json)"
+    handoff_digest="$(fnv_digest artifact-handoff.md)"
+
+    write_handoff
+    cat >"$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "$task_id",
+  "status": "done",
+  "changes": {"files_created": ["artifact-file.txt", "artifact-screenshot.png", "artifact.diff", "artifact-validation.log", "artifact-review.json", "artifact-handoff.md"]},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "compact_summary": "typed resource publication fixture",
+  "artifacts": [
+    {"proposal_id":"proposal-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"},
+    {"proposal_id":"proposal-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"},
+    {"proposal_id":"proposal-screenshot","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-screenshot.png","digest":"$screenshot_digest","media_type":"image/png","role":"screenshot"},
+    {"proposal_id":"proposal-diff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact.diff","digest":"$diff_digest","media_type":"text/x-diff","role":"git_diff"},
+    {"proposal_id":"proposal-validation","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-validation.log","digest":"$validation_digest","media_type":"text/plain","role":"validation_output"},
+    {"proposal_id":"proposal-review","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-review.json","digest":"$review_digest","media_type":"application/json","role":"review_report"},
+    {"proposal_id":"proposal-handoff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-handoff.md","digest":"$handoff_digest","media_type":"text/markdown","role":"handoff"}
+  ],
+  "resources": [
+    {"proposal_id":"proposal-terminal","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"terminal","terminal_id":"fixture-terminal","pid":$$,"start_identity":"$terminal_identity"}},
+    {"proposal_id":"proposal-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$$,"start_identity":"$terminal_identity","command":["fixture-worker"]}},
+    {"proposal_id":"proposal-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"service","url":"http://127.0.0.1:9/health"}},
+    {"proposal_id":"proposal-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"browser","url":"http://127.0.0.1:9/","session_id":"fixture-browser"}}
+  ]
+}
+EOF
+    ;;
+  YARD-CAP)
+    mkdir -p cap-artifacts
+    artifacts=''
+    changes=''
+    for index in $(seq -w 1 140); do
+      path="cap-artifacts/$index.txt"
+      printf 'artifact %s\n' "$index" >"$path"
+      digest="$(fnv_digest "$path")"
+      [[ -z "$artifacts" ]] || artifacts+=','
+      [[ -z "$changes" ]] || changes+=','
+      artifacts+="{\"proposal_id\":\"cap-$index\",\"task_id\":\"$task_id\",\"attempt_id\":\"$run_id\",\"producer\":{\"worker_id\":\"fixture\"},\"causation_id\":\"fixture-result\",\"path\":\"$path\",\"digest\":\"$digest\",\"media_type\":\"text/plain\",\"role\":\"file\"}"
+      changes+="\"$path\""
+    done
+    write_handoff
+    cat >"$run_dir/result.json" <<EOF
+{"schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done","changes":{"files_created":[$changes]},"validation":{"commands_run":[],"passed":true,"failures":[]},"compact_summary":"bounded artifact fixture","artifacts":[$artifacts]}
+EOF
+    ;;
+  YARD-BAD)
+    printf 'unowned evidence\n' >unowned.txt
+    digest="$(fnv_digest unowned.txt)"
+    write_handoff
+    cat >"$run_dir/result.json" <<EOF
+{"schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done","changes":{"files_created":["unowned.txt"]},"validation":{"commands_run":[],"passed":true,"failures":[]},"compact_summary":"must not complete","artifacts":[{"proposal_id":"bad","task_id":"$task_id","attempt_id":"","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"unowned.txt","digest":"$digest","media_type":"text/plain","role":"file"}]}
+EOF
+    ;;
+  *)
+    printf 'unexpected task %s\n' "$task_id" >&2
+    exit 64
+    ;;
+esac

--- a/tests/fixtures/v010_004_resource_model/worker.sh
+++ b/tests/fixtures/v010_004_resource_model/worker.sh
@@ -58,20 +58,20 @@ case "$task_id" in
   "validation":{"commands_run":[],"passed":true,"failures":[]},
   "compact_summary":"resource operation fixture",
   "artifacts":[
-    {"proposal_id":"ops-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"ops-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"}
+    {"proposal_id":"ops-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"ops-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"}
   ],
   "resources":[
-    {"proposal_id":"ops-stop","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$stop_pid,"start_identity":"$stop_identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-restart","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"yardlet","target":{"kind":"process","pid":$restart_pid,"start_identity":"$restart_identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-cleanup","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"yardlet","target":{"kind":"process","pid":$cleanup_pid,"start_identity":"$cleanup_identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-detach","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"terminal","terminal_id":"ops-terminal","pid":$detach_pid,"start_identity":"$detach_identity","attach_hint":"fixture attach"}},
-    {"proposal_id":"ops-external","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"external","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-unknown","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"unknown","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-mismatch","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$external_pid,"start_identity":"forged-start-identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-dead","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$dead_pid,"start_identity":"$dead_identity","command":["/bin/sleep","90"]}},
-    {"proposal_id":"ops-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"service","url":"http://127.0.0.1:9/health"}},
-    {"proposal_id":"ops-unrecoverable","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"service","url":"not-a-url"}},
-    {"proposal_id":"ops-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"browser","url":"http://127.0.0.1:9/","session_id":"expired-browser"}}
+    {"proposal_id":"ops-stop","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"process","pid":$stop_pid,"start_identity":"$stop_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-restart","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"yardlet","target":{"kind":"process","pid":$restart_pid,"start_identity":"$restart_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-cleanup","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"yardlet","target":{"kind":"process","pid":$cleanup_pid,"start_identity":"$cleanup_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-detach","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"terminal","terminal_id":"ops-terminal","pid":$detach_pid,"start_identity":"$detach_identity","attach_hint":"fixture attach"}},
+    {"proposal_id":"ops-external","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"external","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-unknown","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"unknown","target":{"kind":"process","pid":$external_pid,"start_identity":"$external_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-mismatch","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"process","pid":$external_pid,"start_identity":"forged-start-identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-dead","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"process","pid":$dead_pid,"start_identity":"$dead_identity","command":["/bin/sleep","90"]}},
+    {"proposal_id":"ops-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"service","url":"http://127.0.0.1:9/health"}},
+    {"proposal_id":"ops-unrecoverable","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"service","url":"not-a-url"}},
+    {"proposal_id":"ops-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"browser","url":"http://127.0.0.1:9/","session_id":"expired-browser"}}
   ]
 }
 EOF
@@ -103,19 +103,19 @@ EOF
   "validation": {"commands_run": [], "passed": true, "failures": []},
   "compact_summary": "typed resource publication fixture",
   "artifacts": [
-    {"proposal_id":"proposal-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"},
-    {"proposal_id":"proposal-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"},
-    {"proposal_id":"proposal-screenshot","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-screenshot.png","digest":"$screenshot_digest","media_type":"image/png","role":"screenshot"},
-    {"proposal_id":"proposal-diff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact.diff","digest":"$diff_digest","media_type":"text/x-diff","role":"git_diff"},
-    {"proposal_id":"proposal-validation","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-validation.log","digest":"$validation_digest","media_type":"text/plain","role":"validation_output"},
-    {"proposal_id":"proposal-review","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-review.json","digest":"$review_digest","media_type":"application/json","role":"review_report"},
-    {"proposal_id":"proposal-handoff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"artifact-handoff.md","digest":"$handoff_digest","media_type":"text/markdown","role":"handoff"}
+    {"proposal_id":"proposal-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"},
+    {"proposal_id":"proposal-file","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact-file.txt","digest":"$file_digest","media_type":"text/plain","role":"file"},
+    {"proposal_id":"proposal-screenshot","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact-screenshot.png","digest":"$screenshot_digest","media_type":"image/png","role":"screenshot"},
+    {"proposal_id":"proposal-diff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact.diff","digest":"$diff_digest","media_type":"text/x-diff","role":"git_diff"},
+    {"proposal_id":"proposal-validation","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact-validation.log","digest":"$validation_digest","media_type":"text/plain","role":"validation_output"},
+    {"proposal_id":"proposal-review","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact-review.json","digest":"$review_digest","media_type":"application/json","role":"review_report"},
+    {"proposal_id":"proposal-handoff","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"artifact-handoff.md","digest":"$handoff_digest","media_type":"text/markdown","role":"handoff"}
   ],
   "resources": [
-    {"proposal_id":"proposal-terminal","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"terminal","terminal_id":"fixture-terminal","pid":$$,"start_identity":"$terminal_identity"}},
-    {"proposal_id":"proposal-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"process","pid":$$,"start_identity":"$terminal_identity","command":["fixture-worker"]}},
-    {"proposal_id":"proposal-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"service","url":"http://127.0.0.1:9/health"}},
-    {"proposal_id":"proposal-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","ownership":"worker","target":{"kind":"browser","url":"http://127.0.0.1:9/","session_id":"fixture-browser"}}
+    {"proposal_id":"proposal-terminal","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"terminal","terminal_id":"fixture-terminal","pid":$$,"start_identity":"$terminal_identity"}},
+    {"proposal_id":"proposal-process","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"process","pid":$$,"start_identity":"$terminal_identity","command":["fixture-worker"]}},
+    {"proposal_id":"proposal-service","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"service","url":"http://127.0.0.1:9/health"}},
+    {"proposal_id":"proposal-browser","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"$run_id","ownership":"worker","target":{"kind":"browser","url":"http://127.0.0.1:9/","session_id":"fixture-browser"}}
   ]
 }
 EOF
@@ -130,7 +130,7 @@ EOF
       digest="$(fnv_digest "$path")"
       [[ -z "$artifacts" ]] || artifacts+=','
       [[ -z "$changes" ]] || changes+=','
-      artifacts+="{\"proposal_id\":\"cap-$index\",\"task_id\":\"$task_id\",\"attempt_id\":\"$run_id\",\"producer\":{\"worker_id\":\"fixture\"},\"causation_id\":\"fixture-result\",\"path\":\"$path\",\"digest\":\"$digest\",\"media_type\":\"text/plain\",\"role\":\"file\"}"
+      artifacts+="{\"proposal_id\":\"cap-$index\",\"task_id\":\"$task_id\",\"attempt_id\":\"$run_id\",\"producer\":{\"worker_id\":\"fixture\"},\"causation_id\":\"$run_id\",\"path\":\"$path\",\"digest\":\"$digest\",\"media_type\":\"text/plain\",\"role\":\"file\"}"
       changes+="\"$path\""
     done
     write_handoff
@@ -138,12 +138,20 @@ EOF
 {"schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done","changes":{"files_created":[$changes]},"validation":{"commands_run":[],"passed":true,"failures":[]},"compact_summary":"bounded artifact fixture","artifacts":[$artifacts]}
 EOF
     ;;
+  YARD-CAUSE)
+    printf 'forged causation\n' >forged-causation.txt
+    digest="$(fnv_digest forged-causation.txt)"
+    write_handoff
+    cat >"$run_dir/result.json" <<EOF
+{"schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done","changes":{"files_created":["forged-causation.txt"]},"validation":{"commands_run":[],"passed":true,"failures":[]},"compact_summary":"must reject forged causation","artifacts":[{"proposal_id":"forged-cause","task_id":"$task_id","attempt_id":"$run_id","producer":{"worker_id":"fixture"},"causation_id":"evt-from-another-attempt","path":"forged-causation.txt","digest":"$digest","media_type":"text/plain","role":"file"}]}
+EOF
+    ;;
   YARD-BAD)
     printf 'unowned evidence\n' >unowned.txt
     digest="$(fnv_digest unowned.txt)"
     write_handoff
     cat >"$run_dir/result.json" <<EOF
-{"schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done","changes":{"files_created":["unowned.txt"]},"validation":{"commands_run":[],"passed":true,"failures":[]},"compact_summary":"must not complete","artifacts":[{"proposal_id":"bad","task_id":"$task_id","attempt_id":"","producer":{"worker_id":"fixture"},"causation_id":"fixture-result","path":"unowned.txt","digest":"$digest","media_type":"text/plain","role":"file"}]}
+{"schema_version":1,"run_id":"$run_id","task_id":"$task_id","status":"done","changes":{"files_created":["unowned.txt"]},"validation":{"commands_run":[],"passed":true,"failures":[]},"compact_summary":"must not complete","artifacts":[{"proposal_id":"bad","task_id":"$task_id","attempt_id":"","producer":{"worker_id":"fixture"},"causation_id":"$run_id","path":"unowned.txt","digest":"$digest","media_type":"text/plain","role":"file"}]}
 EOF
     ;;
   *)

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -1,0 +1,575 @@
+#[cfg(unix)]
+mod unix {
+    use serde_json::Value;
+    use std::collections::HashSet;
+    use std::fs;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::{Child, Command, Output, Stdio};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    const TASK_ID: &str = "YARD-LOCAL-APP";
+
+    struct ExternalSentinel {
+        child: Child,
+        start_identity: String,
+    }
+
+    impl ExternalSentinel {
+        fn spawn() -> Self {
+            let child = Command::new("/bin/sleep")
+                .arg("120")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn external sentinel");
+            let start_identity = wait_for_identity(child.id());
+            Self {
+                child,
+                start_identity,
+            }
+        }
+
+        fn pid(&self) -> u32 {
+            self.child.id()
+        }
+
+        fn is_alive(&self) -> bool {
+            process_identity(self.pid()).as_deref() == Some(self.start_identity.as_str())
+        }
+    }
+
+    impl Drop for ExternalSentinel {
+        fn drop(&mut self) {
+            if self.is_alive() {
+                let _ = Command::new("kill").arg(self.pid().to_string()).status();
+            }
+            let _ = self.child.wait();
+        }
+    }
+
+    struct Fixture {
+        root: PathBuf,
+        binary: PathBuf,
+        owned_process: Option<(u32, String)>,
+    }
+
+    impl Fixture {
+        fn new(sentinel: &ExternalSentinel) -> Self {
+            let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before Unix epoch")
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "yardlet-v010-004-local-app-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).expect("create fixture workspace");
+
+            must_succeed(&root, Path::new("git"), &["init", "-q"]);
+            must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+            must_succeed(
+                &root,
+                Path::new("git"),
+                &["config", "user.email", "fixture@example.invalid"],
+            );
+            fs::write(root.join("README.md"), "local app fixture\n").unwrap();
+            fs::write(root.join("app-state.txt"), "state=before\n").unwrap();
+            fs::write(root.join("unrelated.txt"), "preserve me\n").unwrap();
+            let port = reserve_local_port();
+            fs::write(root.join("fixture-port.txt"), format!("{port}\n")).unwrap();
+            fs::write(
+                root.join("external-sentinel.meta"),
+                format!("{}|{}\n", sentinel.pid(), sentinel.start_identity),
+            )
+            .unwrap();
+            must_succeed(
+                &root,
+                Path::new("git"),
+                &[
+                    "add",
+                    "README.md",
+                    "app-state.txt",
+                    "unrelated.txt",
+                    "fixture-port.txt",
+                    "external-sentinel.meta",
+                ],
+            );
+            must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+            must_succeed(&root, &binary, &["init"]);
+
+            let fixture_source = manifest.join("tests/fixtures/v010_004_local_app");
+            let fixture_bin = root.join(".agents/fixture-bin");
+            fs::create_dir_all(&fixture_bin).unwrap();
+            let worker = copy_fixture(&fixture_source, &fixture_bin, "worker.sh");
+            let app = copy_fixture(&fixture_source, &fixture_bin, "app.py");
+            let capture = copy_fixture(&fixture_source, &fixture_bin, "capture_browser.py");
+            let mut permissions = fs::metadata(&worker).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&worker, permissions).unwrap();
+
+            let config_path = root.join(".agents/yardlet.yaml");
+            let config = fs::read_to_string(&config_path)
+                .unwrap()
+                .replace("auto_commit: false", "auto_commit: true");
+            fs::write(config_path, config).unwrap();
+            fs::write(
+                root.join(".agents/workers.yaml"),
+                format!(
+                    "schema_version: 1\nworkers:\n  - id: local-app-fixture\n    invocation:\n      command: \"{}\"\n      args: [\"{{run_dir}}\", \"{}\", \"{}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: local-app-fixture\n  fallback_order: [local-app-fixture]\n",
+                    worker.display(),
+                    app.display(),
+                    capture.display()
+                ),
+            )
+            .unwrap();
+            fs::write(
+                root.join(".agents/intent-contract.yaml"),
+                "schema_version: 1\nid: intent-local-app-dogfood\nsummary: local app resource dogfood\nstatus: accepted\n",
+            )
+            .unwrap();
+            fs::write(
+                root.join(".agents/work-queue.yaml"),
+                "schema_version: 1\nqueue_id: queue-local-app-dogfood\nintent_id: intent-local-app-dogfood\ntasks:\n  - {id: YARD-LOCAL-APP, title: publish a real local app, state: queued, priority: 10, preferred_worker: local-app-fixture}\n",
+            )
+            .unwrap();
+
+            Self {
+                root,
+                binary,
+                owned_process: None,
+            }
+        }
+
+        fn run_process(&self, args: &[&str]) -> (u32, Output) {
+            let child = Command::new(&self.binary)
+                .args(args)
+                .current_dir(&self.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap_or_else(|error| panic!("failed to run yardlet {args:?}: {error}"));
+            let pid = child.id();
+            let output = child.wait_with_output().expect("wait for yardlet process");
+            assert!(
+                output.status.success(),
+                "yardlet {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            (pid, output)
+        }
+
+        fn json_process(&self, args: &[&str]) -> (u32, Value) {
+            let (pid, output) = self.run_process(args);
+            let value = serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+                panic!(
+                    "invalid JSON from yardlet {args:?}: {error}\n{}",
+                    String::from_utf8_lossy(&output.stdout)
+                )
+            });
+            (pid, value)
+        }
+
+        fn remember_owned_process(&mut self, resource: &Value) {
+            self.owned_process = Some((
+                resource["target"]["pid"].as_u64().unwrap() as u32,
+                resource["target"]["start_identity"]
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
+            ));
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            if let Some((pid, identity)) = &self.owned_process {
+                terminate_if_exact(*pid, identity);
+            }
+            if std::thread::panicking() {
+                eprintln!(
+                    "V010-004 local app evidence kept at {}",
+                    self.root.display()
+                );
+                return;
+            }
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn copy_fixture(source: &Path, target: &Path, name: &str) -> PathBuf {
+        let destination = target.join(name);
+        fs::copy(source.join(name), &destination)
+            .unwrap_or_else(|error| panic!("copy fixture {name}: {error}"));
+        destination
+    }
+
+    fn command(root: &Path, program: &Path, args: &[&str]) -> Output {
+        Command::new(program)
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()))
+    }
+
+    fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+        let output = command(root, program, args);
+        assert!(
+            output.status.success(),
+            "{} {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            program.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn reserve_local_port() -> u16 {
+        TcpListener::bind(("127.0.0.1", 0))
+            .expect("reserve local app port")
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn process_identity(pid: u32) -> Option<String> {
+        let output = Command::new("ps")
+            .args(["-o", "lstart=", "-p", &pid.to_string()])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let identity = String::from_utf8_lossy(&output.stdout)
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        (!identity.is_empty()).then_some(identity)
+    }
+
+    fn wait_for_identity(pid: u32) -> String {
+        for _ in 0..50 {
+            if let Some(identity) = process_identity(pid) {
+                return identity;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("process {pid} never exposed a start identity");
+    }
+
+    fn terminate_if_exact(pid: u32, identity: &str) {
+        if process_identity(pid).as_deref() != Some(identity) {
+            return;
+        }
+        let _ = Command::new("kill").arg(pid.to_string()).status();
+        for _ in 0..50 {
+            if process_identity(pid).is_none() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    fn digest_bytes(bytes: &[u8]) -> String {
+        let mut hash = 0xcbf29ce484222325_u64;
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        format!("fnv1a64:{hash:016x}")
+    }
+
+    fn entry_by_proposal<'a>(receipt: &'a Value, proposal_id: &str) -> &'a Value {
+        receipt["result"]["entries"]
+            .as_array()
+            .expect("discover entries")
+            .iter()
+            .find(|entry| {
+                entry["artifact"]["proposal_id"].as_str() == Some(proposal_id)
+                    || entry["resource"]["proposal_id"].as_str() == Some(proposal_id)
+            })
+            .unwrap_or_else(|| panic!("missing proposal {proposal_id}: {receipt}"))
+    }
+
+    fn artifact_id(entry: &Value) -> &str {
+        entry["artifact"]["artifact_id"].as_str().unwrap()
+    }
+
+    fn resource_id(entry: &Value) -> &str {
+        entry["resource"]["resource_id"].as_str().unwrap()
+    }
+
+    fn assert_core_record(
+        entry: &Value,
+        proposal_id: &str,
+        attempt_id: &mut Option<String>,
+    ) -> String {
+        let record = entry.get("artifact").unwrap_or(&entry["resource"]);
+        assert_eq!(record["proposal_id"], proposal_id);
+        assert_eq!(record["task_id"], TASK_ID);
+        assert_eq!(record["producer"]["worker_id"], "local-app-fixture");
+        let actual_attempt = record["attempt_id"].as_str().unwrap();
+        assert!(!actual_attempt.is_empty());
+        let causation_id = record["causation_id"].as_str().unwrap();
+        assert!(causation_id.starts_with("evt_"));
+        assert_ne!(causation_id, actual_attempt);
+        if let Some(expected) = attempt_id {
+            assert_eq!(actual_attempt, expected);
+        } else {
+            *attempt_id = Some(actual_attempt.to_string());
+        }
+        let canonical_id = record["artifact_id"]
+            .as_str()
+            .or_else(|| record["resource_id"].as_str())
+            .unwrap();
+        assert!(!canonical_id.is_empty());
+        assert_ne!(canonical_id, proposal_id);
+        assert!(!record["created_event_id"].as_str().unwrap().is_empty());
+        canonical_id.to_string()
+    }
+
+    fn reconcile(fixture: &Fixture, target_id: &str, action_id: &str) -> Value {
+        fixture
+            .json_process(&[
+                "resource",
+                "reconcile",
+                target_id,
+                "--action-id",
+                action_id,
+                "--json",
+            ])
+            .1
+    }
+
+    fn http_get(url: &str) -> String {
+        let authority = url
+            .strip_prefix("http://")
+            .expect("fixture URL must use HTTP")
+            .split('/')
+            .next()
+            .unwrap();
+        let mut stream = TcpStream::connect(authority).expect("connect to local app");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+            .unwrap();
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        response
+    }
+
+    #[test]
+    fn real_local_app_publication_survives_restart_and_expires_honestly() {
+        let sentinel = ExternalSentinel::spawn();
+        let mut fixture = Fixture::new(&sentinel);
+
+        let (publisher_pid, _) = fixture.run_process(&["run", "--task", TASK_ID, "--execute"]);
+        let (discover_pid, discover) = fixture.json_process(&[
+            "resource",
+            "discover",
+            "--task",
+            TASK_ID,
+            "--action-id",
+            "act-local-app-discover-after-restart",
+            "--json",
+        ]);
+        assert_ne!(
+            publisher_pid, discover_pid,
+            "query must run after process restart"
+        );
+        assert_eq!(discover["status"], "completed");
+
+        let proposals = [
+            "local-terminal",
+            "local-process",
+            "local-service",
+            "local-browser",
+            "local-external",
+            "local-screenshot",
+            "local-diff",
+            "local-validation",
+        ];
+        let mut attempt_id = None;
+        let mut canonical_ids = HashSet::new();
+        for proposal in proposals {
+            let canonical_id = assert_core_record(
+                entry_by_proposal(&discover, proposal),
+                proposal,
+                &mut attempt_id,
+            );
+            assert!(canonical_ids.insert(canonical_id));
+        }
+        assert_eq!(canonical_ids.len(), proposals.len());
+
+        let screenshot = entry_by_proposal(&discover, "local-screenshot");
+        assert_eq!(screenshot["status"], "available");
+        assert_eq!(screenshot["artifact"]["role"], "screenshot");
+        assert_eq!(screenshot["artifact"]["media_type"], "image/png");
+        let screenshot_path = PathBuf::from(
+            screenshot["open_target"]["path"]
+                .as_str()
+                .expect("retained screenshot path"),
+        );
+        let screenshot_bytes = fs::read(&screenshot_path).expect("read retained screenshot");
+        assert!(screenshot_bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
+        assert!(
+            screenshot_bytes.len() > 1_000,
+            "screenshot must contain rendered pixels"
+        );
+        assert_eq!(
+            screenshot["artifact"]["digest"],
+            digest_bytes(&screenshot_bytes)
+        );
+
+        let diff = entry_by_proposal(&discover, "local-diff");
+        assert_eq!(diff["status"], "available");
+        assert_eq!(diff["artifact"]["role"], "git_diff");
+        let diff_bytes = fs::read(diff["open_target"]["path"].as_str().unwrap()).unwrap();
+        assert!(String::from_utf8_lossy(&diff_bytes).contains("+state=after"));
+        assert_eq!(diff["artifact"]["digest"], digest_bytes(&diff_bytes));
+
+        let process = entry_by_proposal(&discover, "local-process");
+        let service = entry_by_proposal(&discover, "local-service");
+        let browser = entry_by_proposal(&discover, "local-browser");
+        let terminal = entry_by_proposal(&discover, "local-terminal");
+        let external = entry_by_proposal(&discover, "local-external");
+        assert_eq!(process["resource"]["target"]["kind"], "process");
+        assert_eq!(service["resource"]["target"]["kind"], "service");
+        assert_eq!(browser["resource"]["target"]["kind"], "browser");
+        assert_eq!(terminal["resource"]["target"]["kind"], "terminal");
+        fixture.remember_owned_process(&process["resource"]);
+        let service_url = service["resource"]["target"]["url"].as_str().unwrap();
+        assert!(http_get(service_url).contains("yardlet-local-app"));
+
+        let live_process = reconcile(
+            &fixture,
+            resource_id(process),
+            "act-local-app-reconcile-process-live",
+        );
+        assert_eq!(live_process["result"]["observation"]["status"], "live");
+        assert_eq!(live_process["result"]["observation"]["current"], true);
+        let live_service = reconcile(
+            &fixture,
+            resource_id(service),
+            "act-local-app-reconcile-service-live",
+        );
+        assert_eq!(live_service["result"]["observation"]["status"], "live");
+        let expired_browser = reconcile(
+            &fixture,
+            resource_id(browser),
+            "act-local-app-reconcile-browser-expired",
+        );
+        assert_eq!(
+            expired_browser["result"]["observation"]["status"],
+            "expired"
+        );
+        let dead_terminal = reconcile(
+            &fixture,
+            resource_id(terminal),
+            "act-local-app-reconcile-terminal-dead",
+        );
+        assert_eq!(dead_terminal["result"]["observation"]["status"], "dead");
+
+        let (_, inspect_after_probe) = fixture.json_process(&[
+            "resource",
+            "inspect",
+            resource_id(process),
+            "--action-id",
+            "act-local-app-inspect-last-observed",
+            "--json",
+        ]);
+        assert_eq!(
+            inspect_after_probe["result"]["entries"][0]["status"],
+            "unknown"
+        );
+        assert_eq!(
+            inspect_after_probe["result"]["entries"][0]["last_observation"]["status"],
+            "live"
+        );
+
+        let validation = entry_by_proposal(&discover, "local-validation");
+        let validation_path = PathBuf::from(validation["open_target"]["path"].as_str().unwrap());
+        let validation_bytes = fs::read(&validation_path).unwrap();
+        let validation_json: Value = serde_json::from_slice(&validation_bytes).unwrap();
+        assert_eq!(validation_json["page_status"], 200);
+        assert_eq!(validation_json["health_status"], 200);
+        assert_eq!(validation_json["marker"], "yardlet-local-app");
+        assert_eq!(
+            validation["artifact"]["digest"],
+            digest_bytes(&validation_bytes)
+        );
+        fs::remove_file(&validation_path).expect("remove exact validation artifact");
+        let (_, missing_validation) = fixture.json_process(&[
+            "resource",
+            "open",
+            artifact_id(validation),
+            "--action-id",
+            "act-local-app-open-missing-validation",
+            "--json",
+        ]);
+        assert_eq!(
+            missing_validation["result"]["entries"][0]["status"],
+            "unavailable"
+        );
+        assert_eq!(
+            missing_validation["result"]["open_target"]["target_type"],
+            "unavailable"
+        );
+
+        let (_, rejected_external_cleanup) = fixture.json_process(&[
+            "resource",
+            "cleanup",
+            resource_id(external),
+            "--action-id",
+            "act-local-app-reject-external-cleanup",
+            "--json",
+        ]);
+        assert_eq!(rejected_external_cleanup["status"], "rejected");
+        assert!(rejected_external_cleanup["error"]
+            .as_str()
+            .unwrap()
+            .contains("ownership"));
+        assert!(
+            sentinel.is_alive(),
+            "external process must not be signalled"
+        );
+
+        let (_, cleanup) = fixture.json_process(&[
+            "resource",
+            "cleanup",
+            resource_id(process),
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-local-app-cleanup-owned-process",
+            "--json",
+        ]);
+        assert_eq!(cleanup["status"], "completed");
+        assert_eq!(cleanup["result"]["observation"]["status"], "dead");
+        let unavailable_service = reconcile(
+            &fixture,
+            resource_id(service),
+            "act-local-app-reconcile-service-unavailable",
+        );
+        assert_eq!(
+            unavailable_service["result"]["observation"]["status"],
+            "unavailable"
+        );
+        assert_eq!(
+            fs::read_to_string(fixture.root.join("unrelated.txt")).unwrap(),
+            "preserve me\n"
+        );
+        assert!(sentinel.is_alive());
+
+        drop(fixture);
+        assert!(
+            sentinel.is_alive(),
+            "fixture teardown must preserve external sentinel"
+        );
+    }
+}

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -337,6 +337,19 @@ mod unix {
         })
     }
 
+    fn process_snapshot(pid: u32) -> String {
+        Command::new("ps")
+            .args([
+                "-o",
+                "pid=,ppid=,pgid=,state=,command=",
+                "-p",
+                &pid.to_string(),
+            ])
+            .output()
+            .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+            .unwrap_or_default()
+    }
+
     fn terminate_if_exact(pid: u32, identity: &str) {
         if process_identity(pid).as_deref() != Some(identity) {
             return;
@@ -678,7 +691,8 @@ mod unix {
         assert_eq!(
             healthy_restart["status"],
             "completed",
-            "unexpected restart recovery receipt: {healthy_restart}\nlogs:{}",
+            "unexpected restart recovery receipt: {healthy_restart}\nprocess:{}\nlogs:{}",
+            process_snapshot(spawned_pid),
             fixture.diagnostic_logs()
         );
         assert_eq!(healthy_restart["result"]["observation"]["status"], "live");

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -334,12 +334,19 @@ mod unix {
         canonical_id.to_string()
     }
 
-    fn reconcile(fixture: &Fixture, target_id: &str, action_id: &str) -> Value {
+    fn reconcile(
+        fixture: &Fixture,
+        target_id: &str,
+        expected_status: &str,
+        action_id: &str,
+    ) -> Value {
         fixture
             .json_process(&[
                 "resource",
                 "reconcile",
                 target_id,
+                "--expected-status",
+                expected_status,
                 "--action-id",
                 action_id,
                 "--json",
@@ -372,6 +379,8 @@ mod unix {
         let (discover_pid, discover) = fixture.json_process(&[
             "resource",
             "discover",
+            "--intent",
+            "intent-local-app-dogfood",
             "--task",
             TASK_ID,
             "--action-id",
@@ -388,7 +397,11 @@ mod unix {
             "local-terminal",
             "local-process",
             "local-service",
+            "local-unhealthy-service",
+            "local-open-only-browser",
             "local-browser",
+            "local-live-browser",
+            "local-stale-browser",
             "local-external",
             "local-screenshot",
             "local-diff",
@@ -435,13 +448,34 @@ mod unix {
 
         let process = entry_by_proposal(&discover, "local-process");
         let service = entry_by_proposal(&discover, "local-service");
+        let unhealthy_service = entry_by_proposal(&discover, "local-unhealthy-service");
+        let open_only_browser = entry_by_proposal(&discover, "local-open-only-browser");
         let browser = entry_by_proposal(&discover, "local-browser");
+        let live_browser = entry_by_proposal(&discover, "local-live-browser");
+        let stale_browser = entry_by_proposal(&discover, "local-stale-browser");
         let terminal = entry_by_proposal(&discover, "local-terminal");
         let external = entry_by_proposal(&discover, "local-external");
         assert_eq!(process["resource"]["target"]["kind"], "process");
         assert_eq!(service["resource"]["target"]["kind"], "service");
         assert_eq!(browser["resource"]["target"]["kind"], "browser");
         assert_eq!(terminal["resource"]["target"]["kind"], "terminal");
+        for entry in [
+            process,
+            service,
+            unhealthy_service,
+            open_only_browser,
+            browser,
+            live_browser,
+            stale_browser,
+        ] {
+            assert!(
+                !entry["resource"]["capabilities"]
+                    .as_array()
+                    .expect("typed resource capabilities")
+                    .is_empty(),
+                "runtime declaration must record typed capabilities: {entry}"
+            );
+        }
         fixture.remember_owned_process(&process["resource"]);
         let service_url = service["resource"]["target"]["url"].as_str().unwrap();
         assert!(http_get(service_url).contains("yardlet-local-app"));
@@ -449,6 +483,7 @@ mod unix {
         let live_process = reconcile(
             &fixture,
             resource_id(process),
+            "live",
             "act-local-app-reconcile-process-live",
         );
         assert_eq!(live_process["result"]["observation"]["status"], "live");
@@ -456,21 +491,89 @@ mod unix {
         let live_service = reconcile(
             &fixture,
             resource_id(service),
+            "live",
             "act-local-app-reconcile-service-live",
         );
         assert_eq!(live_service["result"]["observation"]["status"], "live");
         let expired_browser = reconcile(
             &fixture,
             resource_id(browser),
+            "expired",
             "act-local-app-reconcile-browser-expired",
         );
         assert_eq!(
             expired_browser["result"]["observation"]["status"],
             "expired"
         );
+        let live_browser_receipt = reconcile(
+            &fixture,
+            resource_id(live_browser),
+            "live",
+            "act-local-app-reconcile-browser-live-session",
+        );
+        assert_eq!(
+            live_browser_receipt["result"]["observation"]["status"],
+            "live"
+        );
+        let stale_browser_receipt = reconcile(
+            &fixture,
+            resource_id(stale_browser),
+            "expired",
+            "act-local-app-reconcile-browser-stale-session",
+        );
+        assert_eq!(
+            stale_browser_receipt["result"]["observation"]["status"],
+            "expired"
+        );
+        let unhealthy_service_receipt = reconcile(
+            &fixture,
+            resource_id(unhealthy_service),
+            "unavailable",
+            "act-local-app-reconcile-service-unhealthy",
+        );
+        assert_eq!(
+            unhealthy_service_receipt["result"]["observation"]["status"], "unavailable",
+            "an open port with a failing declared health URL is not live"
+        );
+        for (operation, action_id) in [
+            ("stop", "act-local-app-reject-pidless-service-stop"),
+            ("cleanup", "act-local-app-reject-pidless-service-cleanup"),
+        ] {
+            let (_, rejected) = fixture.json_process(&[
+                "resource",
+                operation,
+                resource_id(unhealthy_service),
+                "--expected-status",
+                "unavailable",
+                "--action-id",
+                action_id,
+                "--json",
+            ]);
+            assert_eq!(rejected["status"], "rejected");
+            assert!(rejected["error"].as_str().unwrap().contains("unsupported"));
+        }
+        for operation in [
+            "attach",
+            "stop",
+            "restart",
+            "detach",
+            "cleanup",
+            "reconcile",
+        ] {
+            let action_id = format!("act-local-app-reject-open-only-{operation}");
+            let mut args = vec!["resource", operation, resource_id(open_only_browser)];
+            if operation != "attach" {
+                args.extend(["--expected-status", "expired"]);
+            }
+            args.extend(["--action-id", action_id.as_str(), "--json"]);
+            let (_, rejected) = fixture.json_process(&args);
+            assert_eq!(rejected["status"], "rejected");
+            assert!(rejected["error"].as_str().unwrap().contains("unsupported"));
+        }
         let dead_terminal = reconcile(
             &fixture,
             resource_id(terminal),
+            "dead",
             "act-local-app-reconcile-terminal-dead",
         );
         assert_eq!(dead_terminal["result"]["observation"]["status"], "dead");
@@ -525,6 +628,8 @@ mod unix {
             "resource",
             "cleanup",
             resource_id(external),
+            "--expected-status",
+            "live",
             "--action-id",
             "act-local-app-reject-external-cleanup",
             "--json",
@@ -554,6 +659,7 @@ mod unix {
         let unavailable_service = reconcile(
             &fixture,
             resource_id(service),
+            "unavailable",
             "act-local-app-reconcile-service-unavailable",
         );
         assert_eq!(

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -647,8 +647,10 @@ mod unix {
             .push((spawned_pid, spawned_identity.clone()));
         let (_, healthy_restart) = fixture.json_process(&healthy_restart_args);
         assert_eq!(
-            healthy_restart["status"], "completed",
-            "unexpected restart recovery receipt: {healthy_restart}"
+            healthy_restart["status"],
+            "completed",
+            "unexpected restart recovery receipt: {healthy_restart}\nlogs:{}",
+            fixture.diagnostic_logs()
         );
         assert_eq!(healthy_restart["result"]["observation"]["status"], "live");
         assert_eq!(

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -614,7 +614,10 @@ mod unix {
             .owned_processes
             .push((spawned_pid, spawned_identity.clone()));
         let (_, healthy_restart) = fixture.json_process(&healthy_restart_args);
-        assert_eq!(healthy_restart["status"], "completed");
+        assert_eq!(
+            healthy_restart["status"], "completed",
+            "unexpected restart recovery receipt: {healthy_restart}"
+        );
         assert_eq!(healthy_restart["result"]["observation"]["status"], "live");
         assert_eq!(
             healthy_restart["result"]["observation"]["pid"], spawned_pid,

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -660,6 +660,17 @@ mod unix {
             Some(spawned_pid),
             "restarted resources must survive orchestrator process-group exit"
         );
+        must_succeed(
+            &fixture.root,
+            Path::new("kill"),
+            &["-HUP", &spawned_pid.to_string()],
+        );
+        std::thread::sleep(Duration::from_millis(50));
+        assert_eq!(
+            process_identity(spawned_pid).as_deref(),
+            Some(spawned_identity.as_str()),
+            "restarted resources must ignore session hangup"
+        );
         fixture
             .owned_processes
             .push((spawned_pid, spawned_identity.clone()));

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -324,6 +324,19 @@ mod unix {
         panic!("process {pid} never exposed a start identity");
     }
 
+    fn process_group(pid: u32) -> Option<u32> {
+        let output = Command::new("ps")
+            .args(["-o", "pgid=", "-p", &pid.to_string()])
+            .output()
+            .ok()?;
+        output.status.success().then(|| {
+            String::from_utf8_lossy(&output.stdout)
+                .trim()
+                .parse()
+                .expect("numeric process group")
+        })
+    }
+
     fn terminate_if_exact(pid: u32, identity: &str) {
         if process_identity(pid).as_deref() != Some(identity) {
             return;
@@ -642,6 +655,11 @@ mod unix {
             .as_str()
             .unwrap()
             .to_string();
+        assert_eq!(
+            process_group(spawned_pid),
+            Some(spawned_pid),
+            "restarted resources must survive orchestrator process-group exit"
+        );
         fixture
             .owned_processes
             .push((spawned_pid, spawned_identity.clone()));

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -123,9 +123,13 @@ mod unix {
             let worker = copy_fixture(&fixture_source, &fixture_bin, "worker.sh");
             let app = copy_fixture(&fixture_source, &fixture_bin, "app.py");
             let capture = copy_fixture(&fixture_source, &fixture_bin, "capture_browser.py");
+            let restart = copy_fixture(&fixture_source, &fixture_bin, "restart_app.sh");
             let mut permissions = fs::metadata(&worker).unwrap().permissions();
             permissions.set_mode(0o755);
             fs::set_permissions(&worker, permissions).unwrap();
+            let mut permissions = fs::metadata(&restart).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&restart, permissions).unwrap();
 
             let config_path = root.join(".agents/yardlet.yaml");
             let config = fs::read_to_string(&config_path)
@@ -221,6 +225,26 @@ mod unix {
                 observation["pid"].as_u64().unwrap() as u32,
                 observation["start_identity"].as_str().unwrap().to_string(),
             ));
+        }
+
+        fn diagnostic_logs(&self) -> String {
+            let mut pending = vec![self.root.join(".agents")];
+            let mut logs = String::new();
+            while let Some(directory) = pending.pop() {
+                let Ok(entries) = fs::read_dir(directory) else {
+                    continue;
+                };
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        pending.push(path);
+                    } else if path.extension().and_then(|value| value.to_str()) == Some("log") {
+                        logs.push_str(&format!("\n--- {} ---\n", path.display()));
+                        logs.push_str(&fs::read_to_string(path).unwrap_or_default());
+                    }
+                }
+            }
+            logs
         }
     }
 
@@ -412,7 +436,15 @@ mod unix {
         let sentinel = ExternalSentinel::spawn();
         let mut fixture = Fixture::new(&sentinel);
 
-        let (publisher_pid, _) = fixture.run_process(&["run", "--task", TASK_ID, "--execute"]);
+        let (publisher_pid, publisher) =
+            fixture.run_process(&["run", "--task", TASK_ID, "--execute"]);
+        let publisher_output = String::from_utf8_lossy(&publisher.stdout);
+        assert!(
+            publisher_output.contains("evaluation status: done"),
+            "local app worker did not pass evaluation\nstdout:\n{publisher_output}\nstderr:\n{}\nlogs:{}",
+            String::from_utf8_lossy(&publisher.stderr),
+            fixture.diagnostic_logs()
+        );
         let (discover_pid, discover) = fixture.json_process(&[
             "resource",
             "discover",

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -54,7 +54,7 @@ mod unix {
     struct Fixture {
         root: PathBuf,
         binary: PathBuf,
-        owned_process: Option<(u32, String)>,
+        owned_processes: Vec<(u32, String)>,
     }
 
     impl Fixture {
@@ -82,7 +82,19 @@ mod unix {
             fs::write(root.join("app-state.txt"), "state=before\n").unwrap();
             fs::write(root.join("unrelated.txt"), "preserve me\n").unwrap();
             let port = reserve_local_port();
+            let restart_healthy_port = reserve_local_port();
+            let restart_unhealthy_port = reserve_local_port();
             fs::write(root.join("fixture-port.txt"), format!("{port}\n")).unwrap();
+            fs::write(
+                root.join("fixture-restart-healthy-port.txt"),
+                format!("{restart_healthy_port}\n"),
+            )
+            .unwrap();
+            fs::write(
+                root.join("fixture-restart-unhealthy-port.txt"),
+                format!("{restart_unhealthy_port}\n"),
+            )
+            .unwrap();
             fs::write(
                 root.join("external-sentinel.meta"),
                 format!("{}|{}\n", sentinel.pid(), sentinel.start_identity),
@@ -97,6 +109,8 @@ mod unix {
                     "app-state.txt",
                     "unrelated.txt",
                     "fixture-port.txt",
+                    "fixture-restart-healthy-port.txt",
+                    "fixture-restart-unhealthy-port.txt",
                     "external-sentinel.meta",
                 ],
             );
@@ -142,7 +156,7 @@ mod unix {
             Self {
                 root,
                 binary,
-                owned_process: None,
+                owned_processes: Vec::new(),
             }
         }
 
@@ -176,8 +190,24 @@ mod unix {
             (pid, value)
         }
 
+        fn run_process_with_fault(&self, args: &[&str], fault: &str) -> (u32, Output) {
+            let child = Command::new(&self.binary)
+                .args(args)
+                .current_dir(&self.root)
+                .env("YARDLET_TEST_RESOURCE_ACTION_FAULT", fault)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap_or_else(|error| panic!("failed to run yardlet with {fault}: {error}"));
+            let pid = child.id();
+            let output = child
+                .wait_with_output()
+                .expect("wait for faulted yardlet process");
+            (pid, output)
+        }
+
         fn remember_owned_process(&mut self, resource: &Value) {
-            self.owned_process = Some((
+            self.owned_processes.push((
                 resource["target"]["pid"].as_u64().unwrap() as u32,
                 resource["target"]["start_identity"]
                     .as_str()
@@ -185,11 +215,18 @@ mod unix {
                     .to_string(),
             ));
         }
+
+        fn remember_observation_process(&mut self, observation: &Value) {
+            self.owned_processes.push((
+                observation["pid"].as_u64().unwrap() as u32,
+                observation["start_identity"].as_str().unwrap().to_string(),
+            ));
+        }
     }
 
     impl Drop for Fixture {
         fn drop(&mut self) {
-            if let Some((pid, identity)) = &self.owned_process {
+            for (pid, identity) in &self.owned_processes {
                 terminate_if_exact(*pid, identity);
             }
             if std::thread::panicking() {
@@ -398,6 +435,8 @@ mod unix {
             "local-process",
             "local-service",
             "local-unhealthy-service",
+            "local-restart-service",
+            "local-unhealthy-restart-service",
             "local-open-only-browser",
             "local-browser",
             "local-live-browser",
@@ -449,6 +488,9 @@ mod unix {
         let process = entry_by_proposal(&discover, "local-process");
         let service = entry_by_proposal(&discover, "local-service");
         let unhealthy_service = entry_by_proposal(&discover, "local-unhealthy-service");
+        let restart_service = entry_by_proposal(&discover, "local-restart-service");
+        let unhealthy_restart_service =
+            entry_by_proposal(&discover, "local-unhealthy-restart-service");
         let open_only_browser = entry_by_proposal(&discover, "local-open-only-browser");
         let browser = entry_by_proposal(&discover, "local-browser");
         let live_browser = entry_by_proposal(&discover, "local-live-browser");
@@ -463,6 +505,8 @@ mod unix {
             process,
             service,
             unhealthy_service,
+            restart_service,
+            unhealthy_restart_service,
             open_only_browser,
             browser,
             live_browser,
@@ -477,6 +521,8 @@ mod unix {
             );
         }
         fixture.remember_owned_process(&process["resource"]);
+        fixture.remember_owned_process(&restart_service["resource"]);
+        fixture.remember_owned_process(&unhealthy_restart_service["resource"]);
         let service_url = service["resource"]["target"]["url"].as_str().unwrap();
         assert!(http_get(service_url).contains("yardlet-local-app"));
 
@@ -534,6 +580,110 @@ mod unix {
         assert_eq!(
             unhealthy_service_receipt["result"]["observation"]["status"], "unavailable",
             "an open port with a failing declared health URL is not live"
+        );
+
+        let healthy_restart_args = [
+            "resource",
+            "restart",
+            resource_id(restart_service),
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-local-app-restart-crash-after-spawn",
+            "--json",
+        ];
+        let (_, healthy_restart_crash) = fixture.run_process_with_fault(
+            &healthy_restart_args,
+            "act-local-app-restart-crash-after-spawn:after_spawn",
+        );
+        assert_eq!(healthy_restart_crash.status.code(), Some(86));
+        let restart_recovery: Value = serde_yaml_ng::from_str(
+            &fs::read_to_string(fixture.root.join(
+                ".agents/resources/actions/act-local-app-restart-crash-after-spawn.recovery.yaml",
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(restart_recovery["phase"], "spawned");
+        let spawned_pid = restart_recovery["effect_pid"].as_u64().unwrap() as u32;
+        let spawned_identity = restart_recovery["effect_start_identity"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        fixture
+            .owned_processes
+            .push((spawned_pid, spawned_identity.clone()));
+        let (_, healthy_restart) = fixture.json_process(&healthy_restart_args);
+        assert_eq!(healthy_restart["status"], "completed");
+        assert_eq!(healthy_restart["result"]["observation"]["status"], "live");
+        assert_eq!(
+            healthy_restart["result"]["observation"]["pid"], spawned_pid,
+            "recovery must not spawn a second service process"
+        );
+        assert_eq!(
+            healthy_restart,
+            fixture.json_process(&healthy_restart_args).1
+        );
+
+        let unhealthy_restart_args = [
+            "resource",
+            "restart",
+            resource_id(unhealthy_restart_service),
+            "--expected-status",
+            "unavailable",
+            "--action-id",
+            "act-local-app-unhealthy-restart-terminal-crash",
+            "--json",
+        ];
+        let (_, unhealthy_terminal_crash) = fixture.run_process_with_fault(
+            &unhealthy_restart_args,
+            "act-local-app-unhealthy-restart-terminal-crash:after_terminal_event",
+        );
+        assert_eq!(unhealthy_terminal_crash.status.code(), Some(86));
+        let (_, unhealthy_restart) = fixture.json_process(&unhealthy_restart_args);
+        assert_eq!(unhealthy_restart["status"], "rejected");
+        assert_eq!(
+            unhealthy_restart["result"]["observation"]["status"], "unavailable",
+            "a restarted process is not live until its declared health URL is 2xx"
+        );
+        let unhealthy_spawned_pid = unhealthy_restart["result"]["observation"]["pid"]
+            .as_u64()
+            .unwrap() as u32;
+        fixture.remember_observation_process(&unhealthy_restart["result"]["observation"]);
+        let unhealthy_reconcile = reconcile(
+            &fixture,
+            resource_id(unhealthy_restart_service),
+            "unavailable",
+            "act-local-app-reconcile-unhealthy-restart",
+        );
+        assert_eq!(unhealthy_reconcile["status"], "completed");
+        assert_eq!(
+            unhealthy_reconcile["result"]["observation"]["status"],
+            "unavailable"
+        );
+        assert_eq!(
+            unhealthy_reconcile["result"]["observation"]["pid"], unhealthy_spawned_pid,
+            "reconcile must retain the restarted process identity even when health is unavailable"
+        );
+        let (_, unhealthy_cleanup) = fixture.json_process(&[
+            "resource",
+            "cleanup",
+            resource_id(unhealthy_restart_service),
+            "--expected-status",
+            "unavailable",
+            "--action-id",
+            "act-local-app-cleanup-unhealthy-restart",
+            "--json",
+        ]);
+        assert_eq!(unhealthy_cleanup["status"], "completed");
+        assert_eq!(unhealthy_cleanup["result"]["observation"]["status"], "dead");
+        assert_eq!(
+            unhealthy_cleanup["result"]["observation"]["pid"],
+            unhealthy_spawned_pid
+        );
+        assert!(
+            process_identity(unhealthy_spawned_pid).is_none(),
+            "cleanup must signal the current unhealthy restart process"
         );
         for (operation, action_id) in [
             ("stop", "act-local-app-reject-pidless-service-stop"),

--- a/tests/v010_004_resource_operations.rs
+++ b/tests/v010_004_resource_operations.rs
@@ -6,7 +6,7 @@ mod unix {
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::process::{Command, Output};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     struct Fixture {
         root: PathBuf,
@@ -199,6 +199,34 @@ mod unix {
             .args(["-0", &pid.to_string()])
             .status()
             .is_ok_and(|status| status.success())
+    }
+
+    fn wait_for_nonempty_spawn_log(path: &Path) -> Vec<u8> {
+        const TIMEOUT: Duration = Duration::from_secs(5);
+        const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+        let started = Instant::now();
+        loop {
+            let last_observation = match fs::read(path) {
+                Ok(contents) if !contents.is_empty() => return contents,
+                Ok(_) => "empty",
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => "missing",
+                Err(error) => panic!(
+                    "failed to inspect restart spawn log {} while waiting for publication: {error}",
+                    path.display()
+                ),
+            };
+
+            assert!(
+                started.elapsed() < TIMEOUT,
+                "timed out after {TIMEOUT:?} waiting for restart spawn log {} to become non-empty \
+                 (last observation: {last_observation}); the helper writes its PID before its \
+                 15-second sleep, so this bound permits delayed scheduling under 8-way parallel \
+                 load while still failing before the helper exits",
+                path.display()
+            );
+            std::thread::sleep(POLL_INTERVAL);
+        }
     }
 
     fn resource_id(discover: &Value, proposal_id: &str) -> String {
@@ -770,13 +798,7 @@ mod unix {
             .collect();
         fixture.owned_pids.extend(spawned_pids.iter().copied());
         let spawn_log = fixture.root.join("restart-spawns.log");
-        for _ in 0..50 {
-            if fs::metadata(&spawn_log).is_ok_and(|metadata| metadata.len() > 0) {
-                break;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        let spawn_log_before_retry = fs::read(&spawn_log).unwrap();
+        let spawn_log_before_retry = wait_for_nonempty_spawn_log(&spawn_log);
 
         assert_eq!(crashed.status.code(), Some(86));
         assert!(!process_alive(original_pid));

--- a/tests/v010_004_resource_operations.rs
+++ b/tests/v010_004_resource_operations.rs
@@ -49,6 +49,32 @@ mod unix {
                 &worker,
             )
             .unwrap();
+            if label == "spawn-before-recovery" {
+                let restart_helper = root.join("restart-once.sh");
+                let spawn_log = root.join("restart-spawns.log");
+                fs::write(
+                    &restart_helper,
+                    format!(
+                        "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\n' \"$$\" >> \"{}\"\nexec /bin/sleep 15\n",
+                        spawn_log.display()
+                    ),
+                )
+                .unwrap();
+                let mut helper_permissions = fs::metadata(&restart_helper).unwrap().permissions();
+                helper_permissions.set_mode(0o755);
+                fs::set_permissions(&restart_helper, helper_permissions).unwrap();
+
+                let source = fs::read_to_string(&worker).unwrap();
+                let needle =
+                    "\"command\":[\"/bin/sleep\",\"90\"]}},\n    {\"proposal_id\":\"ops-cleanup\"";
+                let replacement = format!(
+                    "\"command\":[\"{}\"]}}}},\n    {{\"proposal_id\":\"ops-cleanup\"",
+                    restart_helper.display()
+                );
+                let updated = source.replacen(needle, &replacement, 1);
+                assert_ne!(source, updated, "restart command fixture marker changed");
+                fs::write(&worker, updated).unwrap();
+            }
             let mut permissions = fs::metadata(&worker).unwrap().permissions();
             permissions.set_mode(0o755);
             fs::set_permissions(&worker, permissions).unwrap();
@@ -93,6 +119,25 @@ mod unix {
             })
         }
 
+        fn command_with_fault(&self, args: &[&str], fault: &str) -> Output {
+            Command::new(&self.binary)
+                .args(args)
+                .current_dir(&self.root)
+                .env("YARDLET_TEST_RESOURCE_ACTION_FAULT", fault)
+                .output()
+                .unwrap_or_else(|error| panic!("failed to run yardlet with {fault}: {error}"))
+        }
+
+        fn command_with_fault_trace(&self, args: &[&str], fault: &str, trace: &Path) -> Output {
+            Command::new(&self.binary)
+                .args(args)
+                .current_dir(&self.root)
+                .env("YARDLET_TEST_RESOURCE_ACTION_FAULT", fault)
+                .env("YARDLET_TEST_RESOURCE_ACTION_TRACE", trace)
+                .output()
+                .unwrap_or_else(|error| panic!("failed to run yardlet with {fault}: {error}"))
+        }
+
         fn discover(&self) -> Value {
             self.receipt(&[
                 "resource",
@@ -116,6 +161,13 @@ mod unix {
                     .stdout(std::process::Stdio::null())
                     .stderr(std::process::Stdio::null())
                     .status();
+            }
+            if std::thread::panicking() {
+                eprintln!(
+                    "V010-004 resource operations evidence kept at {}",
+                    self.root.display()
+                );
+                return;
             }
             let _ = fs::remove_dir_all(&self.root);
         }
@@ -197,6 +249,18 @@ mod unix {
             }
         }
         panic!("missing canonical event {event_id}");
+    }
+
+    fn resource_pid(discover: &Value, proposal_id: &str) -> u32 {
+        discover["result"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["resource"]["proposal_id"] == proposal_id)
+            .unwrap_or_else(|| panic!("missing resource proposal {proposal_id}"))["resource"]
+            ["target"]["pid"]
+            .as_u64()
+            .unwrap() as u32
     }
 
     #[test]
@@ -517,6 +581,256 @@ mod unix {
         assert_eq!(
             missing["result"]["open_target"]["target_type"],
             "unavailable"
+        );
+    }
+
+    #[test]
+    fn requested_and_post_terminate_crashes_recover_without_duplicate_signal() {
+        let fixture = Fixture::new("action-crash-recovery");
+        let discover = fixture.discover();
+        let cleanup = resource_id(&discover, "ops-cleanup");
+        let cleanup_pid = resource_pid(&discover, "ops-cleanup");
+        let cleanup_args = [
+            "resource",
+            "cleanup",
+            cleanup.as_str(),
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-crash-after-requested",
+            "--json",
+        ];
+
+        let requested_crash =
+            fixture.command_with_fault(&cleanup_args, "act-crash-after-requested:after_requested");
+        assert_eq!(requested_crash.status.code(), Some(86));
+        assert!(
+            process_alive(cleanup_pid),
+            "requested-only crash must happen before cleanup mutation"
+        );
+        let cleanup_receipt = fixture.receipt(&cleanup_args);
+        assert_receipt(&cleanup_receipt, "cleanup", "completed");
+        assert!(!process_alive(cleanup_pid));
+        assert_eq!(cleanup_receipt, fixture.receipt(&cleanup_args));
+
+        let restart = resource_id(&discover, "ops-restart");
+        let restart_pid = resource_pid(&discover, "ops-restart");
+        let prepared_args = [
+            "resource",
+            "restart",
+            restart.as_str(),
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-crash-after-prepared",
+            "--json",
+        ];
+        let prepared_crash =
+            fixture.command_with_fault(&prepared_args, "act-crash-after-prepared:after_prepared");
+        assert_eq!(prepared_crash.status.code(), Some(86));
+        assert!(process_alive(restart_pid));
+        let prepared_receipt = fixture.receipt(&prepared_args);
+        assert_receipt(&prepared_receipt, "restart", "rejected");
+        assert!(prepared_receipt["error"]
+            .as_str()
+            .unwrap()
+            .contains("prepared"));
+        assert!(
+            process_alive(restart_pid),
+            "ambiguous prepared-only recovery must not signal or spawn"
+        );
+        assert_eq!(prepared_receipt, fixture.receipt(&prepared_args));
+
+        let stop = resource_id(&discover, "ops-stop");
+        let stop_pid = resource_pid(&discover, "ops-stop");
+        let stop_args = [
+            "resource",
+            "stop",
+            stop.as_str(),
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-crash-after-terminate",
+            "--json",
+        ];
+        let terminated_crash =
+            fixture.command_with_fault(&stop_args, "act-crash-after-terminate:after_terminate");
+        assert_eq!(terminated_crash.status.code(), Some(86));
+        assert!(!process_alive(stop_pid));
+        let recovery_path = fixture
+            .root
+            .join(".agents/resources/actions/act-crash-after-terminate.recovery.yaml");
+        let recovery: YamlValue =
+            serde_yaml_ng::from_str(&fs::read_to_string(recovery_path).unwrap()).unwrap();
+        assert_eq!(recovery["phase"].as_str(), Some("terminated"));
+
+        let stop_receipt = fixture.receipt(&stop_args);
+        assert_receipt(&stop_receipt, "stop", "completed");
+        assert_eq!(stop_receipt["result"]["observation"]["status"], "dead");
+        assert_eq!(stop_receipt, fixture.receipt(&stop_args));
+    }
+
+    #[test]
+    fn lifecycle_failures_terminalize_as_immutable_rejections() {
+        let fixture = Fixture::new("action-failure-receipts");
+        let discover = fixture.discover();
+        let cases = [
+            (
+                "reconcile",
+                resource_id(&discover, "ops-stop"),
+                "live",
+                "act-fail-probe",
+                "probe",
+            ),
+            (
+                "stop",
+                resource_id(&discover, "ops-cleanup"),
+                "live",
+                "act-fail-terminate",
+                "terminate",
+            ),
+            (
+                "restart",
+                resource_id(&discover, "ops-restart"),
+                "live",
+                "act-fail-spawn",
+                "spawn",
+            ),
+            (
+                "detach",
+                resource_id(&discover, "ops-detach"),
+                "live",
+                "act-fail-receipt",
+                "receipt",
+            ),
+        ];
+
+        for (operation, target, expected, action_id, point) in cases {
+            let args = [
+                "resource",
+                operation,
+                target.as_str(),
+                "--expected-status",
+                expected,
+                "--action-id",
+                action_id,
+                "--json",
+            ];
+            let output = fixture.command_with_fault(&args, &format!("{action_id}:{point}"));
+            assert!(
+                output.status.success(),
+                "{point} failure must return its rejected receipt\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let receipt: Value = serde_json::from_slice(&output.stdout).unwrap();
+            assert_receipt(&receipt, operation, "rejected");
+            assert!(receipt["error"].as_str().unwrap().contains(point));
+            let terminal_event = channel_event(
+                &fixture.root,
+                receipt["result_event_ids"][1].as_str().unwrap(),
+            );
+            assert_eq!(terminal_event["type"].as_str(), Some("action.rejected"));
+            let terminal_path = fixture
+                .root
+                .join(format!(".agents/resources/actions/{action_id}.yaml"));
+            let terminal_before = fs::read(&terminal_path).unwrap();
+            assert_eq!(receipt, fixture.receipt(&args));
+            assert_eq!(terminal_before, fs::read(terminal_path).unwrap());
+        }
+    }
+
+    #[test]
+    fn spawn_before_recovery_crash_rejects_without_a_second_spawn() {
+        let mut fixture = Fixture::new("spawn-before-recovery");
+        let discover = fixture.discover();
+        let restart = resource_id(&discover, "ops-restart");
+        let original_pid = resource_pid(&discover, "ops-restart");
+        let args = [
+            "resource",
+            "restart",
+            restart.as_str(),
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-crash-after-spawn-before-recovery",
+            "--json",
+        ];
+
+        let spawn_trace = fixture.root.join("spawn-gap-pid.txt");
+        let crashed = fixture.command_with_fault_trace(
+            &args,
+            "act-crash-after-spawn-before-recovery:after_spawn_before_recovery",
+            &spawn_trace,
+        );
+        let spawned_pids: Vec<u32> = fs::read_to_string(&spawn_trace)
+            .unwrap()
+            .lines()
+            .map(|line| line.parse().unwrap())
+            .collect();
+        fixture.owned_pids.extend(spawned_pids.iter().copied());
+        let spawn_log = fixture.root.join("restart-spawns.log");
+        for _ in 0..50 {
+            if fs::metadata(&spawn_log).is_ok_and(|metadata| metadata.len() > 0) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let spawn_log_before_retry = fs::read(&spawn_log).unwrap();
+
+        assert_eq!(crashed.status.code(), Some(86));
+        assert!(!process_alive(original_pid));
+        assert_eq!(spawned_pids.len(), 1, "the interrupted action spawned once");
+        assert_eq!(
+            String::from_utf8(spawn_log_before_retry.clone()).unwrap(),
+            format!("{}\n", spawned_pids[0])
+        );
+        assert!(process_alive(spawned_pids[0]));
+        let recovery_path = fixture
+            .root
+            .join(".agents/resources/actions/act-crash-after-spawn-before-recovery.recovery.yaml");
+        let recovery: YamlValue =
+            serde_yaml_ng::from_str(&fs::read_to_string(recovery_path).unwrap()).unwrap();
+        assert_eq!(recovery["phase"].as_str(), Some("terminated"));
+
+        let spawn_trace_before_retry = fs::read(&spawn_trace).unwrap();
+        let receipt = fixture.receipt(&args);
+        assert_receipt(&receipt, "restart", "rejected");
+        assert_eq!(receipt["result"]["observation"]["status"], "unrecoverable");
+        assert!(receipt["error"]
+            .as_str()
+            .unwrap()
+            .contains("terminated restart recovery"));
+        assert_eq!(spawn_trace_before_retry, fs::read(&spawn_trace).unwrap());
+        assert_eq!(spawn_log_before_retry, fs::read(&spawn_log).unwrap());
+        assert!(process_alive(spawned_pids[0]));
+        assert_eq!(receipt, fixture.receipt(&args));
+        assert_eq!(spawn_trace_before_retry, fs::read(&spawn_trace).unwrap());
+        assert_eq!(spawn_log_before_retry, fs::read(&spawn_log).unwrap());
+
+        let reconcile = fixture.receipt(&[
+            "resource",
+            "reconcile",
+            restart.as_str(),
+            "--expected-status",
+            "unrecoverable",
+            "--action-id",
+            "act-reconcile-spawn-gap",
+            "--json",
+        ]);
+        assert_receipt(&reconcile, "reconcile", "rejected");
+        assert!(reconcile["result"]["observation"].is_null());
+        let inspect = fixture.receipt(&[
+            "resource",
+            "inspect",
+            restart.as_str(),
+            "--action-id",
+            "act-inspect-spawn-gap",
+            "--json",
+        ]);
+        assert_eq!(
+            inspect["result"]["entries"][0]["last_observation"]["status"],
+            "unrecoverable"
         );
     }
 }

--- a/tests/v010_004_resource_operations.rs
+++ b/tests/v010_004_resource_operations.rs
@@ -14,7 +14,7 @@ mod unix {
     }
 
     impl Fixture {
-        fn new() -> Self {
+        fn new(label: &str) -> Self {
             let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
             let nonce = SystemTime::now()
@@ -22,7 +22,7 @@ mod unix {
                 .unwrap()
                 .as_nanos();
             let root = std::env::temp_dir().join(format!(
-                "yardlet-v010-004-operations-{}-{nonce}",
+                "yardlet-v010-004-operations-{label}-{}-{nonce}",
                 std::process::id()
             ));
             fs::create_dir_all(&root).unwrap();
@@ -179,7 +179,7 @@ mod unix {
 
     #[test]
     fn all_nine_operations_share_receipts_and_minimum_cli_open_targets() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::new("all-operations");
         let discover = fixture.discover();
         assert_receipt(&discover, "discover", "completed");
         let file = artifact_id(&discover, "ops-file");
@@ -315,7 +315,7 @@ mod unix {
 
     #[test]
     fn fresh_probe_and_identity_ownership_gates_prevent_false_live_and_external_kill() {
-        let fixture = Fixture::new();
+        let fixture = Fixture::new("lifecycle-gates");
         let discover = fixture.discover();
         let stop = resource_id(&discover, "ops-stop");
         let external = resource_id(&discover, "ops-external");

--- a/tests/v010_004_resource_operations.rs
+++ b/tests/v010_004_resource_operations.rs
@@ -1,0 +1,432 @@
+#[cfg(unix)]
+mod unix {
+    use serde_json::Value;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Output};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct Fixture {
+        root: PathBuf,
+        binary: PathBuf,
+        owned_pids: Vec<u32>,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "yardlet-v010-004-operations-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).unwrap();
+            must_succeed(&root, Path::new("git"), &["init", "-q"]);
+            must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+            must_succeed(
+                &root,
+                Path::new("git"),
+                &["config", "user.email", "fixture@example.invalid"],
+            );
+            fs::write(root.join("README.md"), "fixture\n").unwrap();
+            must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+            must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+            must_succeed(&root, &binary, &["init"]);
+            let config_path = root.join(".agents/yardlet.yaml");
+            let config = fs::read_to_string(&config_path)
+                .unwrap()
+                .replace("auto_commit: false", "auto_commit: true");
+            fs::write(&config_path, config).unwrap();
+            let worker = root.join("resource-worker.sh");
+            fs::copy(
+                manifest.join("tests/fixtures/v010_004_resource_model/worker.sh"),
+                &worker,
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&worker).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&worker, permissions).unwrap();
+            fs::write(
+                root.join(".agents/workers.yaml"),
+                format!(
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    worker.display()
+                ),
+            )
+            .unwrap();
+            fs::write(
+                root.join(".agents/intent-contract.yaml"),
+                "schema_version: 1\nid: intent-resource-operations\nsummary: resource operations\nstatus: accepted\n",
+            )
+            .unwrap();
+            fs::write(
+                root.join(".agents/work-queue.yaml"),
+                "schema_version: 1\nqueue_id: queue-resource-operations\nintent_id: intent-resource-operations\ntasks:\n  - {id: YARD-OPS, title: exercise operations, state: queued, priority: 10, preferred_worker: fixture}\n",
+            )
+            .unwrap();
+            must_succeed(&root, &binary, &["run", "--task", "YARD-OPS", "--execute"]);
+            let owned_pids = fs::read_to_string(root.join("ops-pids.txt"))
+                .unwrap()
+                .lines()
+                .map(|line| line.parse().unwrap())
+                .collect();
+            Self {
+                root,
+                binary,
+                owned_pids,
+            }
+        }
+
+        fn receipt(&self, args: &[&str]) -> Value {
+            let output = must_succeed(&self.root, &self.binary, args);
+            serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+                panic!(
+                    "invalid JSON receipt: {error}\nstdout:\n{}",
+                    String::from_utf8_lossy(&output.stdout)
+                )
+            })
+        }
+
+        fn discover(&self) -> Value {
+            self.receipt(&[
+                "resource",
+                "discover",
+                "--task",
+                "YARD-OPS",
+                "--action-id",
+                "act-ops-discover",
+                "--json",
+            ])
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            for pid in &self.owned_pids {
+                let _ = Command::new("kill")
+                    .arg(pid.to_string())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn command(root: &Path, program: &Path, args: &[&str]) -> Output {
+        Command::new(program)
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()))
+    }
+
+    fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+        let output = command(root, program, args);
+        assert!(
+            output.status.success(),
+            "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            program.display(),
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output
+    }
+
+    fn process_alive(pid: u32) -> bool {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    fn resource_id(discover: &Value, proposal_id: &str) -> String {
+        discover["result"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["resource"]["proposal_id"] == proposal_id)
+            .unwrap_or_else(|| panic!("missing resource proposal {proposal_id}"))["resource"]
+            ["resource_id"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn artifact_id(discover: &Value, proposal_id: &str) -> String {
+        discover["result"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["artifact"]["proposal_id"] == proposal_id)
+            .unwrap()["artifact"]["artifact_id"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn assert_receipt(receipt: &Value, operation: &str, status: &str) {
+        assert_eq!(receipt["operation"], operation);
+        assert_eq!(receipt["status"], status);
+        assert_eq!(receipt["result_event_ids"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn all_nine_operations_share_receipts_and_minimum_cli_open_targets() {
+        let fixture = Fixture::new();
+        let discover = fixture.discover();
+        assert_receipt(&discover, "discover", "completed");
+        let file = artifact_id(&discover, "ops-file");
+        let terminal = resource_id(&discover, "ops-detach");
+        let service = resource_id(&discover, "ops-service");
+        let restart = resource_id(&discover, "ops-restart");
+        let cleanup = resource_id(&discover, "ops-cleanup");
+
+        let inspect = fixture.receipt(&[
+            "resource",
+            "inspect",
+            &file,
+            "--action-id",
+            "act-ops-inspect",
+            "--json",
+        ]);
+        assert_receipt(&inspect, "inspect", "completed");
+        assert_eq!(inspect["result"]["entries"][0]["status"], "available");
+        let open_file = fixture.receipt(&[
+            "resource",
+            "open",
+            &file,
+            "--action-id",
+            "act-ops-open-file",
+            "--json",
+        ]);
+        assert_receipt(&open_file, "open", "completed");
+        assert_eq!(open_file["result"]["open_target"]["target_type"], "file");
+        let open_service = fixture.receipt(&[
+            "resource",
+            "open",
+            &service,
+            "--action-id",
+            "act-ops-open-url",
+            "--json",
+        ]);
+        assert_eq!(open_service["result"]["open_target"]["target_type"], "url");
+        let attach = fixture.receipt(&[
+            "resource",
+            "attach",
+            &terminal,
+            "--action-id",
+            "act-ops-attach",
+            "--json",
+        ]);
+        assert_receipt(&attach, "attach", "completed");
+        assert_eq!(
+            attach["result"]["open_target"]["target_type"],
+            "terminal_session"
+        );
+
+        let reconcile = fixture.receipt(&[
+            "resource",
+            "reconcile",
+            &restart,
+            "--action-id",
+            "act-ops-reconcile",
+            "--json",
+        ]);
+        assert_receipt(&reconcile, "reconcile", "completed");
+        assert_eq!(reconcile["result"]["observation"]["status"], "live");
+        assert_eq!(reconcile["result"]["observation"]["current"], true);
+        let after_restart_inspect = fixture.receipt(&[
+            "resource",
+            "inspect",
+            &restart,
+            "--action-id",
+            "act-ops-inspect-last-observed",
+            "--json",
+        ]);
+        assert_eq!(
+            after_restart_inspect["result"]["entries"][0]["status"],
+            "unknown"
+        );
+        assert_eq!(
+            after_restart_inspect["result"]["entries"][0]["last_observation"]["status"],
+            "live"
+        );
+        let restart_receipt = fixture.receipt(&[
+            "resource",
+            "restart",
+            &restart,
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-ops-restart",
+            "--json",
+        ]);
+        assert_receipt(&restart_receipt, "restart", "completed");
+        let restarted_pid = restart_receipt["result"]["observation"]["pid"]
+            .as_u64()
+            .unwrap() as u32;
+        assert!(process_alive(restarted_pid));
+
+        let detach = fixture.receipt(&[
+            "resource",
+            "detach",
+            &terminal,
+            "--action-id",
+            "act-ops-detach",
+            "--json",
+        ]);
+        assert_receipt(&detach, "detach", "completed");
+        assert_eq!(detach["result"]["observation"]["status"], "detached");
+
+        let cleanup_receipt = fixture.receipt(&[
+            "resource",
+            "cleanup",
+            &cleanup,
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-ops-cleanup",
+            "--json",
+        ]);
+        assert_receipt(&cleanup_receipt, "cleanup", "completed");
+        assert_eq!(cleanup_receipt["result"]["observation"]["status"], "dead");
+        fixture.owned_pids.iter().for_each(|pid| {
+            if *pid == restarted_pid {
+                let _ = Command::new("kill")
+                    .arg(pid.to_string())
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .status();
+            }
+        });
+        let _ = Command::new("kill")
+            .arg(restarted_pid.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+
+    #[test]
+    fn fresh_probe_and_identity_ownership_gates_prevent_false_live_and_external_kill() {
+        let fixture = Fixture::new();
+        let discover = fixture.discover();
+        let stop = resource_id(&discover, "ops-stop");
+        let external = resource_id(&discover, "ops-external");
+        let unknown = resource_id(&discover, "ops-unknown");
+        let mismatch = resource_id(&discover, "ops-mismatch");
+        let dead = resource_id(&discover, "ops-dead");
+        let service = resource_id(&discover, "ops-service");
+        let browser = resource_id(&discover, "ops-browser");
+        let unrecoverable = resource_id(&discover, "ops-unrecoverable");
+        let external_pid = discover["result"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["resource"]["proposal_id"] == "ops-external")
+            .unwrap()["resource"]["target"]["pid"]
+            .as_u64()
+            .unwrap() as u32;
+
+        let rejected = fixture.receipt(&[
+            "resource",
+            "stop",
+            &external,
+            "--action-id",
+            "act-external-stop",
+            "--json",
+        ]);
+        assert_receipt(&rejected, "stop", "rejected");
+        assert!(rejected["error"].as_str().unwrap().contains("ownership"));
+        assert!(process_alive(external_pid));
+        let unknown_rejected = fixture.receipt(&[
+            "resource",
+            "cleanup",
+            &unknown,
+            "--action-id",
+            "act-unknown-cleanup",
+            "--json",
+        ]);
+        assert_eq!(unknown_rejected["status"], "rejected");
+        assert!(unknown_rejected["error"]
+            .as_str()
+            .unwrap()
+            .contains("ownership"));
+        assert!(process_alive(external_pid));
+
+        let mismatch_probe = fixture.receipt(&[
+            "resource",
+            "reconcile",
+            &mismatch,
+            "--action-id",
+            "act-mismatch-probe",
+            "--json",
+        ]);
+        assert_eq!(
+            mismatch_probe["result"]["observation"]["status"],
+            "orphaned"
+        );
+        let mismatch_stop = fixture.receipt(&[
+            "resource",
+            "stop",
+            &mismatch,
+            "--action-id",
+            "act-mismatch-stop",
+            "--json",
+        ]);
+        assert_eq!(mismatch_stop["status"], "rejected");
+        assert!(process_alive(external_pid));
+
+        for (target, action, status) in [
+            (&dead, "act-dead-probe", "dead"),
+            (&service, "act-service-probe", "unavailable"),
+            (&browser, "act-browser-probe", "expired"),
+            (&unrecoverable, "act-unrecoverable-probe", "unrecoverable"),
+        ] {
+            let receipt = fixture.receipt(&[
+                "resource",
+                "reconcile",
+                target,
+                "--action-id",
+                action,
+                "--json",
+            ]);
+            assert_eq!(receipt["result"]["observation"]["status"], status);
+        }
+
+        let stop_receipt = fixture.receipt(&[
+            "resource",
+            "stop",
+            &stop,
+            "--expected-status",
+            "live",
+            "--action-id",
+            "act-owned-stop",
+            "--json",
+        ]);
+        assert_receipt(&stop_receipt, "stop", "completed");
+        assert_eq!(stop_receipt["result"]["observation"]["status"], "dead");
+
+        let file = artifact_id(&discover, "ops-file");
+        fs::remove_file(fixture.root.join("ops-file.txt")).unwrap();
+        let missing = fixture.receipt(&[
+            "resource",
+            "open",
+            &file,
+            "--action-id",
+            "act-missing-open",
+            "--json",
+        ]);
+        assert_eq!(missing["result"]["entries"][0]["status"], "unavailable");
+        assert_eq!(
+            missing["result"]["open_target"]["target_type"],
+            "unavailable"
+        );
+    }
+}

--- a/tests/v010_004_resource_operations.rs
+++ b/tests/v010_004_resource_operations.rs
@@ -1,6 +1,7 @@
 #[cfg(unix)]
 mod unix {
     use serde_json::Value;
+    use serde_yaml_ng::Value as YamlValue;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
@@ -96,6 +97,8 @@ mod unix {
             self.receipt(&[
                 "resource",
                 "discover",
+                "--intent",
+                "intent-resource-operations",
                 "--task",
                 "YARD-OPS",
                 "--action-id",
@@ -177,6 +180,25 @@ mod unix {
         assert_eq!(receipt["result_event_ids"].as_array().unwrap().len(), 2);
     }
 
+    fn channel_event(root: &Path, event_id: &str) -> YamlValue {
+        let channels = root.join(".agents/task-channels");
+        for channel in fs::read_dir(channels).unwrap().flatten() {
+            let events = channel.path().join("events");
+            if !events.is_dir() {
+                continue;
+            }
+            for path in fs::read_dir(events).unwrap().flatten() {
+                let path = path.path();
+                let event: YamlValue =
+                    serde_yaml_ng::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+                if event["event_id"].as_str() == Some(event_id) {
+                    return event;
+                }
+            }
+        }
+        panic!("missing canonical event {event_id}");
+    }
+
     #[test]
     fn all_nine_operations_share_receipts_and_minimum_cli_open_targets() {
         let fixture = Fixture::new("all-operations");
@@ -235,6 +257,8 @@ mod unix {
             "resource",
             "reconcile",
             &restart,
+            "--expected-status",
+            "live",
             "--action-id",
             "act-ops-reconcile",
             "--json",
@@ -278,6 +302,8 @@ mod unix {
             "resource",
             "detach",
             &terminal,
+            "--expected-status",
+            "live",
             "--action-id",
             "act-ops-detach",
             "--json",
@@ -314,6 +340,60 @@ mod unix {
     }
 
     #[test]
+    fn unsupported_operations_are_canonical_rejections_and_expected_state_is_required() {
+        let fixture = Fixture::new("capability-rejections");
+        let discover = fixture.discover();
+        let file = artifact_id(&discover, "ops-file");
+        let external = resource_id(&discover, "ops-external");
+        let external_pid = discover["result"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["resource"]["proposal_id"] == "ops-external")
+            .unwrap()["resource"]["target"]["pid"]
+            .as_u64()
+            .unwrap() as u32;
+
+        let missing_expected = command(
+            &fixture.root,
+            &fixture.binary,
+            &[
+                "resource",
+                "stop",
+                &external,
+                "--action-id",
+                "act-missing-expected-state",
+                "--json",
+            ],
+        );
+        assert!(!missing_expected.status.success());
+        assert!(String::from_utf8_lossy(&missing_expected.stderr).contains("--expected-status"));
+        assert!(process_alive(external_pid));
+
+        for (operation, expected_status) in [
+            ("attach", None),
+            ("stop", Some("available")),
+            ("restart", Some("available")),
+            ("detach", Some("available")),
+            ("cleanup", Some("available")),
+            ("reconcile", Some("available")),
+        ] {
+            let action_id = format!("act-unsupported-{operation}");
+            let mut args = vec!["resource", operation, file.as_str()];
+            if let Some(expected_status) = expected_status {
+                args.extend(["--expected-status", expected_status]);
+            }
+            args.extend(["--action-id", action_id.as_str(), "--json"]);
+            let receipt = fixture.receipt(&args);
+            assert_receipt(&receipt, operation, "rejected");
+            assert!(receipt["error"].as_str().unwrap().contains("unsupported"));
+            let terminal_event_id = receipt["result_event_ids"][1].as_str().unwrap();
+            let terminal_event = channel_event(&fixture.root, terminal_event_id);
+            assert_eq!(terminal_event["type"].as_str(), Some("action.rejected"));
+        }
+    }
+
+    #[test]
     fn fresh_probe_and_identity_ownership_gates_prevent_false_live_and_external_kill() {
         let fixture = Fixture::new("lifecycle-gates");
         let discover = fixture.discover();
@@ -338,6 +418,8 @@ mod unix {
             "resource",
             "stop",
             &external,
+            "--expected-status",
+            "live",
             "--action-id",
             "act-external-stop",
             "--json",
@@ -349,6 +431,8 @@ mod unix {
             "resource",
             "cleanup",
             &unknown,
+            "--expected-status",
+            "live",
             "--action-id",
             "act-unknown-cleanup",
             "--json",
@@ -364,6 +448,8 @@ mod unix {
             "resource",
             "reconcile",
             &mismatch,
+            "--expected-status",
+            "orphaned",
             "--action-id",
             "act-mismatch-probe",
             "--json",
@@ -376,6 +462,8 @@ mod unix {
             "resource",
             "stop",
             &mismatch,
+            "--expected-status",
+            "orphaned",
             "--action-id",
             "act-mismatch-stop",
             "--json",
@@ -393,6 +481,8 @@ mod unix {
                 "resource",
                 "reconcile",
                 target,
+                "--expected-status",
+                status,
                 "--action-id",
                 action,
                 "--json",

--- a/tests/v010_004_resource_publication.rs
+++ b/tests/v010_004_resource_publication.rs
@@ -62,7 +62,7 @@ mod unix {
             .unwrap();
             fs::write(
                 root.join(".agents/work-queue.yaml"),
-                "schema_version: 1\nqueue_id: queue-resource-fixture\nintent_id: intent-resource-fixture\ntasks:\n  - {id: YARD-001, title: publish typed resources, state: queued, priority: 10, preferred_worker: fixture}\n  - {id: YARD-CAP, title: publish bounded artifacts, state: queued, priority: 20, preferred_worker: fixture}\n  - {id: YARD-BAD, title: reject unowned evidence, state: queued, priority: 30, preferred_worker: fixture}\n",
+                "schema_version: 1\nqueue_id: queue-resource-fixture\nintent_id: intent-resource-fixture\ntasks:\n  - {id: YARD-001, title: publish typed resources, state: queued, priority: 10, preferred_worker: fixture}\n  - {id: YARD-CAP, title: publish bounded artifacts, state: queued, priority: 20, preferred_worker: fixture}\n  - {id: YARD-BAD, title: reject unowned evidence, state: queued, priority: 30, preferred_worker: fixture}\n  - {id: YARD-CAUSE, title: reject forged causation, state: queued, priority: 40, preferred_worker: fixture}\n",
             )
             .unwrap();
             Self { root, binary }
@@ -126,6 +126,22 @@ mod unix {
 
     fn read_yaml(path: &Path) -> YamlValue {
         serde_yaml_ng::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn task_channel_events(root: &Path) -> Vec<YamlValue> {
+        let channels = root.join(".agents/task-channels");
+        if !channels.is_dir() {
+            return Vec::new();
+        }
+        let mut events = Vec::new();
+        for channel in fs::read_dir(channels).unwrap().flatten() {
+            events.extend(
+                yaml_files(&channel.path().join("events"))
+                    .iter()
+                    .map(|path| read_yaml(path)),
+            );
+        }
+        events
     }
 
     fn canonical_bytes(root: &Path) -> Vec<(String, Vec<u8>)> {
@@ -202,12 +218,25 @@ mod unix {
         kinds.sort_unstable();
         assert_eq!(kinds, ["browser", "process", "service", "terminal"]);
 
+        let events = task_channel_events(&fixture.root);
         for entry in entries {
             let record = entry.get("artifact").unwrap_or(&entry["resource"]);
             assert_eq!(record["task_id"], "YARD-001");
             assert!(!record["attempt_id"].as_str().unwrap().is_empty());
             assert_eq!(record["producer"]["worker_id"], "fixture");
             assert!(!record["created_event_id"].as_str().unwrap().is_empty());
+            if record["proposal_id"]
+                .as_str()
+                .is_some_and(|proposal_id| proposal_id.starts_with("proposal-"))
+            {
+                let causation_id = record["causation_id"].as_str().unwrap();
+                assert_ne!(causation_id, record["attempt_id"].as_str().unwrap());
+                let cause = events
+                    .iter()
+                    .find(|event| event["event_id"].as_str() == Some(causation_id))
+                    .expect("canonical publication causation event");
+                assert_eq!(cause["attempt_id"].as_str(), record["attempt_id"].as_str());
+            }
         }
 
         for (index, entry) in entries.iter().enumerate() {
@@ -262,7 +291,7 @@ mod unix {
         assert!(index_path.is_file());
         fs::remove_file(&index_path).unwrap();
 
-        fixture.must_run(&[
+        let discovered = fixture.must_run(&[
             "resource",
             "discover",
             "--task",
@@ -271,8 +300,33 @@ mod unix {
             "act-index-missing",
             "--json",
         ]);
+        let discovered: Value = serde_json::from_slice(&discovered.stdout).unwrap();
+        let discovered_cap_artifacts = discovered["result"]["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|entry| {
+                entry["artifact"]["proposal_id"]
+                    .as_str()
+                    .is_some_and(|proposal_id| proposal_id.starts_with("cap-"))
+            })
+            .count();
+        assert_eq!(
+            discovered_cap_artifacts, 140,
+            "bounded index must fall back to canonical task facts"
+        );
         let rebuilt = read_yaml(&index_path);
         assert!(rebuilt["artifacts"].as_sequence().unwrap().len() <= 128);
+        let task_index = rebuilt["tasks"]
+            .as_sequence()
+            .expect("resource index must carry bounded task projections")
+            .iter()
+            .find(|entry| entry["task_id"].as_str() == Some("YARD-CAP"))
+            .expect("YARD-CAP task projection");
+        assert!(task_index["artifacts"].as_sequence().unwrap().len() <= 128);
+        assert_eq!(task_index["resources"].as_sequence().unwrap().len(), 0);
+        assert_eq!(task_index["attempts"].as_sequence().unwrap().len(), 1);
+        assert_eq!(task_index["truncated"].as_bool(), Some(true));
         fs::write(&index_path, "malformed: [\n").unwrap();
         fixture.must_run(&[
             "resource",
@@ -344,6 +398,50 @@ mod unix {
                     .iter()
                     .map(|path| read_yaml(path))
                     .all(|record| record["proposal_id"].as_str() != Some("bad"))
+        );
+    }
+
+    #[test]
+    fn evidence_with_forged_attempt_causation_cannot_complete() {
+        let fixture = Fixture::new("invalid-causation");
+        let output = fixture.run(&["run", "--task", "YARD-CAUSE", "--execute"]);
+        assert!(
+            output.status.success(),
+            "the orchestrator should record rejected evidence cleanly: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let queue = read_yaml(&fixture.root.join(".agents/work-queue.yaml"));
+        let state = queue["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| task["id"].as_str() == Some("YARD-CAUSE"))
+            .unwrap()["state"]
+            .as_str()
+            .unwrap();
+        assert_ne!(state, "done");
+        let evaluation_path = fs::read_dir(fixture.root.join(".agents/runs"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path().join("evaluation.json"))
+            .find(|path| path.is_file())
+            .expect("evaluation record");
+        let evaluation: Value =
+            serde_json::from_str(&fs::read_to_string(evaluation_path).unwrap()).unwrap();
+        let provenance_check = evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == "resource_provenance_valid")
+            .expect("causation must be part of the exact provenance gate");
+        assert_eq!(provenance_check["passed"], false);
+        assert_eq!(provenance_check["fatal"], true);
+        assert!(
+            !fixture.root.join(".agents/resources/artifacts").is_dir()
+                || yaml_files(&fixture.root.join(".agents/resources/artifacts"))
+                    .iter()
+                    .map(|path| read_yaml(path))
+                    .all(|record| record["proposal_id"].as_str() != Some("forged-cause"))
         );
     }
 }

--- a/tests/v010_004_resource_publication.rs
+++ b/tests/v010_004_resource_publication.rs
@@ -171,6 +171,22 @@ mod unix {
         out
     }
 
+    fn copy_tree(source: &Path, destination: &Path) {
+        if !source.is_dir() {
+            return;
+        }
+        fs::create_dir_all(destination).unwrap();
+        for entry in fs::read_dir(source).unwrap().flatten() {
+            let source_path = entry.path();
+            let destination_path = destination.join(entry.file_name());
+            if source_path.is_dir() {
+                copy_tree(&source_path, &destination_path);
+            } else {
+                fs::copy(source_path, destination_path).unwrap();
+            }
+        }
+    }
+
     #[test]
     fn publishes_every_typed_kind_and_role_with_exact_attempt_provenance() {
         let fixture = Fixture::new("round-trip");
@@ -179,6 +195,8 @@ mod unix {
         let output = fixture.must_run(&[
             "resource",
             "discover",
+            "--intent",
+            "intent-resource-fixture",
             "--task",
             "YARD-001",
             "--action-id",
@@ -217,6 +235,18 @@ mod unix {
             .collect::<Vec<_>>();
         kinds.sort_unstable();
         assert_eq!(kinds, ["browser", "process", "service", "terminal"]);
+        for entry in entries
+            .iter()
+            .filter(|entry| entry["entry_type"] == "runtime_resource")
+        {
+            assert!(
+                !entry["resource"]["capabilities"]
+                    .as_array()
+                    .expect("typed runtime capabilities")
+                    .is_empty(),
+                "canonical runtime declaration must record capabilities: {entry}"
+            );
+        }
 
         let events = task_channel_events(&fixture.root);
         for entry in entries {
@@ -294,6 +324,8 @@ mod unix {
         let discovered = fixture.must_run(&[
             "resource",
             "discover",
+            "--intent",
+            "intent-resource-fixture",
             "--task",
             "YARD-CAP",
             "--action-id",
@@ -331,6 +363,8 @@ mod unix {
         fixture.must_run(&[
             "resource",
             "discover",
+            "--intent",
+            "intent-resource-fixture",
             "--task",
             "YARD-CAP",
             "--action-id",
@@ -355,6 +389,92 @@ mod unix {
             })
             .count();
         assert_eq!(cap_records, 140);
+    }
+
+    #[test]
+    fn resource_index_and_discover_use_exact_intent_task_namespace() {
+        let first = Fixture::new("namespace-first");
+        first.must_run(&["run", "--task", "YARD-001", "--execute"]);
+
+        let second = Fixture::new("namespace-second");
+        fs::write(
+            second.root.join(".agents/intent-contract.yaml"),
+            "schema_version: 1\nid: intent-resource-fixture-two\nsummary: second resource fixture\nstatus: accepted\n",
+        )
+        .unwrap();
+        fs::write(
+            second.root.join(".agents/work-queue.yaml"),
+            "schema_version: 1\nqueue_id: queue-resource-fixture-two\nintent_id: intent-resource-fixture-two\ntasks:\n  - {id: YARD-001, title: publish typed resources again, state: queued, priority: 10, preferred_worker: fixture}\n",
+        )
+        .unwrap();
+        second.must_run(&["run", "--task", "YARD-001", "--execute"]);
+
+        let first_resources = first.root.join(".agents/resources");
+        let second_resources = second.root.join(".agents/resources");
+        for directory in ["artifacts", "runtime", "observations"] {
+            copy_tree(
+                &second_resources.join(directory),
+                &first_resources.join(directory),
+            );
+        }
+        let _ = fs::remove_file(first_resources.join("index.yaml"));
+
+        let discover = |intent: &str, action: &str| {
+            let output = first.must_run(&[
+                "resource",
+                "discover",
+                "--intent",
+                intent,
+                "--task",
+                "YARD-001",
+                "--action-id",
+                action,
+                "--json",
+            ]);
+            serde_json::from_slice::<Value>(&output.stdout).unwrap()
+        };
+        let first_projection = discover("intent-resource-fixture", "act-namespace-first");
+        let second_projection = discover("intent-resource-fixture-two", "act-namespace-second");
+        assert_eq!(first_projection["intent_id"], "intent-resource-fixture");
+        assert_eq!(
+            second_projection["intent_id"],
+            "intent-resource-fixture-two"
+        );
+
+        let projection_attempts = |receipt: &Value, intent: &str| {
+            receipt["result"]["entries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|entry| entry.get("artifact").unwrap_or(&entry["resource"]))
+                .map(|record| {
+                    assert_eq!(record["intent_id"], intent);
+                    record["attempt_id"].as_str().unwrap().to_string()
+                })
+                .collect::<std::collections::BTreeSet<_>>()
+        };
+        let first_attempts = projection_attempts(&first_projection, "intent-resource-fixture");
+        let second_attempts =
+            projection_attempts(&second_projection, "intent-resource-fixture-two");
+        assert!(!first_attempts.is_empty());
+        assert!(!second_attempts.is_empty());
+        assert!(first_attempts.is_disjoint(&second_attempts));
+
+        let index = read_yaml(&first_resources.join("index.yaml"));
+        let namespaces = index["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .filter(|entry| entry["task_id"].as_str() == Some("YARD-001"))
+            .map(|entry| entry["intent_id"].as_str().unwrap())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            namespaces,
+            std::collections::BTreeSet::from([
+                "intent-resource-fixture",
+                "intent-resource-fixture-two"
+            ])
+        );
     }
 
     #[test]

--- a/tests/v010_004_resource_publication.rs
+++ b/tests/v010_004_resource_publication.rs
@@ -1,0 +1,349 @@
+#[cfg(unix)]
+mod unix {
+    use serde_json::Value;
+    use serde_yaml_ng::Value as YamlValue;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::{Command, Output};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct Fixture {
+        root: PathBuf,
+        binary: PathBuf,
+    }
+
+    impl Fixture {
+        fn new(label: &str) -> Self {
+            let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let root = std::env::temp_dir().join(format!(
+                "yardlet-v010-004-{label}-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&root).unwrap();
+            must_succeed(&root, Path::new("git"), &["init", "-q"]);
+            must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+            must_succeed(
+                &root,
+                Path::new("git"),
+                &["config", "user.email", "fixture@example.invalid"],
+            );
+            fs::write(root.join("README.md"), "fixture\n").unwrap();
+            must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+            must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+            must_succeed(&root, &binary, &["init"]);
+
+            let worker = root.join("resource-worker.sh");
+            fs::copy(
+                manifest.join("tests/fixtures/v010_004_resource_model/worker.sh"),
+                &worker,
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&worker).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&worker, permissions).unwrap();
+            fs::write(
+                root.join(".agents/workers.yaml"),
+                format!(
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    worker.display()
+                ),
+            )
+            .unwrap();
+            fs::write(
+                root.join(".agents/intent-contract.yaml"),
+                "schema_version: 1\nid: intent-resource-fixture\nsummary: resource fixture\nstatus: accepted\n",
+            )
+            .unwrap();
+            fs::write(
+                root.join(".agents/work-queue.yaml"),
+                "schema_version: 1\nqueue_id: queue-resource-fixture\nintent_id: intent-resource-fixture\ntasks:\n  - {id: YARD-001, title: publish typed resources, state: queued, priority: 10, preferred_worker: fixture}\n  - {id: YARD-CAP, title: publish bounded artifacts, state: queued, priority: 20, preferred_worker: fixture}\n  - {id: YARD-BAD, title: reject unowned evidence, state: queued, priority: 30, preferred_worker: fixture}\n",
+            )
+            .unwrap();
+            Self { root, binary }
+        }
+
+        fn run(&self, args: &[&str]) -> Output {
+            command(&self.root, &self.binary, args)
+        }
+
+        fn must_run(&self, args: &[&str]) -> Output {
+            let output = self.run(args);
+            assert_success(&self.binary, args, &output);
+            output
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn command(root: &Path, program: &Path, args: &[&str]) -> Output {
+        Command::new(program)
+            .args(args)
+            .current_dir(root)
+            .output()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()))
+    }
+
+    fn assert_success(program: &Path, args: &[&str], output: &Output) {
+        assert!(
+            output.status.success(),
+            "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+            program.display(),
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+        let output = command(root, program, args);
+        assert_success(program, args, &output);
+        output
+    }
+
+    fn yaml_files(path: &Path) -> Vec<PathBuf> {
+        if !path.is_dir() {
+            return Vec::new();
+        }
+        let mut files = fs::read_dir(path)
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("yaml"))
+            .collect::<Vec<_>>();
+        files.sort();
+        files
+    }
+
+    fn read_yaml(path: &Path) -> YamlValue {
+        serde_yaml_ng::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    fn canonical_bytes(root: &Path) -> Vec<(String, Vec<u8>)> {
+        let base = root.join(".agents/resources");
+        let mut out = Vec::new();
+        for directory in ["artifacts", "runtime", "observations"] {
+            let directory = base.join(directory);
+            if !directory.is_dir() {
+                continue;
+            }
+            let mut stack = vec![directory];
+            while let Some(path) = stack.pop() {
+                for entry in fs::read_dir(path).unwrap().flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        stack.push(path);
+                    } else {
+                        out.push((
+                            path.strip_prefix(&base).unwrap().display().to_string(),
+                            fs::read(&path).unwrap(),
+                        ));
+                    }
+                }
+            }
+        }
+        out.sort_by(|left, right| left.0.cmp(&right.0));
+        out
+    }
+
+    #[test]
+    fn publishes_every_typed_kind_and_role_with_exact_attempt_provenance() {
+        let fixture = Fixture::new("round-trip");
+        fixture.must_run(&["run", "--task", "YARD-001", "--execute"]);
+
+        let output = fixture.must_run(&[
+            "resource",
+            "discover",
+            "--task",
+            "YARD-001",
+            "--action-id",
+            "act-discover-round-trip",
+            "--json",
+        ]);
+        let receipt: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(receipt["status"], "completed");
+        let entries = receipt["result"]["entries"].as_array().unwrap();
+
+        let mut roles = entries
+            .iter()
+            .filter(|entry| entry["entry_type"] == "artifact")
+            .filter_map(|entry| entry["artifact"]["role"].as_str())
+            .collect::<Vec<_>>();
+        roles.sort_unstable();
+        roles.dedup();
+        for role in [
+            "file",
+            "screenshot",
+            "git_diff",
+            "validation_output",
+            "review_report",
+            "handoff",
+        ] {
+            assert!(
+                roles.contains(&role),
+                "missing artifact role {role}: {roles:?}"
+            );
+        }
+
+        let mut kinds = entries
+            .iter()
+            .filter(|entry| entry["entry_type"] == "runtime_resource")
+            .filter_map(|entry| entry["resource"]["target"]["kind"].as_str())
+            .collect::<Vec<_>>();
+        kinds.sort_unstable();
+        assert_eq!(kinds, ["browser", "process", "service", "terminal"]);
+
+        for entry in entries {
+            let record = entry.get("artifact").unwrap_or(&entry["resource"]);
+            assert_eq!(record["task_id"], "YARD-001");
+            assert!(!record["attempt_id"].as_str().unwrap().is_empty());
+            assert_eq!(record["producer"]["worker_id"], "fixture");
+            assert!(!record["created_event_id"].as_str().unwrap().is_empty());
+        }
+
+        for (index, entry) in entries.iter().enumerate() {
+            let (id, expected_target) = if entry["entry_type"] == "artifact" {
+                let expected = if entry["status"] == "available" {
+                    "file"
+                } else {
+                    "unavailable"
+                };
+                if entry["artifact"]["proposal_id"]
+                    .as_str()
+                    .is_some_and(|proposal_id| proposal_id.starts_with("proposal-"))
+                {
+                    assert_eq!(entry["status"], "available", "explicit artifact {entry:?}");
+                }
+                (entry["artifact"]["artifact_id"].as_str().unwrap(), expected)
+            } else {
+                let expected = match entry["resource"]["target"]["kind"].as_str().unwrap() {
+                    "terminal" => "terminal_session",
+                    "process" => "process_monitor",
+                    "service" | "browser" => "url",
+                    other => panic!("unexpected resource kind {other}"),
+                };
+                (entry["resource"]["resource_id"].as_str().unwrap(), expected)
+            };
+            let action_id = format!("act-open-round-trip-{index}");
+            let opened =
+                fixture.must_run(&["resource", "open", id, "--action-id", &action_id, "--json"]);
+            let opened: Value = serde_json::from_slice(&opened.stdout).unwrap();
+            assert_eq!(opened["status"], "completed");
+            assert_eq!(
+                opened["result"]["open_target"]["target_type"], expected_target,
+                "entry {entry:?} opened as {opened:?}"
+            );
+        }
+
+        let artifact_records = yaml_files(&fixture.root.join(".agents/resources/artifacts"));
+        let duplicate_count = artifact_records
+            .iter()
+            .map(|path| read_yaml(path))
+            .filter(|record| record["proposal_id"].as_str() == Some("proposal-file"))
+            .count();
+        assert_eq!(duplicate_count, 1, "same proposal must publish once");
+    }
+
+    #[test]
+    fn derived_index_rebuild_is_bounded_and_never_changes_canonical_bytes() {
+        let fixture = Fixture::new("bounded-index");
+        fixture.must_run(&["run", "--task", "YARD-CAP", "--execute"]);
+        let canonical_before = canonical_bytes(&fixture.root);
+        let index_path = fixture.root.join(".agents/resources/index.yaml");
+        assert!(index_path.is_file());
+        fs::remove_file(&index_path).unwrap();
+
+        fixture.must_run(&[
+            "resource",
+            "discover",
+            "--task",
+            "YARD-CAP",
+            "--action-id",
+            "act-index-missing",
+            "--json",
+        ]);
+        let rebuilt = read_yaml(&index_path);
+        assert!(rebuilt["artifacts"].as_sequence().unwrap().len() <= 128);
+        fs::write(&index_path, "malformed: [\n").unwrap();
+        fixture.must_run(&[
+            "resource",
+            "discover",
+            "--task",
+            "YARD-CAP",
+            "--action-id",
+            "act-index-malformed",
+            "--json",
+        ]);
+        assert!(
+            read_yaml(&index_path)["artifacts"]
+                .as_sequence()
+                .unwrap()
+                .len()
+                <= 128
+        );
+        assert_eq!(canonical_before, canonical_bytes(&fixture.root));
+        let cap_records = yaml_files(&fixture.root.join(".agents/resources/artifacts"))
+            .iter()
+            .map(|path| read_yaml(path))
+            .filter(|record| {
+                record["proposal_id"]
+                    .as_str()
+                    .is_some_and(|proposal_id| proposal_id.starts_with("cap-"))
+            })
+            .count();
+        assert_eq!(cap_records, 140);
+    }
+
+    #[test]
+    fn evidence_without_exact_attempt_provenance_cannot_complete() {
+        let fixture = Fixture::new("invalid-provenance");
+        let output = fixture.run(&["run", "--task", "YARD-BAD", "--execute"]);
+        assert!(
+            output.status.success(),
+            "the orchestrator should record a failed task cleanly: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let queue = read_yaml(&fixture.root.join(".agents/work-queue.yaml"));
+        let state = queue["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| task["id"].as_str() == Some("YARD-BAD"))
+            .unwrap()["state"]
+            .as_str()
+            .unwrap();
+        assert_ne!(state, "done");
+        let evaluation_path = fs::read_dir(fixture.root.join(".agents/runs"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path().join("evaluation.json"))
+            .find(|path| path.is_file())
+            .expect("evaluation record");
+        let evaluation: Value =
+            serde_json::from_str(&fs::read_to_string(evaluation_path).unwrap()).unwrap();
+        let provenance_check = evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == "resource_provenance_valid")
+            .expect("evaluator must record an independent resource provenance check");
+        assert_eq!(provenance_check["passed"], false);
+        assert_eq!(provenance_check["fatal"], true);
+        assert!(
+            !fixture.root.join(".agents/resources/artifacts").is_dir()
+                || yaml_files(&fixture.root.join(".agents/resources/artifacts"))
+                    .iter()
+                    .map(|path| read_yaml(path))
+                    .all(|record| record["proposal_id"].as_str() != Some("bad"))
+        );
+    }
+}


### PR DESCRIPTION
## 무엇이 바뀌었나\n\n- terminal, process, service, browser target, artifact, verification output을 공통 typed resource로 게시합니다.\n- exact intent, task, attempt provenance와 bounded derived index를 기록하고 재구축할 수 있게 했습니다.\n- discover, inspect, open, terminate, restart 등 9개 operation을 immutable action receipt 경계로 제공합니다.\n- PID identity와 ownership을 검증하고 crash window recovery 및 service health gate를 추가했습니다.\n- 실제 local app과 browser capture를 사용한 restart/expiry dogfood를 포함했습니다.\n\n## 왜 필요한가\n\nworker가 만든 runtime과 artifact가 task 결과와 분리되어 사라지거나 수동 경로 탐색에 의존하면 Yardlet이 작업을 끝까지 소유할 수 없습니다. V010-004는 모든 resource를 생성 attempt에 귀속하고, core가 안전하게 탐색하고 조작하며 재시작 후에도 동일한 결과로 수렴하게 합니다.\n\n## 영향\n\nCLI에서 task resource를 검색하고 열거나 lifecycle operation을 실행할 수 있습니다. 외부 process를 잘못 종료하지 않도록 fresh probe, PID identity, ownership, expected-state 검사를 fail closed로 적용합니다.\n\n## 검증\n\n- V010-004 independent final review: AC-001부터 AC-007까지 PASS, unresolved finding 없음\n- cargo fmt --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test: 489 passed, 0 failed\n- V010-004 focused process suites: 12 passed\n- spawn-before-recovery test 8-way parallel repetition: 8/8 passed\n- public forbidden-string scan passed