### PR TITLE
Fix dogfood integrity and routing gaps

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -153,6 +153,7 @@ pub fn evaluate(
                 let undisclosed: Vec<String> = actual
                     .iter()
                     .map(|p| norm(p))
+                    .filter(|p| !is_current_run_artifact(p, run_id))
                     .filter(|p| !reported_norm.contains(p))
                     .collect();
                 checks.push(advisory(
@@ -287,6 +288,12 @@ pub fn evaluate(
     }
 }
 
+fn is_current_run_artifact(path: &str, run_id: &str) -> bool {
+    let path = path.trim_start_matches("./").trim_matches('"');
+    let root = format!(".agents/runs/{run_id}");
+    path == root || path.starts_with(&format!("{root}/"))
+}
+
 /// Paths that are sensitive (secrets/keys), escape the workspace, or are
 /// Yardlet-owned canonical state a worker must never write directly. A worker
 /// touching any of these fails the run regardless of its self-report.
@@ -337,6 +344,20 @@ pub fn is_canonical_state_path(path: &str) -> bool {
         rest,
         "work-queue.yaml" | "intent-contract.yaml" | "workers.yaml" | "yardlet.yaml" | "yard.yaml"
     ) || rest.ends_with("-policy.yaml")
+}
+
+/// Is this path a repository deliverable that Yardlet may integrate from an
+/// isolated worker worktree? Everything outside `.agents/` is deliverable. The
+/// only deliverables inside `.agents/` are the workspace-authored harness asset
+/// roots; canonical and runtime state remain main-process-owned.
+pub fn is_integratable_path(path: &str) -> bool {
+    let p = path.trim_start_matches("./").trim_matches('"');
+    if p == ".agents" || p.starts_with(".agents/") {
+        return [".agents/rules", ".agents/skills", ".agents/agents"]
+            .iter()
+            .any(|root| p == *root || p.starts_with(&format!("{root}/")));
+    }
+    true
 }
 
 /// Paths git reports as changed or untracked in `cwd`: the actual on-disk
@@ -753,6 +774,46 @@ mod tests {
             .expect("reported validation must be a fatal check");
         assert!(check.fatal && !check.passed);
         assert!(check.note.contains("test_parser failed"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn diff_report_ignores_current_run_artifacts_owned_by_yardlet() {
+        let dir = temp_path("core-run-artifact-disclosure");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("handoff.md"), "h").unwrap();
+        let mut result = dummy_result();
+        result.run_id = "run-x".into();
+        result.task_id = "YARD-RUN-ARTIFACT".into();
+        result.status = "done".into();
+        std::fs::write(
+            dir.join("result.json"),
+            serde_json::to_string(&result).unwrap(),
+        )
+        .unwrap();
+
+        let actual = vec![
+            ".agents/runs/run-x/worker-output.log".to_string(),
+            ".agents/runs/another-run/worker-output.log".to_string(),
+        ];
+        let evaluation = evaluate(
+            &dir,
+            "run-x",
+            &implementation_task("YARD-RUN-ARTIFACT"),
+            Some(&actual),
+        );
+        let disclosure = evaluation
+            .checks
+            .iter()
+            .find(|check| check.name == "diff_matches_report")
+            .unwrap();
+        assert!(!disclosure.passed);
+        assert!(!disclosure
+            .note
+            .contains(".agents/runs/run-x/worker-output.log"));
+        assert!(disclosure
+            .note
+            .contains(".agents/runs/another-run/worker-output.log"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -150,4 +150,22 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&root);
     }
+
+    #[test]
+    fn init_writes_explicit_default_off_preferred_worker_failover_policy() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-init-preferred-worker-failover-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        init(&root, false).unwrap();
+
+        let text = std::fs::read_to_string(root.join(".agents/workers.yaml")).unwrap();
+        let workers: crate::schemas::WorkersFile = crate::yaml::from_str(&text).unwrap();
+        assert!(!workers.routing.allow_preferred_worker_failover);
+        assert!(text.contains("allow_preferred_worker_failover: false"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -942,6 +942,24 @@ pub fn compile(inputs: &PacketInputs) -> String {
 /// draft revision after explicit acceptance, and active intent/queue snapshots
 /// only after explicit confirmation. The worker therefore only needs write
 /// access to the run directory.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct PlanningGitPolicy {
+    pub auto_commit: bool,
+    pub auto_push: bool,
+    pub push_target_configured: bool,
+}
+
+impl From<&crate::schemas::YardConfig> for PlanningGitPolicy {
+    fn from(config: &crate::schemas::YardConfig) -> Self {
+        Self {
+            auto_commit: config.auto_commit,
+            auto_push: config.git_finish.auto_push,
+            push_target_configured: !config.git_finish.remote.trim().is_empty()
+                && !config.git_finish.target_ref.trim().is_empty(),
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn compile_planning(
     request: &str,
@@ -953,6 +971,7 @@ pub fn compile_planning(
     images: &[String],
     harness: &Harness,
     planner_worker_id: &str,
+    git_policy: PlanningGitPolicy,
 ) -> String {
     let mut p = String::new();
     p.push_str("# Yardlet planning gate\n\n");
@@ -1030,6 +1049,31 @@ pub fn compile_planning(
         ));
     }
     p.push_str(&format!("- top level: {}\n\n", repo.top_level.join(", ")));
+
+    p.push_str("## Git delivery policy\n\n");
+    p.push_str(&format!(
+        "- auto_commit: {}\n- auto_push: {}\n- push target configured: {}\n",
+        if git_policy.auto_commit {
+            "enabled"
+        } else {
+            "disabled"
+        },
+        if git_policy.auto_push {
+            "enabled"
+        } else {
+            "disabled"
+        },
+        if git_policy.push_target_configured {
+            "yes"
+        } else {
+            "no"
+        },
+    ));
+    p.push_str(
+        "- Git integration and configured exact-ref push are Yardlet core/author-session responsibilities, not worker actions. Yardlet has no PR-create or merge policy in this contract.\n\
+         - Do not make commit, push, PR creation, or merge a worker-verifiable intent or task acceptance criterion. Review criteria must be satisfiable from the workspace before author-session delivery.\n\
+         - When delivery is explicitly requested, make the worker-verifiable criterion prepare a PR body or exact author-session commands in the handoff; keep the external delivery responsibility outside worker acceptance.\n\n",
+    );
 
     let classification = crate::skills::classify_repo(repo, request);
     p.push_str("## Deterministic repository classification\n\n");
@@ -1747,6 +1791,7 @@ mod tests {
             &[],
             &harness,
             "codex",
+            PlanningGitPolicy::default(),
         );
         assert!(plan.contains("## Workspace rules (always apply)"));
         assert!(plan.contains("## Skills (read on demand)"));
@@ -1765,11 +1810,36 @@ mod tests {
             &[],
             &Harness::default(),
             "codex",
+            PlanningGitPolicy::default(),
         );
 
         assert!(plan.contains("cost as a tie-breaker, not a proxy for task breadth"));
         assert!(plan.contains("broad work with executable terminal feedback"));
         assert!(plan.contains("prefer a different worker from the builder"));
+    }
+
+    #[test]
+    fn planning_packet_excludes_author_session_git_delivery_from_worker_acceptance() {
+        let plan = compile_planning(
+            "implement issue 21 and open a PR with Refs #21",
+            None,
+            &crate::inspect::RepoSummary::default(),
+            ".agents/runs/plan-git-policy",
+            "en",
+            "",
+            &[],
+            &Harness::default(),
+            "codex",
+            PlanningGitPolicy::default(),
+        );
+
+        assert!(plan.contains("## Git delivery policy"));
+        assert!(plan.contains("auto_commit: disabled"));
+        assert!(plan.contains("auto_push: disabled"));
+        assert!(
+            plan.contains("Do not make commit, push, PR creation, or merge a worker-verifiable")
+        );
+        assert!(plan.contains("PR body or exact author-session commands"));
     }
 
     #[test]
@@ -1800,6 +1870,7 @@ mod tests {
             &[],
             &Harness::default(),
             "codex",
+            PlanningGitPolicy::default(),
         );
 
         assert!(plan.contains("## Current intent (same planning thread)"));
@@ -1820,6 +1891,7 @@ mod tests {
             &[],
             &Harness::default(),
             "codex",
+            PlanningGitPolicy::default(),
         );
         assert!(!fresh.contains("intent-current"));
         assert!(!fresh.contains("current intent summary"));

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -334,8 +334,10 @@ pub fn run_batch<F: FnMut(&str)>(
         let _ = std::fs::copy(ws.queue_path(), wt_agents.join("work-queue.yaml"));
         // Harness assets too (small text): skill anchors and role notes are
         // cwd-relative in the packet and must resolve inside the worktree.
+        let harness_seed_dir = p.run_dir.join(run::HARNESS_SEED_DIR);
         for d in ["rules", "skills", "agents"] {
             copy_dir(&ws.agents_dir().join(d), &wt_agents.join(d));
+            copy_dir(&ws.agents_dir().join(d), &harness_seed_dir.join(d));
         }
 
         std::fs::create_dir_all(p.run_dir.join("evidence"))?;
@@ -651,12 +653,16 @@ pub fn run_batch<F: FnMut(&str)>(
         // self-report), then — only on a Done run — merges the worktree back;
         // it writes artifacts, the queue state, follow-ups, and telemetry. The
         // single finalization pipeline is shared with the serial path.
-        let evidence = evaluator::changed_paths(&p.wt_path).map(|paths| {
-            paths
-                .into_iter()
-                .filter(|path| !path.starts_with(".agents/"))
-                .collect()
-        });
+        let evidence = match parallel_worker_evidence(&p.wt_path, &p.run_dir) {
+            Ok(paths) => Some(paths),
+            Err(error) => {
+                on_event(&format!(
+                    "{}: change evidence unavailable after harness seed cleanup: {error}",
+                    p.task.id
+                ));
+                None
+            }
+        };
         // A finalize error for one task (e.g. a transient queue-write hiccup)
         // must not abort the whole batch and strand the other already-finished
         // worktrees — log it and move on; `yardlet recover` salvages this one.
@@ -1287,7 +1293,7 @@ where
             )));
         }
     }
-    git(wt, &["add", "-A", "--", ".", ":(exclude).agents"])?;
+    stage_integratable_changes(wt)?;
     let staged = git(wt, &["diff", "--cached", "--name-only"])?;
     after_staged(root, wt, branch)?;
     let transaction_exists = match commit_mode {
@@ -1608,7 +1614,7 @@ pub(crate) fn cleanup_integrated_worktree(
         };
         let retained = changed
             .into_iter()
-            .filter(|path| path != ".agents" && !path.starts_with(".agents/"))
+            .filter(|path| evaluator::is_integratable_path(path))
             .collect::<Vec<_>>();
         if !retained.is_empty() {
             warnings.push(format!(
@@ -1665,6 +1671,50 @@ pub(crate) fn cleanup_integrated_worktree(
         complete: target_clean && transaction_clean,
         warnings,
     }
+}
+
+fn stage_integratable_changes(wt: &Path) -> Result<()> {
+    let paths = evaluator::changed_paths(wt)
+        .ok_or_else(|| anyhow!("could not enumerate worktree changes before integration"))?;
+    // Discard worker-controlled index state, then rebuild the staged tree from
+    // the deterministic integration allowlist. This keeps canonical/runtime
+    // `.agents` state out while permitting repository harness assets.
+    git(wt, &["reset", "-q"])?;
+    for path in paths
+        .into_iter()
+        .filter(|path| evaluator::is_integratable_path(path))
+    {
+        git(wt, &["add", "-A", "--", &path])?;
+    }
+    Ok(())
+}
+
+fn parallel_worker_evidence(wt: &Path, run_dir: &Path) -> Result<Vec<String>> {
+    let mut paths = evaluator::changed_paths(wt)
+        .ok_or_else(|| anyhow!("could not enumerate parallel worktree changes"))?;
+    let seed_root = run_dir.join(run::HARNESS_SEED_DIR);
+    if seed_root.is_dir() {
+        let (seeded, modified) = run::seeded_harness_evidence(&seed_root, wt)
+            .ok_or_else(|| anyhow!("could not compare harness seed snapshot"))?;
+        let unchanged = paths
+            .iter()
+            .filter(|path| seeded.contains(*path) && !modified.contains(*path))
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.retain(|path| !seeded.contains(path) || modified.contains(path));
+        for path in modified {
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+        for path in unchanged {
+            run::discard_unchanged_seeded_harness_copy(wt, &path)?;
+        }
+    }
+    Ok(paths
+        .into_iter()
+        .filter(|path| evaluator::is_integratable_path(path))
+        .collect())
 }
 
 /// Keep `.agents/worktrees/` out of `git status` in any repo Yardlet runs in,
@@ -1998,6 +2048,44 @@ mod tests {
         sh_git(&root, &["add", "base.txt"]);
         sh_git(&root, &["commit", "-q", "-m", "init"]);
         root
+    }
+
+    #[test]
+    fn parallel_seed_cleanup_restores_dirty_tracked_harness_to_worktree_head() {
+        let root = temp_repo("parallel-dirty-tracked-harness-seed");
+        let tracked = root.join(".agents/rules/tracked-dirty.md");
+        write_str(&tracked, "# Tracked baseline\n").unwrap();
+        sh_git(&root, &["add", ".agents/rules/tracked-dirty.md"]);
+        sh_git(&root, &["commit", "-q", "-m", "track harness fixture"]);
+        write_str(&tracked, "# User dirty edit\n").unwrap();
+
+        let wt = root.join(".agents/worktrees/parallel-dirty-seed");
+        let branch = "yard/parallel-dirty-seed/run-test";
+        create_worktree(&root, &wt, branch).unwrap();
+        let run_dir = root.join(".agents/runs/run-parallel-dirty-seed");
+        let seed = run_dir
+            .join(run::HARNESS_SEED_DIR)
+            .join("rules/tracked-dirty.md");
+        write_str(
+            &wt.join(".agents/rules/tracked-dirty.md"),
+            "# User dirty edit\n",
+        )
+        .unwrap();
+        write_str(&seed, "# User dirty edit\n").unwrap();
+
+        let evidence = parallel_worker_evidence(&wt, &run_dir).unwrap();
+        assert!(evidence.is_empty(), "seed copy is not worker evidence");
+        assert_eq!(
+            std::fs::read_to_string(wt.join(".agents/rules/tracked-dirty.md")).unwrap(),
+            "# Tracked baseline\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&tracked).unwrap(),
+            "# User dirty edit\n"
+        );
+
+        remove_worktree(&root, &wt, branch);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     fn setup_workspace(root: &Path, worker_yaml: &str, tasks: Vec<Task>) -> Workspace {

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -585,6 +585,7 @@ fn plan_core(
         images,
         &harness,
         &worker_id,
+        packet::PlanningGitPolicy::from(config),
     );
     write_str(&workers::packet_path(&run_dir), &packet_text)?;
 
@@ -794,6 +795,7 @@ pub fn run_planning_amend(ws: &Workspace, request: &str) -> Result<PlanningRepor
         &images,
         &harness,
         &worker_id,
+        packet::PlanningGitPolicy::from(&config),
     );
     write_str(&workers::packet_path(&run_dir), &packet_text)?;
     let env = guard::sanitized_worker_env_for(&billing, &profile.invocation.pass_env)
@@ -1051,6 +1053,9 @@ pub(crate) fn ingest_follow_ups(
         .unwrap_or(tail_priority + 10);
     let mut ingested = Vec::new();
     for fu in follow_ups {
+        if !follow_up_scope_is_workspace_local(fu) {
+            continue;
+        }
         let title = fu.title.trim();
         if title.is_empty() {
             continue;
@@ -1155,6 +1160,21 @@ pub(crate) fn ingest_follow_ups(
         }
     }
     ingested
+}
+
+fn follow_up_scope_is_workspace_local(follow_up: &crate::schemas::FollowUpTask) -> bool {
+    follow_up.allowed_scope.iter().all(|scope| {
+        let path = std::path::Path::new(scope.trim());
+        !path.is_absolute()
+            && !path.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            })
+    })
 }
 
 pub(crate) fn persist_ingested_decision_questions(
@@ -1802,6 +1822,7 @@ mod tests {
             &[],
             &harness,
             "codex",
+            packet::PlanningGitPolicy::default(),
         );
 
         assert!(packet.contains("CURRENT_REQUEST_ANCHOR"));
@@ -2517,6 +2538,53 @@ routing:
             by_id("YARD-005").approval_required(),
             "a high-risk follow-up must be gated"
         );
+    }
+
+    #[test]
+    fn ingest_follow_ups_keeps_cross_workspace_scope_as_suggestion_only() {
+        use crate::schemas::FollowUpTask;
+        let root = std::env::temp_dir().join(format!(
+            "yard-cross-workspace-follow-up-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let ws = Workspace::at(&root);
+        let plan: PlanningResult = serde_json::from_str(
+            r#"{ "summary": "s", "tasks": [{ "id": "YARD-001", "title": "existing", "risk": "low" }] }"#,
+        )
+        .unwrap();
+        let mut queue = build_queue("intent-x", &plan);
+
+        let ingested = ingest_follow_ups(
+            &mut queue,
+            &["evidence/**".to_string()],
+            &[
+                FollowUpTask {
+                    title: "modify another repository".into(),
+                    reason: "valid adjacent work, but not owned here".into(),
+                    allowed_scope: vec!["/tmp/another-repository/src/**".into()],
+                    ..Default::default()
+                },
+                FollowUpTask {
+                    title: "escape to a sibling repository".into(),
+                    reason: "relative path still leaves this workspace".into(),
+                    allowed_scope: vec!["../another-repository/src/**".into()],
+                    ..Default::default()
+                },
+                FollowUpTask {
+                    title: "record local evidence".into(),
+                    reason: "repo-local follow-up".into(),
+                    allowed_scope: vec!["evidence/**".into()],
+                    ..Default::default()
+                },
+            ],
+            Some(&ws),
+        );
+
+        assert_eq!(ingested, vec!["YARD-002".to_string()]);
+        assert_eq!(queue.tasks.len(), 2);
+        assert_eq!(queue.tasks[1].title, "record local evidence");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -93,6 +93,25 @@ pub fn resolve_worker_for_task(
         }
     }
 
+    if candidate.reason == "planner preferred"
+        && !task.preferred_worker.trim().is_empty()
+        && !workers.routing.allow_preferred_worker_failover
+    {
+        let pinned = candidate.worker_id.clone();
+        return resolve_order(
+            workers,
+            billing,
+            pinned.clone(),
+            candidate.reason,
+            std::slice::from_ref(&pinned),
+        )
+        .map_err(|_| {
+            anyhow!(
+                "preferred worker '{pinned}' is not invocable; cross-worker fallback requires explicit opt-in with routing.allow_preferred_worker_failover"
+            )
+        });
+    }
+
     resolve_candidate(
         workers,
         billing,
@@ -108,6 +127,13 @@ pub fn resolve_failover_worker_for_task(
     failed_worker: &str,
     task: &Task,
 ) -> Result<Resolved> {
+    if !task.preferred_worker.trim().is_empty() && !workers.routing.allow_preferred_worker_failover
+    {
+        return Err(anyhow!(
+            "task pinned preferred worker '{}'; cross-worker failover requires explicit opt-in with routing.allow_preferred_worker_failover",
+            task.preferred_worker
+        ));
+    }
     let required: Vec<String> = task
         .required_capabilities
         .iter()
@@ -472,6 +498,65 @@ mod tests {
             err.contains("no alternate worker") && err.contains("image_generation"),
             "the failed worker must stay excluded and only capable alternatives may be tried: {err}"
         );
+    }
+
+    #[test]
+    fn preferred_worker_failover_requires_explicit_opt_in() {
+        let mut w: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, second]\nworkers:\n  - id: first\n    invocation: { command: bash }\n  - id: second\n    invocation: { command: bash }\n",
+        )
+        .unwrap();
+        let task: Task = crate::yaml::from_str(
+            "id: T\ntitle: t\npreferred_worker: first\nmodel: pinned-model\n",
+        )
+        .unwrap();
+
+        let error = resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "first", &task)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            error.contains("preferred worker") && error.contains("opt-in"),
+            "a pinned task must fail closed instead of changing workers: {error}"
+        );
+
+        w.routing.allow_preferred_worker_failover = true;
+        let resolved =
+            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "first", &task)
+                .unwrap();
+        assert_eq!(resolved.worker_id, "second");
+    }
+
+    #[test]
+    fn preferred_worker_initial_resolution_requires_explicit_fallback_opt_in() {
+        let mut workers: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nrouting:\n  default_worker: ready\n  fallback_order: [missing, ready]\nworkers:\n  - id: missing\n    invocation: { command: yardlet-definitely-missing-worker-command }\n  - id: ready\n    invocation: { command: bash }\n",
+        )
+        .unwrap();
+        let task: Task = crate::yaml::from_str(
+            "id: T\ntitle: t\npreferred_worker: missing\nmodel: pinned-model\n",
+        )
+        .unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "yard-routing-preferred-initial-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let workspace = Workspace::at(&root);
+
+        let error =
+            resolve_worker_for_task(&workspace, &workers, &BillingPolicy::default(), None, &task)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("preferred worker") && error.contains("opt-in"));
+
+        workers.routing.allow_preferred_worker_failover = true;
+        let resolved =
+            resolve_worker_for_task(&workspace, &workers, &BillingPolicy::default(), None, &task)
+                .unwrap();
+        assert_eq!(resolved.worker_id, "ready");
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -120,6 +120,7 @@ impl Drop for SerialWorktreeErrorCleanup<'_> {
 }
 
 const SERIAL_CANONICAL_SEED_DIR: &str = "evidence/canonical-state-seed";
+pub(crate) const HARNESS_SEED_DIR: &str = "evidence/harness-state-seed";
 
 fn git_stdout(root: &std::path::Path, args: &[&str]) -> Result<String> {
     let output = std::process::Command::new("git")
@@ -164,8 +165,13 @@ fn prepare_serial_worktree(
         let queue = ws.queue_path();
         std::fs::copy(&queue, wt_agents.join("work-queue.yaml"))?;
         std::fs::copy(&queue, canonical_seed_dir.join("work-queue.yaml"))?;
+        let harness_seed_dir = run_dir.join(HARNESS_SEED_DIR);
         for directory in ["rules", "skills", "agents"] {
             crate::parallel::copy_dir(&ws.agents_dir().join(directory), &wt_agents.join(directory));
+            crate::parallel::copy_dir(
+                &ws.agents_dir().join(directory),
+                &harness_seed_dir.join(directory),
+            );
         }
         let worker_run_dir = wt_agents.join("runs").join(run_id);
         std::fs::create_dir_all(&worker_run_dir)?;
@@ -218,6 +224,7 @@ struct SerialCommittedEvidence {
 struct SerialWorktreeEvidence {
     paths: Vec<String>,
     merge_target_oid: String,
+    unchanged_seeded_harness: Vec<String>,
 }
 
 fn serial_committed_paths(
@@ -290,6 +297,7 @@ fn serial_worktree_evidence(
         return Some(SerialWorktreeEvidence {
             paths,
             merge_target_oid: committed.merge_target_oid,
+            unchanged_seeded_harness: Vec::new(),
         });
     }
 
@@ -323,13 +331,103 @@ fn serial_worktree_evidence(
             paths.push(path);
         }
     }
+    let harness_seed_dir = run_dir.join(HARNESS_SEED_DIR);
+    let mut unchanged_seeded_harness = Vec::new();
+    if harness_seed_dir.is_dir() {
+        let (seeded_harness, modified_harness) =
+            seeded_harness_evidence(&harness_seed_dir, worktree)?;
+        unchanged_seeded_harness = paths
+            .iter()
+            .filter(|path| seeded_harness.contains(*path) && !modified_harness.contains(*path))
+            .cloned()
+            .collect();
+        paths.retain(|path| !seeded_harness.contains(path) || modified_harness.contains(path));
+        for path in modified_harness {
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
     paths.extend(committed.paths);
     paths.sort();
     paths.dedup();
     Some(SerialWorktreeEvidence {
         paths,
         merge_target_oid: committed.merge_target_oid,
+        unchanged_seeded_harness,
     })
+}
+
+fn remove_unchanged_seeded_harness_copies(
+    worktree: &std::path::Path,
+    evidence: &SerialWorktreeEvidence,
+) -> Result<()> {
+    for path in &evidence.unchanged_seeded_harness {
+        discard_unchanged_seeded_harness_copy(worktree, path)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn discard_unchanged_seeded_harness_copy(
+    worktree: &std::path::Path,
+    path: &str,
+) -> Result<()> {
+    git_stdout(worktree, &["reset", "-q", "HEAD", "--", path])?;
+    let tracked = !git_stdout(worktree, &["ls-files", "--", path])?
+        .trim()
+        .is_empty();
+    if tracked {
+        git_stdout(
+            worktree,
+            &["restore", "--source=HEAD", "--worktree", "--", path],
+        )?;
+    } else {
+        let candidate = worktree.join(path);
+        if candidate.is_file() {
+            std::fs::remove_file(candidate)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn seeded_harness_evidence(
+    seed_root: &std::path::Path,
+    worktree: &std::path::Path,
+) -> Option<(
+    std::collections::BTreeSet<String>,
+    std::collections::BTreeSet<String>,
+)> {
+    fn visit(
+        seed_root: &std::path::Path,
+        directory: &std::path::Path,
+        worktree: &std::path::Path,
+        seeded: &mut std::collections::BTreeSet<String>,
+        modified: &mut std::collections::BTreeSet<String>,
+    ) -> Option<()> {
+        for entry in std::fs::read_dir(directory).ok()? {
+            let entry = entry.ok()?;
+            let metadata = entry.file_type().ok()?;
+            if metadata.is_dir() {
+                visit(seed_root, &entry.path(), worktree, seeded, modified)?;
+                continue;
+            }
+            if !metadata.is_file() {
+                continue;
+            }
+            let relative = entry.path().strip_prefix(seed_root).ok()?.to_path_buf();
+            let path = format!(".agents/{}", relative.to_string_lossy());
+            seeded.insert(path.clone());
+            if !seeded_canonical_file_unchanged(&entry.path(), &worktree.join(&path)) {
+                modified.insert(path);
+            }
+        }
+        Some(())
+    }
+
+    let mut seeded = std::collections::BTreeSet::new();
+    let mut modified = std::collections::BTreeSet::new();
+    visit(seed_root, seed_root, worktree, &mut seeded, &mut modified)?;
+    Some((seeded, modified))
 }
 
 const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 18] = [
@@ -1486,10 +1584,17 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
 
     // ---- deterministic evidence -----------------------------------------
     let summary = inspect::summarize(&ws.root);
+    let summary_markdown = inspect::to_markdown(&summary);
     write_str(
         &run_dir.join("evidence").join("repo-summary.md"),
-        &inspect::to_markdown(&summary),
+        &summary_markdown,
     )?;
+    if serial_worktree.is_some() {
+        write_str(
+            &worker_run_dir.join("evidence").join("repo-summary.md"),
+            &summary_markdown,
+        )?;
+    }
 
     // ---- compile packet --------------------------------------------------
     // Resolve output language from config (auto-detects Korean from the intent).
@@ -2084,6 +2189,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     let serial_evidence = serial_worktree
         .as_ref()
         .and_then(|owned| serial_worktree_evidence(&owned.path, &run_dir));
+    if let (Some(owned), Some(serial_evidence)) = (&serial_worktree, &serial_evidence) {
+        remove_unchanged_seeded_harness_copies(&owned.path, serial_evidence)?;
+    }
     let evidence: Option<Vec<String>> = if serial_worktree.is_some() {
         serial_evidence
             .as_ref()
@@ -2166,14 +2274,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
 /// changes were left to commit when the run actually produced deliverable
 /// (non-`.agents/`) edits. `None` evidence (no git signal) counts as no change.
 /// A leading `./` is normalized so `./.agents/x` is still recognized as state.
-fn worker_changed_outside_agents(evidence: Option<&[String]>) -> bool {
+fn worker_changed_integratable_path(evidence: Option<&[String]>) -> bool {
     evidence
-        .map(|e| {
-            e.iter().any(|p| {
-                let p = p.trim_start_matches("./");
-                !p.starts_with(".agents/") && p != ".agents"
-            })
-        })
+        .map(|e| e.iter().any(|p| evaluator::is_integratable_path(p)))
         .unwrap_or(false)
 }
 
@@ -3677,6 +3780,14 @@ pub(crate) fn recover_orphans(ws: &Workspace) -> Vec<String> {
                 let serial_evidence = wt
                     .as_ref()
                     .and_then(|w| serial_worktree_evidence(w, &run_dir));
+                if let (Some(wt), Some(serial_evidence)) = (&wt, &serial_evidence) {
+                    if let Err(error) = remove_unchanged_seeded_harness_copies(wt, serial_evidence)
+                    {
+                        msgs.push(format!(
+                            "{id}: could not remove unchanged harness seed copies: {error}"
+                        ));
+                    }
+                }
                 let evidence = if wt.is_some() {
                     serial_evidence
                         .as_ref()
@@ -4918,7 +5029,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         if !m.auto_commit {
             let has_changes = evidence
                 .as_ref()
-                .is_some_and(|paths| worker_changed_outside_agents(Some(paths)));
+                .is_some_and(|paths| worker_changed_integratable_path(Some(paths)));
             if next_state == TaskState::Done && has_changes {
                 next_state = TaskState::Partial;
                 let _ = state::write_str(&run_dir.join("partial-reason"), "auto_commit_disabled");
@@ -7916,11 +8027,18 @@ case "$mode" in
     git -c user.name="Worker" -c user.email="worker@example.test" commit -q -m "worker canonical commit"
     git checkout -q --detach HEAD~1
     ;;
-  committed-and-uncommitted)
-    printf "committed deliverable\n" > committed.txt
-    git add -- committed.txt
-    git -c user.name="Worker" -c user.email="worker@example.test" commit -q -m "worker commit"
-    printf "schema_version: 1\nid: worker-uncommitted\nsummary: forbidden\nstatus: accepted\n" > .agents/intent-contract.yaml
+	  committed-and-uncommitted)
+	    printf "committed deliverable\n" > committed.txt
+	    git add -- committed.txt
+	    git -c user.name="Worker" -c user.email="worker@example.test" commit -q -m "worker commit"
+	    printf "schema_version: 1\nid: worker-uncommitted\nsummary: forbidden\nstatus: accepted\n" > .agents/intent-contract.yaml
+	    ;;
+  harness-asset)
+    mkdir -p .agents/skills/example
+    printf '%s\n' '---' 'name: example' 'description: fixture' '---' > .agents/skills/example/SKILL.md
+    ;;
+  anchor-probe)
+    test -f "$run_dir/evidence/repo-summary.md" || exit 42
     ;;
 esac
 cat > "$run_dir/result.json" <<EOF
@@ -7947,6 +8065,20 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
             shell_literal(&builder), task_id, mode
         );
         let ws = init_test_workspace(name, &worker_yaml);
+        if mode == "preexisting-learned-rule" {
+            write_str(
+                &ws.agents_dir().join("rules/learned-from-earlier-run.md"),
+                "# Earlier learning\n\nDo not blame the next worker.\n",
+            )
+            .unwrap();
+        }
+        if mode == "preexisting-dirty-tracked-rule" {
+            let rule = ws.agents_dir().join("rules/tracked-dirty.md");
+            write_str(&rule, "# Tracked baseline\n").unwrap();
+            git_stdout(&ws.root, &["add", ".agents/rules/tracked-dirty.md"]).unwrap();
+            git_stdout(&ws.root, &["commit", "-q", "-m", "track harness fixture"]).unwrap();
+            write_str(&rule, "# User dirty edit\n").unwrap();
+        }
         if mode == "canonical-detach" {
             write_str(
                 &ws.agents_dir().join("tool-policy.yaml"),
@@ -8054,6 +8186,33 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
     }
 
     #[test]
+    fn auto_commit_off_retains_harness_asset_as_partial() {
+        let (ws, report, source) = run_serial_worker_commit_case(
+            "serial-default-off-harness-asset",
+            "YARD-DEFAULT-OFF-HARNESS",
+            "harness-asset",
+            false,
+        );
+        let record: RunRecord = state::load_yaml(&report.run_dir.join("run.yaml")).unwrap();
+        let wt = std::path::Path::new(&record.worktree);
+
+        assert_eq!(report.result_state, Some(TaskState::Partial));
+        assert_eq!(ws.load_queue().unwrap().tasks[0].state, TaskState::Partial);
+        assert_eq!(
+            std::fs::read_to_string(report.run_dir.join("partial-reason"))
+                .unwrap()
+                .trim(),
+            "auto_commit_disabled"
+        );
+        assert!(wt.join(".agents/skills/example/SKILL.md").is_file());
+        assert!(!ws.root.join(".agents/skills/example/SKILL.md").exists());
+
+        crate::parallel::remove_worktree(&ws.root, wt, &record.worktree_branch);
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
     fn auto_commit_on_blocks_worker_committed_canonical_mutation_before_merge() {
         let (ws, report, source) = run_serial_worker_commit_case(
             "serial-worker-canonical-commit",
@@ -8089,6 +8248,105 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         crate::parallel::remove_worktree(&ws.root, wt, &record.worktree_branch);
         let _ = std::fs::remove_dir_all(&source);
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn auto_commit_on_integrates_harness_asset() {
+        let (ws, report, source) = run_serial_worker_commit_case(
+            "serial-auto-commit-harness-asset",
+            "YARD-AUTO-COMMIT-HARNESS",
+            "harness-asset",
+            true,
+        );
+
+        assert_eq!(report.result_state, Some(TaskState::Done));
+        assert!(ws.root.join(".agents/skills/example/SKILL.md").is_file());
+        let integrated_names =
+            git_stdout(&ws.root, &["diff", "--name-only", "HEAD^1", "HEAD"]).unwrap();
+        assert!(
+            integrated_names
+                .lines()
+                .any(|path| path == ".agents/skills/example/SKILL.md"),
+            "integrated diff should contain the harness asset: {integrated_names}"
+        );
+
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn serial_worker_packet_repo_summary_anchor_exists_before_spawn() {
+        let (ws, report, source) = run_serial_worker_commit_case(
+            "serial-repo-summary-anchor",
+            "YARD-REPO-SUMMARY-ANCHOR",
+            "anchor-probe",
+            false,
+        );
+
+        assert_eq!(report.result_state, Some(TaskState::Done));
+        assert!(report.run_dir.join("evidence/repo-summary.md").is_file());
+
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn serial_evidence_does_not_attribute_preexisting_learned_rule_to_next_worker() {
+        let (ws, report, source) = run_serial_worker_commit_case(
+            "serial-preexisting-learned-rule",
+            "YARD-PREEXISTING-LEARNED-RULE",
+            "preexisting-learned-rule",
+            false,
+        );
+
+        assert_eq!(report.result_state, Some(TaskState::Done));
+        let evaluation: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(report.run_dir.join("evaluation.json")).unwrap(),
+        )
+        .unwrap();
+        let disclosure = evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == "diff_matches_report")
+            .unwrap();
+        assert_eq!(disclosure["passed"], true);
+
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn serial_seed_cleanup_preserves_preexisting_dirty_tracked_harness_file() {
+        for (name, auto_commit) in [("off", false), ("on", true)] {
+            let (ws, report, source) = run_serial_worker_commit_case(
+                &format!("serial-dirty-tracked-harness-{name}"),
+                &format!("YARD-DIRTY-TRACKED-HARNESS-{}", name.to_uppercase()),
+                "preexisting-dirty-tracked-rule",
+                auto_commit,
+            );
+
+            assert_eq!(report.result_state, Some(TaskState::Done));
+            assert_eq!(
+                std::fs::read_to_string(ws.agents_dir().join("rules/tracked-dirty.md")).unwrap(),
+                "# User dirty edit\n"
+            );
+            assert!(git_stdout(
+                &ws.root,
+                &[
+                    "diff",
+                    "--name-only",
+                    "--",
+                    ".agents/rules/tracked-dirty.md"
+                ]
+            )
+            .unwrap()
+            .lines()
+            .any(|path| path == ".agents/rules/tracked-dirty.md"));
+
+            let _ = std::fs::remove_dir_all(&source);
+            let _ = std::fs::remove_dir_all(ws.root);
+        }
     }
 
     #[test]
@@ -9177,7 +9435,7 @@ exit 1
     }
 
     #[test]
-    fn serial_auto_commit_guidance_fires_only_on_non_agents_changes() {
+    fn serial_auto_commit_guidance_fires_only_on_integratable_changes() {
         // 1d worktree-only interim: a serial run never auto-commits, but it points
         // an opted-in user at a manual commit ONLY when the worker produced real
         // deliverable changes — not on a no-op Done or a .agents-only write.
@@ -9186,15 +9444,18 @@ exit 1
             ".agents/work-queue.yaml".to_string(),
             "src/feature.rs".to_string(),
         ];
-        assert!(!worker_changed_outside_agents(None)); // no git signal
-        assert!(!worker_changed_outside_agents(Some(&[]))); // nothing changed
-        assert!(!worker_changed_outside_agents(Some(&agents_only))); // state-only
-        assert!(!worker_changed_outside_agents(Some(&[
+        assert!(!worker_changed_integratable_path(None)); // no git signal
+        assert!(!worker_changed_integratable_path(Some(&[]))); // nothing changed
+        assert!(!worker_changed_integratable_path(Some(&agents_only))); // state-only
+        assert!(!worker_changed_integratable_path(Some(&[
             "./.agents/telemetry/runs.jsonl".to_string()
         ]))); // ./-prefixed state still recognized
-        assert!(worker_changed_outside_agents(Some(&with_work))); // real deliverable
-        assert!(worker_changed_outside_agents(Some(&[
+        assert!(worker_changed_integratable_path(Some(&with_work))); // real deliverable
+        assert!(worker_changed_integratable_path(Some(&[
             "./README.md".to_string()
+        ])));
+        assert!(worker_changed_integratable_path(Some(&[
+            ".agents/skills/example/SKILL.md".to_string()
         ])));
     }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1320,6 +1320,11 @@ pub struct Routing {
     pub default_worker: String,
     #[serde(default)]
     pub fallback_order: Vec<String>,
+    /// Permit a task that names `preferred_worker` to switch to another worker
+    /// after exhausting its own retries. Default false: a pinned provider/model
+    /// fails closed instead of silently incurring work or cost elsewhere.
+    #[serde(default)]
+    pub allow_preferred_worker_failover: bool,
     /// Human cost dial read by the planner: cheap | balanced | quality.
     #[serde(default = "default_cost_bias")]
     pub cost_bias: String,
@@ -1348,6 +1353,7 @@ impl Default for Routing {
         Self {
             default_worker: default_codex(),
             fallback_order: vec!["codex".to_string(), "claude-code".to_string()],
+            allow_preferred_worker_failover: false,
             cost_bias: default_cost_bias(),
             planning_gate: GateRoute::default(),
         }

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1624,6 +1624,7 @@ mod tests {
             &[],
             &planning_harness,
             "codex",
+            crate::packet::PlanningGitPolicy::default(),
         );
         assert!(planning_packet.contains("mcp-builder"));
         assert!(!planning_packet.contains("frontend-design"));

--- a/templates/agents/workers.yaml
+++ b/templates/agents/workers.yaml
@@ -104,6 +104,9 @@ routing:
   # is not ready. Resolution is deterministic; telemetry never overrides it.
   default_worker: codex
   fallback_order: [codex, claude-code]
+  # A task that names preferred_worker stays on that worker unless this is
+  # explicitly enabled. Default-off prevents silent provider/model cost changes.
+  allow_preferred_worker_failover: false
   # The planner itself runs on this worker (primary, then fallback if not ready).
   planning_gate:
     primary: codex

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -1187,7 +1187,7 @@ mod unix {
             fs::write(
                 &workers_path,
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
                     producer_command.display(),
                     worker.display()
                 ),


### PR DESCRIPTION
## What changed

- project the active Git delivery policy into planning packets so worker acceptance criteria never require author-session commit, push, PR, or merge actions
- exclude current-run Yardlet artifacts from worker disclosure checks while keeping fatal diff safety evidence intact
- copy `repo-summary.md` into the serial worker run directory before spawn
- snapshot harness inputs so pre-existing learned rules are not attributed to the next worker
- integrate worker-authored `.agents/rules`, `.agents/skills`, and `.agents/agents` assets without integrating canonical/runtime state
- preserve tracked and dirty harness files by restoring isolated worktrees to `HEAD`, while removing only unchanged untracked seed copies
- keep cross-workspace follow-ups as suggestions instead of auto-enqueuing them
- make both initial and mid-run cross-worker fallback for a preferred worker explicit opt-in

## Root causes

The serial and parallel evidence paths treated all `.agents/**` paths as one category even though harness assets are repository deliverables and runtime/canonical state is core-owned. Planning also lacked the effective Git delivery policy, and routing treated planner preference as an ordering hint during both initial selection and resultless failover.

## Verification

- `cargo fmt --check`
- `git diff --check`
- `cargo build`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -q` — 424 unit tests plus every integration/process suite passed
- independent Yardlet review with Claude fable: initial AC-9/AC-11 findings repaired; focused re-review passed all 6 remediation criteria

Closes #2
Closes #3
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11