### PR TITLE
fix: harden worker readiness and git-finish recovery

### DIFF
--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -153,7 +153,6 @@ pub fn finish_owned_run(
         task_state,
         ownership,
         FinishMode::CurrentHead,
-        false,
     )
 }
 
@@ -216,15 +215,23 @@ pub(crate) fn recover_owned_run(
         task_id,
         task_state,
         ownership,
-        FinishMode::AccumulatedHead,
-        preserve_verified,
+        FinishMode::AccumulatedHead { preserve_verified },
     )
 }
 
 #[derive(Clone, Copy)]
 enum FinishMode {
     CurrentHead,
-    AccumulatedHead,
+    AccumulatedHead { preserve_verified: bool },
+}
+
+impl FinishMode {
+    fn preserve_verified(self) -> bool {
+        match self {
+            Self::CurrentHead => false,
+            Self::AccumulatedHead { preserve_verified } => preserve_verified,
+        }
+    }
 }
 
 fn finish_owned_run_with_mode(
@@ -235,12 +242,11 @@ fn finish_owned_run_with_mode(
     task_state: TaskState,
     ownership: Option<GitFinishOwnership>,
     mode: FinishMode,
-    preserve_verified: bool,
 ) -> anyhow::Result<GitFinishRecord> {
     let previous = ws.load_git_finish_record(run_dir).ok();
     let verified_floor = previous
         .as_ref()
-        .filter(|record| preserve_verified && record.status.verified_complete())
+        .filter(|record| mode.preserve_verified() && record.status.verified_complete())
         .cloned();
     let persist_result =
         |record| persist_with_verified_floor(ws, run_dir, record, verified_floor.as_ref());
@@ -342,7 +348,7 @@ fn finish_owned_run_with_mode(
             block(&mut record, "owned_oid_is_not_head");
             return persist_result(record);
         }
-        FinishMode::AccumulatedHead
+        FinishMode::AccumulatedHead { .. }
             if !git_ok(
                 &ws.root,
                 &["merge-base", "--is-ancestor", &expected, &pins_before.head],
@@ -366,7 +372,7 @@ fn finish_owned_run_with_mode(
             return persist_result(record);
         }
         Ok(Some(oid))
-            if matches!(mode, FinishMode::AccumulatedHead)
+            if matches!(mode, FinishMode::AccumulatedHead { .. })
                 && git_ok(&ws.root, &["merge-base", "--is-ancestor", &expected, &oid]) =>
         {
             record.status = GitFinishStatus::AlreadyApplied;

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -153,6 +153,7 @@ pub fn finish_owned_run(
         task_state,
         ownership,
         FinishMode::CurrentHead,
+        false,
     )
 }
 
@@ -206,6 +207,7 @@ pub(crate) fn recover_owned_run(
     task_id: &str,
     task_state: TaskState,
     ownership: Option<GitFinishOwnership>,
+    preserve_verified: bool,
 ) -> anyhow::Result<GitFinishRecord> {
     finish_owned_run_with_mode(
         ws,
@@ -215,6 +217,7 @@ pub(crate) fn recover_owned_run(
         task_state,
         ownership,
         FinishMode::AccumulatedHead,
+        preserve_verified,
     )
 }
 
@@ -232,17 +235,24 @@ fn finish_owned_run_with_mode(
     task_state: TaskState,
     ownership: Option<GitFinishOwnership>,
     mode: FinishMode,
+    preserve_verified: bool,
 ) -> anyhow::Result<GitFinishRecord> {
+    let previous = ws.load_git_finish_record(run_dir).ok();
+    let verified_floor = previous
+        .as_ref()
+        .filter(|record| preserve_verified && record.status.verified_complete())
+        .cloned();
+    let persist_result =
+        |record| persist_with_verified_floor(ws, run_dir, record, verified_floor.as_ref());
     let policy = match ws.load_config() {
         Ok(config) => config.git_finish,
         Err(_) => {
             let policy = GitFinishPolicy::default();
             let mut record = base_record(run_id, task_id, &policy, ownership.as_ref());
             block(&mut record, "config_unreadable");
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
     };
-    let previous = ws.load_git_finish_record(run_dir).ok();
     let target_changed = previous.as_ref().is_some_and(|record| {
         record.policy.auto_push
             && (record.policy.remote != policy.remote
@@ -259,36 +269,36 @@ fn finish_owned_run_with_mode(
     if ownership_changed {
         let mut blocked_record = base_record(run_id, task_id, &policy, recorded_ownership.as_ref());
         block(&mut blocked_record, "run_ownership_evidence_changed");
-        return persist_and_return(ws, run_dir, blocked_record);
+        return persist_result(blocked_record);
     }
     let mut record = base_record(run_id, task_id, &policy, ownership.as_ref());
     if target_changed {
         block(&mut record, "git_finish_target_changed");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
 
     if !policy.auto_push {
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     if task_state != TaskState::Done {
         block(&mut record, "task_not_done");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     if policy.remote.trim().is_empty() {
         block(&mut record, "remote_not_configured");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     let Some(branch) = policy.target_ref.strip_prefix("refs/heads/") else {
         block(&mut record, "target_ref_must_be_branch");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     };
     if branch.is_empty() || policy.target_ref.contains([' ', ':', '^', '~']) {
         block(&mut record, "target_ref_invalid");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     if !git_ok(&ws.root, &["check-ref-format", &policy.target_ref]) {
         block(&mut record, "target_ref_invalid");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     let _lock = match FinishLock::acquire(&ws.root, &policy.remote, &policy.target_ref) {
         Ok(lock) => lock,
@@ -297,37 +307,40 @@ fn finish_owned_run_with_mode(
             // non-durable safety block for this caller; never project an older
             // status as current truth, and never overwrite a concurrent
             // finisher's durable record.
-            return Ok(lock_failure_record(record, reason));
+            return Ok(with_verified_floor(
+                lock_failure_record(record, reason),
+                verified_floor.as_ref(),
+            ));
         }
     };
     let pins_before = match git_security_pins(&ws.root, &policy.remote) {
         Ok(pins) => pins,
         Err(()) => {
             block(&mut record, "remote_not_found");
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
     };
     if pins_before.head.is_empty() {
         block(&mut record, "remote_not_found");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     let Some(push_destination) = single_push_destination(&pins_before.push_urls) else {
         block(&mut record, "remote_must_have_one_push_destination");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     };
     let current_branch = git_stdout(&ws.root, &["symbolic-ref", "--quiet", "--short", "HEAD"]);
     if current_branch.as_deref().map(str::trim) != Some(branch) {
         block(&mut record, "branch_does_not_match_target_ref");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     let Some(expected) = record.expected_oid.clone() else {
         block(&mut record, "run_has_no_owned_commit");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     };
     match mode {
         FinishMode::CurrentHead if pins_before.head != expected => {
             block(&mut record, "owned_oid_is_not_head");
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
         FinishMode::AccumulatedHead
             if !git_ok(
@@ -336,13 +349,13 @@ fn finish_owned_run_with_mode(
             ) =>
         {
             block(&mut record, "owned_oid_is_not_in_head_history");
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
         _ => {}
     }
     if !worktree_clean_except_agents(&ws.root) {
         block(&mut record, "worktree_not_clean");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
 
     let remote_before = match remote_oid(&ws.root, &policy.remote, &policy.target_ref) {
@@ -350,7 +363,7 @@ fn finish_owned_run_with_mode(
             record.status = GitFinishStatus::AlreadyApplied;
             record.remote_oid = Some(oid);
             record.reason = "remote_already_matches".to_string();
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
         Ok(Some(oid))
             if matches!(mode, FinishMode::AccumulatedHead)
@@ -359,20 +372,28 @@ fn finish_owned_run_with_mode(
             record.status = GitFinishStatus::AlreadyApplied;
             record.remote_oid = Some(oid);
             record.reason = "remote_contains_owned_commit".to_string();
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
         Ok(oid) => oid,
         Err(()) => {
             record.status = GitFinishStatus::GitFailed;
             record.reason = "remote_lookup_before_push_failed".to_string();
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
     };
     record.remote_before_oid = remote_before.clone();
 
+    // A Done-projection repair may confirm an earlier verified finish, but it
+    // must never turn that durable fact back into Prepared or perform a second
+    // push. If the remote no longer contains the owned commit, retain the last
+    // verified record and leave any explicit remote repair to a new operation.
+    if let Some(previous) = verified_floor.as_ref() {
+        return Ok(previous.clone());
+    }
+
     if !ownership_proven(&ws.root, &record, remote_before.as_deref()) {
         block(&mut record, "reachable_commits_not_owned_by_run");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
 
     for (index, check) in policy.pre_push_checks.iter().enumerate() {
@@ -386,7 +407,7 @@ fn finish_owned_run_with_mode(
         if !passed {
             record.status = GitFinishStatus::CheckBlocked;
             record.reason = "pre_push_check_failed".to_string();
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
     }
 
@@ -394,33 +415,33 @@ fn finish_owned_run_with_mode(
         Ok(pins) => pins,
         Err(()) => {
             block(&mut record, "git_state_changed_during_checks");
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
     };
     if pins_after.head != pins_before.head {
         block(&mut record, "head_changed_during_checks");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     if pins_after.fetch_urls != pins_before.fetch_urls
         || pins_after.push_urls != pins_before.push_urls
     {
         block(&mut record, "remote_urls_changed_during_checks");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     if !worktree_clean_except_agents(&ws.root) {
         block(&mut record, "worktree_changed_during_checks");
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     match remote_oid(&ws.root, &policy.remote, &policy.target_ref) {
         Ok(oid) if oid == remote_before => {}
         Ok(_) => {
             block(&mut record, "remote_ref_changed_during_checks");
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
         Err(()) => {
             record.status = GitFinishStatus::GitFailed;
             record.reason = "remote_lookup_during_checks_failed".to_string();
-            return persist_and_return(ws, run_dir, record);
+            return persist_result(record);
         }
     }
 
@@ -439,7 +460,7 @@ fn finish_owned_run_with_mode(
     ) {
         record.status = GitFinishStatus::GitFailed;
         record.reason = "push_failed".to_string();
-        return persist_and_return(ws, run_dir, record);
+        return persist_result(record);
     }
     record.push_succeeded = true;
 
@@ -459,7 +480,7 @@ fn finish_owned_run_with_mode(
             record.reason = "remote_lookup_after_push_failed".to_string();
         }
     }
-    persist_and_return(ws, run_dir, record)
+    persist_result(record)
 }
 
 fn single_push_destination(bytes: &[u8]) -> Option<String> {
@@ -683,6 +704,32 @@ fn persist_and_return(
 ) -> anyhow::Result<GitFinishRecord> {
     persist(ws, run_dir, &record)?;
     Ok(record)
+}
+
+fn with_verified_floor(
+    record: GitFinishRecord,
+    verified_floor: Option<&GitFinishRecord>,
+) -> GitFinishRecord {
+    if !record.status.verified_complete() {
+        if let Some(previous) = verified_floor {
+            return previous.clone();
+        }
+    }
+    record
+}
+
+fn persist_with_verified_floor(
+    ws: &Workspace,
+    run_dir: &Path,
+    record: GitFinishRecord,
+    verified_floor: Option<&GitFinishRecord>,
+) -> anyhow::Result<GitFinishRecord> {
+    if !record.status.verified_complete() {
+        if let Some(previous) = verified_floor {
+            return Ok(previous.clone());
+        }
+    }
+    persist_and_return(ws, run_dir, record)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -924,6 +971,7 @@ mod tests {
                 "YARD-001",
                 TaskState::Done,
                 ownership,
+                false,
             )
             .unwrap()
         }
@@ -1745,6 +1793,7 @@ mod tests {
                 "YARD-001",
                 TaskState::Done,
                 Some(proof_a),
+                false,
             )
             .unwrap()
         });
@@ -1756,6 +1805,7 @@ mod tests {
                 "YARD-001",
                 TaskState::Done,
                 Some(proof_b),
+                false,
             )
             .unwrap()
         });

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -20,6 +20,8 @@ use crate::schemas::{BillingPolicy, WorkerProfile};
 pub enum Readiness {
     Ready,
     NotReady,
+    /// The worker is configured but explicitly disabled in workers.yaml.
+    Disabled,
     /// Binary is present but its offline `--version` probe failed, so the
     /// resolved CLI or its runtime cannot be confirmed. Yardlet stops rather than
     /// guess (it never risks a billed call to verify auth).
@@ -31,6 +33,7 @@ impl Readiness {
         match self {
             Readiness::Ready => "invocable",
             Readiness::NotReady => "not ready",
+            Readiness::Disabled => "disabled",
             Readiness::Ambiguous => "ambiguous",
         }
     }
@@ -64,6 +67,8 @@ pub enum StageMark {
     Offline,
     /// Gate does not apply (e.g. version when no binary was found).
     Skipped,
+    /// Worker is explicitly disabled in workers.yaml.
+    Disabled,
 }
 
 impl StageMark {
@@ -76,6 +81,7 @@ impl StageMark {
             StageMark::Blocked => "BLOCK",
             StageMark::Offline => "n/a",
             StageMark::Skipped => "-",
+            StageMark::Disabled => "off",
         }
     }
 }
@@ -104,6 +110,14 @@ impl WorkerStatus {
     /// makes a billed call to confirm a subscription login, so it never claims
     /// the login was verified. It only reports what it can prove locally.
     pub fn stages(&self, billing: &BillingPolicy) -> Vec<StatusStage> {
+        if self.readiness == Readiness::Disabled {
+            return vec![StatusStage {
+                label: "enabled",
+                mark: StageMark::Disabled,
+                note: "disabled in .agents/workers.yaml".to_string(),
+            }];
+        }
+
         let binary = match &self.binary_path {
             Some(p) => StatusStage {
                 label: "binary",
@@ -194,6 +208,9 @@ impl WorkerStatus {
                 "not invocable: binary found but unverified (see version gate)".to_string()
             }
             Readiness::NotReady => "not invocable: worker CLI not installed".to_string(),
+            Readiness::Disabled => {
+                "not invocable: worker is disabled in .agents/workers.yaml".to_string()
+            }
         }
     }
 }
@@ -266,6 +283,18 @@ fn fallback_paths(worker_id: &str) -> Vec<PathBuf> {
 pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
     let command = profile.invocation.command.clone();
     let billing_env_present = present_billing_env(&billing.blocked_worker_env_names);
+
+    if !profile.enabled {
+        return WorkerStatus {
+            id: profile.id.clone(),
+            command,
+            binary_path: None,
+            version: None,
+            billing_env_present,
+            readiness: Readiness::Disabled,
+            detail: "disabled in .agents/workers.yaml".to_string(),
+        };
+    }
 
     let mut candidates: Vec<PathBuf> = Vec::new();
     if let Some(p) = find_binary(&command) {
@@ -471,6 +500,30 @@ mod tests {
         // Strict policy blocks only when billing env is actually present.
         assert!(billing_blocked("block", 1));
         assert!(!billing_blocked("block", 0));
+    }
+
+    #[test]
+    fn disabled_worker_is_not_reported_as_invocable() {
+        let profile: WorkerProfile = serde_yaml_ng::from_str(
+            r#"
+id: disabled-cargo
+enabled: false
+invocation:
+  command: cargo
+"#,
+        )
+        .unwrap();
+        let billing = BillingPolicy::default();
+
+        let status = probe(&profile, &billing);
+
+        assert_ne!(status.readiness, Readiness::Ready);
+        assert_eq!(status.readiness.label(), "disabled");
+        assert!(status.invocation_verdict(&billing).contains("disabled"));
+        let stages = status.stages(&billing);
+        assert_eq!(stages.len(), 1);
+        assert_eq!(stages[0].label, "enabled");
+        assert_eq!(stages[0].mark, StageMark::Disabled);
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -3117,12 +3117,21 @@ struct PendingGitFinish {
     started_at: String,
 }
 
-/// Find every unverified integration for the live intent and order each remote
-/// target by the workspace's first-parent integration history. This deliberately
-/// scans runs rather than tasks: multiple runs may own distinct accumulated
+/// Find every integration whose Git-finish or run projection still needs
+/// recovery for the live intent, then order each remote target by the
+/// workspace's first-parent integration history. This deliberately scans runs
+/// rather than tasks: multiple non-Done runs may own distinct accumulated
 /// commits even when they share a task id.
 fn pending_git_finishes(ws: &Workspace, queue: &WorkQueue) -> Vec<PendingGitFinish> {
     let config_policy = ws.load_config().ok().map(|config| config.git_finish);
+    let latest_done_runs = queue
+        .tasks
+        .iter()
+        .filter(|task| task.state == TaskState::Done)
+        .filter_map(|task| {
+            latest_run_for(ws, &task.id).map(|(_, run_dir)| (task.id.clone(), run_dir))
+        })
+        .collect::<HashMap<_, _>>();
     let positions = std::process::Command::new("git")
         .arg("-C")
         .arg(&ws.root)
@@ -3155,18 +3164,25 @@ fn pending_git_finishes(ws: &Workspace, queue: &WorkQueue) -> Vec<PendingGitFini
         else {
             continue;
         };
-        // The live queue is authoritative for task completion. Historical
-        // runs belonging to an already-Done task must not be re-finalized just
-        // because an older Git-finish record used another target or never
-        // reached a verified status. Recovery remains available for Partial
-        // tasks, including the post-push crash window repaired below.
-        if task_state == TaskState::Done {
-            continue;
-        }
         if run.intent_id != queue.intent_id || !run_dir.join("result.json").exists() {
             continue;
         }
         let finish = ws.load_git_finish_record(&run_dir).ok();
+        // The live queue is authoritative for task completion, so Done tasks
+        // skip historical and unverified runs. The one exception is their
+        // latest run after a verified external finish when the run projection
+        // is still stale. Recovery may re-seal that run without pushing again.
+        let repairs_done_projection = task_state == TaskState::Done
+            && latest_done_runs
+                .get(&run.task_id)
+                .is_some_and(|latest| latest == &run_dir)
+            && finish
+                .as_ref()
+                .is_some_and(|record| record.status.verified_complete())
+            && (run.state != "done" || run.completed_at.is_none());
+        if task_state == TaskState::Done && !repairs_done_projection {
+            continue;
+        }
         let (auto_push, remote, target_ref, expected_oid) = match finish.as_ref() {
             Some(record) => (
                 record.policy.auto_push,
@@ -3186,19 +3202,7 @@ fn pending_git_finishes(ws: &Workspace, queue: &WorkQueue) -> Vec<PendingGitFini
                 )
             }
         };
-        // A verified external finish is only globally terminal once the queue
-        // and worker-writable run projection agree. A crash can land after the
-        // authoritative Pushed/AlreadyApplied checkpoint but before sealing a
-        // previously Partial run; include that mismatch so recovery re-derives
-        // remote truth, repairs the projection, and converges without pushing
-        // again.
-        let verified_everywhere = finish
-            .as_ref()
-            .is_some_and(|record| record.status.verified_complete())
-            && task_state == TaskState::Done
-            && run.state == "done"
-            && run.completed_at.is_some();
-        if !auto_push || verified_everywhere || expected_oid.is_empty() {
+        if !auto_push || expected_oid.is_empty() {
             continue;
         }
         pending.push(PendingGitFinish {
@@ -6203,8 +6207,82 @@ mod tests {
             vec!["YARD-010"],
             "Done historical runs must not be re-finalized for unrelated targets"
         );
-        assert_eq!(q.tasks[0].state, TaskState::Done);
-        assert_eq!(q.tasks[1].state, TaskState::Done);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn pending_git_finish_recovery_retains_only_latest_verified_stale_done_run() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-latest-verified-stale-git-finish-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ws = Workspace::at(&root);
+        let task_id = "YARD-DONE-STALE";
+        let mut q = queue(vec![task(task_id, TaskState::Done, 10, false)]);
+        q.intent_id = "intent-latest-verified-stale".into();
+        ws.save_queue(&q).unwrap();
+
+        for index in [1, 2] {
+            let run_id = format!("run-20990101-00000{index}-{task_id}");
+            let run_dir = ws.runs_dir().join(&run_id);
+            std::fs::create_dir_all(&run_dir).unwrap();
+            write_str(&run_dir.join("result.json"), "{\"status\":\"done\"}").unwrap();
+            state::save_yaml(
+                &run_dir.join("run.yaml"),
+                &RunRecord {
+                    schema_version: 1,
+                    run_id: run_id.clone(),
+                    task_id: task_id.into(),
+                    intent_id: q.intent_id.clone(),
+                    worker: "codex".into(),
+                    state: "partial".into(),
+                    started_at: format!("2099-01-01T00:00:0{index}+00:00"),
+                    completed_at: Some(format!("2099-01-01T00:01:0{index}+00:00")),
+                    integration_oid: format!("integration-{index}"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            ws.save_git_finish_record(
+                &run_dir,
+                &crate::git_finish::GitFinishRecord {
+                    schema_version: 2,
+                    run_id: run_id.clone(),
+                    task_id: task_id.into(),
+                    attempted_at: String::new(),
+                    status: crate::git_finish::GitFinishStatus::Pushed,
+                    policy: crate::git_finish::GitFinishPolicySnapshot {
+                        auto_push: true,
+                        remote: "fixture".into(),
+                        target_ref: "refs/heads/main".into(),
+                        pre_push_checks: vec![],
+                    },
+                    expected_oid: Some(format!("integration-{index}")),
+                    baseline_oid: format!("baseline-{index}"),
+                    owned_oids: vec![format!("integration-{index}")],
+                    checks: vec![],
+                    push_invoked: true,
+                    push_succeeded: true,
+                    remote_oid: Some(format!("integration-{index}")),
+                    remote_before_oid: Some(format!("baseline-{index}")),
+                    reason: "remote_verified".into(),
+                },
+            )
+            .unwrap();
+        }
+
+        let candidates = pending_git_finishes(&ws, &q);
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.run_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run-20990101-000002-YARD-DONE-STALE"],
+            "only the latest verified run may repair a stale Done projection"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -11683,7 +11761,7 @@ exit 1
         let worktree = ws.agents_dir().join("worktrees").join(run_id);
         let run_dir = ws.runs_dir().join(run_id);
         std::fs::create_dir_all(&run_dir).unwrap();
-        let mut queued = task(task_id, TaskState::Partial, 10, false);
+        let mut queued = task(task_id, TaskState::Done, 10, false);
         queued.kind = "implementation".into();
         let mut q = queue(vec![queued]);
         q.intent_id = "intent-verified-projection".into();
@@ -11754,8 +11832,8 @@ exit 1
         .unwrap();
 
         // Reproduce the post-push crash boundary: the authoritative checkpoint
-        // is durable, but the worker-writable projection cannot be replaced and
-        // the queue is still Partial.
+        // and queue state are durable, but the completed run projection is
+        // still Partial.
         std::fs::create_dir_all(run_dir.join("git-finish.json")).unwrap();
         let projection_error = ws
             .save_git_finish_record(
@@ -11804,6 +11882,9 @@ exit 1
         );
         assert!(!finish.push_invoked, "recovery must not repeat the push");
         assert_eq!(finish.remote_oid.as_deref(), Some(integration_oid.as_str()));
+        let sealed = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml")).unwrap();
+        assert_eq!(sealed.state, "done");
+        assert!(sealed.completed_at.is_some());
         assert_eq!(
             git(&["ls-remote", "--refs", "fixture", "refs/heads/main"]),
             format!("{integration_oid}\trefs/heads/main")

--- a/src/run.rs
+++ b/src/run.rs
@@ -3155,6 +3155,14 @@ fn pending_git_finishes(ws: &Workspace, queue: &WorkQueue) -> Vec<PendingGitFini
         else {
             continue;
         };
+        // The live queue is authoritative for task completion. Historical
+        // runs belonging to an already-Done task must not be re-finalized just
+        // because an older Git-finish record used another target or never
+        // reached a verified status. Recovery remains available for Partial
+        // tasks, including the post-push crash window repaired below.
+        if task_state == TaskState::Done {
+            continue;
+        }
         if run.intent_id != queue.intent_id || !run_dir.join("result.json").exists() {
             continue;
         }
@@ -6114,6 +6122,91 @@ mod tests {
                 "{status:?}"
             );
         }
+    }
+
+    #[test]
+    fn pending_git_finish_recovery_skips_done_historical_runs_on_other_targets() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-done-historical-git-finishes-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ws = Workspace::at(&root);
+        let mut q = queue(vec![
+            task("YARD-001", TaskState::Done, 10, false),
+            task("YARD-005", TaskState::Done, 20, false),
+            task("YARD-010", TaskState::Partial, 30, false),
+        ]);
+        q.intent_id = "intent-git-finish-history".into();
+        ws.save_queue(&q).unwrap();
+
+        for (index, task_id, state, target_ref) in [
+            (1, "YARD-001", "done", "refs/heads/release-v010-001"),
+            (5, "YARD-005", "done", "refs/heads/release-v010-005"),
+            (10, "YARD-010", "partial", "refs/heads/main"),
+        ] {
+            let run_id = format!("run-20990101-0000{index:02}-{task_id}");
+            let run_dir = ws.runs_dir().join(&run_id);
+            std::fs::create_dir_all(&run_dir).unwrap();
+            write_str(&run_dir.join("result.json"), "{\"status\":\"done\"}").unwrap();
+            state::save_yaml(
+                &run_dir.join("run.yaml"),
+                &RunRecord {
+                    schema_version: 1,
+                    run_id: run_id.clone(),
+                    task_id: task_id.into(),
+                    intent_id: q.intent_id.clone(),
+                    worker: "codex".into(),
+                    state: state.into(),
+                    started_at: format!("2099-01-01T00:00:{index:02}+00:00"),
+                    completed_at: Some(format!("2099-01-01T00:01:{index:02}+00:00")),
+                    integration_oid: format!("integration-{index}"),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            ws.save_git_finish_record(
+                &run_dir,
+                &crate::git_finish::GitFinishRecord {
+                    schema_version: 2,
+                    run_id,
+                    task_id: task_id.into(),
+                    attempted_at: String::new(),
+                    status: crate::git_finish::GitFinishStatus::CheckBlocked,
+                    policy: crate::git_finish::GitFinishPolicySnapshot {
+                        auto_push: true,
+                        remote: format!("fixture-{index}"),
+                        target_ref: target_ref.into(),
+                        pre_push_checks: vec![],
+                    },
+                    expected_oid: Some(format!("integration-{index}")),
+                    baseline_oid: format!("baseline-{index}"),
+                    owned_oids: vec![format!("integration-{index}")],
+                    checks: vec![],
+                    push_invoked: false,
+                    push_succeeded: false,
+                    remote_oid: None,
+                    remote_before_oid: None,
+                    reason: "historical fixture".into(),
+                },
+            )
+            .unwrap();
+        }
+
+        let candidates = pending_git_finishes(&ws, &q);
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.task_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["YARD-010"],
+            "Done historical runs must not be re-finalized for unrelated targets"
+        );
+        assert_eq!(q.tasks[0].state, TaskState::Done);
+        assert_eq!(q.tasks[1].state, TaskState::Done);
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -3255,6 +3255,11 @@ fn recover_pending_git_finishes(
                 .collect()
         });
         let worker = run_worker(&candidate.run_dir).unwrap_or_default();
+        let flags = if task.state == TaskState::Done {
+            FinalizeFlags::done_projection_recovery()
+        } else {
+            FinalizeFlags::recovery()
+        };
         match finalize_run(FinalizeInput {
             ws,
             run_dir: &candidate.run_dir,
@@ -3268,7 +3273,7 @@ fn recover_pending_git_finishes(
             intent_summary: "",
             billing,
             queue,
-            flags: FinalizeFlags::recovery(),
+            flags,
             merge: None,
         }) {
             Ok(report) if report.next_state == TaskState::Done => {
@@ -4286,6 +4291,10 @@ pub(crate) struct FinalizeFlags {
     /// Reconcile a previously integrated run whose exact OID may sit behind
     /// later integrations. The run's durable ownership proof remains immutable.
     pub git_finish_recovery: bool,
+    /// Repair only the stale run projection of a queue task that is already
+    /// Done with a verified Git-finish record. Re-evaluation may add diagnostics,
+    /// but it cannot regress the canonical queue state or verified finish fact.
+    pub repairs_done_projection: bool,
     /// Ingest worker-proposed follow-ups AND run review auto-remediation (both
     /// rewrite queue topology from the worker's proposals). Off for recovery,
     /// which must only finalize the stranded run, not mutate the queue graph.
@@ -4303,6 +4312,7 @@ impl FinalizeFlags {
             artifacts: true,
             telemetry: true,
             git_finish_recovery: false,
+            repairs_done_projection: false,
             follow_ups: true,
         }
     }
@@ -4321,6 +4331,7 @@ impl FinalizeFlags {
             artifacts: true,
             telemetry: true,
             git_finish_recovery: false,
+            repairs_done_projection: false,
             follow_ups: true,
         }
     }
@@ -4342,7 +4353,15 @@ impl FinalizeFlags {
             artifacts: false,
             telemetry: true,
             git_finish_recovery: true,
+            repairs_done_projection: false,
             follow_ups: false,
+        }
+    }
+
+    pub fn done_projection_recovery() -> Self {
+        Self {
+            repairs_done_projection: true,
+            ..Self::recovery()
         }
     }
 }
@@ -4953,6 +4972,13 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             lines.push(format!("feedback stopped: {}", f.terminal_reason));
         }
     }
+    if flags.repairs_done_projection && next_state != TaskState::Done {
+        lines.push(format!(
+            "{}: retained Done while repairing its verified Git finish projection",
+            task.id
+        ));
+        next_state = TaskState::Done;
+    }
 
     if let Some(question) = result
         .as_ref()
@@ -5261,7 +5287,15 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     let git_finish = if git_finish_not_needed {
         crate::git_finish::finish_no_change_run(ws, run_dir, run_id, &task.id, next_state)?
     } else if flags.git_finish_recovery {
-        crate::git_finish::recover_owned_run(ws, run_dir, run_id, &task.id, next_state, ownership)?
+        crate::git_finish::recover_owned_run(
+            ws,
+            run_dir,
+            run_id,
+            &task.id,
+            next_state,
+            ownership,
+            flags.repairs_done_projection,
+        )?
     } else {
         crate::git_finish::finish_owned_run(ws, run_dir, run_id, &task.id, next_state, ownership)?
     };
@@ -11687,10 +11721,16 @@ exit 1
         let _ = std::fs::remove_dir_all(&remote);
     }
 
-    #[test]
-    fn verified_external_finish_recovers_partial_projection_without_duplicate_push() {
+    fn assert_verified_external_finish_recovers_partial_projection(
+        sensitive_uncommitted_file: bool,
+    ) {
         let root = std::env::temp_dir().join(format!(
-            "yard-verified-finish-projection-{}",
+            "yard-verified-finish-projection-{}-{}",
+            if sensitive_uncommitted_file {
+                "sensitive"
+            } else {
+                "clean"
+            },
             std::process::id()
         ));
         let remote = root.with_extension("bare.git");
@@ -11868,6 +11908,9 @@ exit 1
             crate::git_finish::GitFinishStatus::Pushed
         );
         std::fs::remove_dir_all(run_dir.join("git-finish.json")).unwrap();
+        if sensitive_uncommitted_file {
+            std::fs::write(root.join(".env.recovery-secret"), "must remain untouched\n").unwrap();
+        }
 
         let messages = recover_orphans(&ws);
         assert_eq!(
@@ -11876,11 +11919,18 @@ exit 1
             "{messages:?}"
         );
         let finish = ws.load_git_finish_record(&run_dir).unwrap();
-        assert_eq!(
-            finish.status,
-            crate::git_finish::GitFinishStatus::AlreadyApplied
-        );
-        assert!(!finish.push_invoked, "recovery must not repeat the push");
+        if sensitive_uncommitted_file {
+            assert_eq!(finish.status, crate::git_finish::GitFinishStatus::Pushed);
+            assert_eq!(finish.reason, "remote_verified");
+            assert_eq!(finish.attempted_at, "2099-01-01T00:00:01+00:00");
+        } else {
+            assert_eq!(
+                finish.status,
+                crate::git_finish::GitFinishStatus::AlreadyApplied
+            );
+            assert!(!finish.push_invoked, "recovery must not repeat the push");
+        }
+        assert!(finish.status.verified_complete());
         assert_eq!(finish.remote_oid.as_deref(), Some(integration_oid.as_str()));
         let sealed = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml")).unwrap();
         assert_eq!(sealed.state, "done");
@@ -11889,6 +11939,12 @@ exit 1
             git(&["ls-remote", "--refs", "fixture", "refs/heads/main"]),
             format!("{integration_oid}\trefs/heads/main")
         );
+        if sensitive_uncommitted_file {
+            assert_eq!(
+                std::fs::read_to_string(root.join(".env.recovery-secret")).unwrap(),
+                "must remain untouched\n"
+            );
+        }
 
         let second = recover_orphans(&ws);
         assert!(
@@ -11897,6 +11953,16 @@ exit 1
         );
         let _ = std::fs::remove_dir_all(&root);
         let _ = std::fs::remove_dir_all(&remote);
+    }
+
+    #[test]
+    fn verified_external_finish_recovers_partial_projection_without_duplicate_push() {
+        assert_verified_external_finish_recovers_partial_projection(false);
+    }
+
+    #[test]
+    fn done_projection_recovery_preserves_verified_finish_with_sensitive_uncommitted_file() {
+        assert_verified_external_finish_recovers_partial_projection(true);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -2431,12 +2431,17 @@ impl Workspace {
                 && existing.producer == proposal.producer
                 && existing.causation_id == causation_id
                 && existing.path == proposal.path
-                && existing.source_path == source_path
                 && existing.digest == proposal.digest
                 && existing.media_type == proposal.media_type
                 && existing.role == proposal.role
                 && existing.channel_role == proposal.channel_role;
             if same {
+                // `source_path` is the physical location used to verify the
+                // publication, not proposal identity. A Git-finish recovery
+                // can replay an already-published worktree artifact from the
+                // integrated workspace root. Preserve the first canonical
+                // record while still failing closed on provenance, logical
+                // path, digest, media type, or role mutations.
                 return Ok(existing);
             }
             bail!("artifact_proposal_conflict: {}", proposal.proposal_id);
@@ -5536,6 +5541,89 @@ routing:
             raw_stdout_ref: format!("attempts/{id}/stdout.log"),
             raw_stderr_ref: format!("attempts/{id}/stderr.log"),
         }
+    }
+
+    #[test]
+    fn artifact_proposal_replay_accepts_a_new_source_location_but_rejects_mutation() {
+        let dir = temp_root("artifact-proposal-source-replay");
+        let _ = fs::remove_dir_all(&dir);
+        let ws = Workspace::at(&dir);
+        let attempt_id = "att_artifact_replay";
+        let mut attempt = prepared_attempt(attempt_id);
+        attempt.raw_stdout_ref = format!("attempts/{attempt_id}/stdout.log");
+        attempt.raw_stderr_ref = format!("attempts/{attempt_id}/stderr.log");
+        ws.record_worker_attempt(&attempt).unwrap();
+
+        let mut completed = channel_event(ChannelEventType::WorkerCompleted, Some(attempt_id));
+        completed.payload = serde_json::json!({"worker_id": "codex", "outcome": "succeeded"});
+        ws.record_task_event("intent_channel", completed).unwrap();
+
+        let proposal = ArtifactProposal {
+            proposal_id: "proposal_guard_rs".into(),
+            task_id: "YARD-001".into(),
+            attempt_id: attempt_id.into(),
+            producer: crate::schemas::ResourceProducer {
+                worker_id: "codex".into(),
+            },
+            causation_id: attempt_id.into(),
+            path: "src/guard.rs".into(),
+            digest: "fnv1a64:0123456789abcdef".into(),
+            media_type: "text/plain".into(),
+            role: crate::schemas::ArtifactRole::File,
+            channel_role: "worker_declared".into(),
+        };
+
+        let first = ws
+            .publish_artifact(
+                "ses_channel",
+                "intent_channel",
+                &proposal,
+                "/workspace/.agents/worktrees/run-yard-010/src/guard.rs",
+            )
+            .unwrap();
+        let replay = ws
+            .publish_artifact(
+                "ses_channel",
+                "intent_channel",
+                &proposal,
+                "/workspace/src/guard.rs",
+            )
+            .expect("recovery must replay the same proposal from the workspace root");
+
+        assert_eq!(replay, first);
+        assert_eq!(ws.load_artifacts().unwrap(), vec![first]);
+
+        let mut mutated = proposal.clone();
+        mutated.digest = "fnv1a64:fedcba9876543210".into();
+        let error = ws
+            .publish_artifact(
+                "ses_channel",
+                "intent_channel",
+                &mutated,
+                "/workspace/src/guard.rs",
+            )
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("artifact_proposal_conflict"),
+            "{error:#}"
+        );
+        let mut mutated = proposal;
+        mutated.path = "src/guard-mutated.rs".into();
+        let error = ws
+            .publish_artifact(
+                "ses_channel",
+                "intent_channel",
+                &mutated,
+                "/workspace/src/guard-mutated.rs",
+            )
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("artifact_proposal_conflict"),
+            "{error:#}"
+        );
+        assert_eq!(ws.load_artifacts().unwrap().len(), 1);
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- report disabled worker profiles as explicitly non-invocable
- make artifact proposal replay idempotent across physical source locations while preserving mutation conflicts
- keep Git-finish recovery from regressing historical Done tasks, while repairing only the latest verified stale projection
- preserve verified Git-finish records and Done state when projection repair encounters unrelated sensitive-name workspace files
- refactor recovery finish mode to remain clippy-clean without lint suppression

## Why

Dogfooding exposed several recovery edges: a disabled worker appeared ready, artifact replay conflicted after a branch mismatch, historical Done tasks could be reprocessed, and projection repair could either miss a crash window or lower already-verified state. These changes make those paths explicit, idempotent, and fail-closed.

## Validation

- independent Yardlet/Fable reviews: YARD-015 and YARD-019 passed all structured criteria
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test` (429 unit tests plus all integration/process suites)
- `git diff --check origin/main...HEAD`
- Yardlet Git finish pushed and independently verified exact remote HEAD `3b9e202496916ebbfb3a70893b9db107784669b4`