### PR TITLE
fix: require actionable NeedsUser questions

### DIFF
--- a/src/eval_fixtures.rs
+++ b/src/eval_fixtures.rs
@@ -539,6 +539,11 @@ fn goal_feedback_is_bounded() -> Result<Vec<String>> {
     .context("second feedback cycle")?;
     if crate::run::feedback_next_state(&first) != TaskState::Partial
         || crate::run::feedback_next_state(&second) != TaskState::NeedsUser
+        || second
+            .question_for_user
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(|question| question.is_empty())
         || !second
             .unmet_acceptance
             .iter()
@@ -547,7 +552,8 @@ fn goal_feedback_is_bounded() -> Result<Vec<String>> {
         bail!("goal feedback did not retry once then stop with exact evidence")
     }
     Ok(vec![
-        "cycle 1 retries; cycle 2 reaches needs_user with AC evidence".to_string(),
+        "cycle 1 retries; cycle 2 reaches needs_user with AC evidence and an actionable question"
+            .to_string(),
     ])
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -600,7 +600,18 @@ fn decide_state(reported: &str, all_passed: bool, result: Option<&RunResult>) ->
         "done" => TaskState::Failed, // claimed done but evidence is incomplete
         "partial" => TaskState::Partial,
         "blocked" => TaskState::Blocked,
-        "needs_user" => TaskState::NeedsUser,
+        "needs_user"
+            if result
+                .and_then(|result| result.question_for_user.as_deref())
+                .map(str::trim)
+                .is_some_and(|question| !question.is_empty()) =>
+        {
+            TaskState::NeedsUser
+        }
+        // NeedsUser is an actionable hand-off contract, not just a status
+        // label. A blank question is evaluated as a failed worker result so the
+        // run layer can retry it or create a concrete feedback question.
+        "needs_user" => TaskState::Failed,
         "failed" => TaskState::Failed,
         _ => {
             if result.is_none() {
@@ -829,10 +840,28 @@ mod tests {
     }
 
     #[test]
+    fn needs_user_requires_an_actionable_question() {
+        let mut r = dummy_result();
+        r.status = "needs_user".into();
+        r.question_for_user = Some(" \n\t ".into());
+
+        assert_eq!(
+            decide_state("needs_user", true, Some(&r)),
+            TaskState::Failed,
+            "an empty question must not be exposed as NeedsUser"
+        );
+        assert_eq!(
+            decide_state("needs_user", true, None),
+            TaskState::Failed,
+            "NeedsUser without a parsed result cannot carry a question"
+        );
+    }
+
+    #[test]
     fn non_done_states_map_safely() {
         assert_eq!(decide_state("partial", true, None), TaskState::Partial);
         assert_eq!(decide_state("blocked", true, None), TaskState::Blocked);
-        assert_eq!(decide_state("needs_user", true, None), TaskState::NeedsUser);
+        assert_eq!(decide_state("needs_user", true, None), TaskState::Failed);
         assert_eq!(decide_state("failed", true, None), TaskState::Failed);
     }
 
@@ -1182,6 +1211,9 @@ exit 89
         r.task_id = "YARD-9".into();
         r.status = status.into();
         r.verdict = verdict;
+        if status == "needs_user" {
+            r.question_for_user = Some("Which review decision should be made?".into());
+        }
         std::fs::write(dir.join("result.json"), serde_json::to_string(&r).unwrap()).unwrap();
         let mut t = crate::schemas::Task {
             id: "YARD-9".into(),
@@ -1305,6 +1337,54 @@ exit 89
         // a build task needs no verdict
         let e = eval_with("implementation", "done", vec![]);
         assert_eq!(e.next_task_state, TaskState::Done);
+    }
+
+    #[test]
+    fn review_ignores_unknown_nested_domain_statuses() {
+        let dir = temp_path("nested-domain-status");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("handoff.md"), "h").unwrap();
+        std::fs::write(
+            dir.join("result.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "run_id": "run-nested-domain",
+                "task_id": "YARD-REVIEW",
+                "status": "done",
+                "validation": {
+                    "commands_run": ["cargo test"],
+                    "passed": true,
+                    "failures": []
+                },
+                "verdict": [{
+                    "criterion_id": "AC-001",
+                    "pass": true,
+                    "evidence": "foundation passes while runtime conformity remains unresolved"
+                }],
+                "domain_artifact": {
+                    "runtime_conformity": {"status": "not_pass"},
+                    "free_text": "status fail blocked not_pass",
+                    "nested": [{"status": "blocked", "fail": "not_pass"}]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let mut review = implementation_task("YARD-REVIEW");
+        review.kind = "review".into();
+
+        let evaluation = evaluate(&dir, "run-nested-domain", &review, Some(&[]));
+
+        assert_eq!(evaluation.next_task_state, TaskState::Done);
+        assert!(evaluation
+            .checks
+            .iter()
+            .any(|check| check.name == "review_criteria_pass" && check.passed));
+        assert!(!evaluation
+            .checks
+            .iter()
+            .any(|check| check.fatal && !check.passed));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // Regression: a done result with no validation commands must stay Done.

--- a/src/run.rs
+++ b/src/run.rs
@@ -1038,7 +1038,14 @@ pub(crate) fn finish_worker_attempt(
                     .map(str::trim)
                     .filter(|question| !question.is_empty())
                 {
-                    if let Some(asked) = record_result_question(ws, context, run_dir, question)? {
+                    if let Some(asked) = record_result_question(
+                        ws,
+                        lock,
+                        context,
+                        run_dir,
+                        question,
+                        EventActorKind::Worker,
+                    )? {
                         causation_id = Some(asked.event_id);
                     }
                 }
@@ -1116,9 +1123,11 @@ pub(crate) fn finish_worker_attempt_error(
 
 fn record_result_question(
     ws: &Workspace,
+    lock: Option<&PlanningLock>,
     context: &ChannelRunContext,
     run_dir: &std::path::Path,
     question_text: &str,
+    actor_kind: EventActorKind,
 ) -> Result<Option<ChannelEvent>> {
     let attempt_id = std::fs::read_to_string(run_dir.join("latest-attempt"))
         .with_context(|| format!("reading latest attempt for {}", context.task_id))?;
@@ -1152,17 +1161,21 @@ fn record_result_question(
     } else {
         record_channel_event(
             ws,
-            None,
+            lock,
             context,
             ChannelEventType::QuestionAsked,
             EventActor {
-                kind: EventActorKind::Worker,
-                id: channel
-                    .attempts
-                    .iter()
-                    .find(|attempt| attempt.attempt_id == attempt_id)
-                    .map(|attempt| attempt.worker_id.clone())
-                    .unwrap_or_else(|| "unknown".to_string()),
+                kind: actor_kind,
+                id: if actor_kind == EventActorKind::Worker {
+                    channel
+                        .attempts
+                        .iter()
+                        .find(|attempt| attempt.attempt_id == attempt_id)
+                        .map(|attempt| attempt.worker_id.clone())
+                        .unwrap_or_else(|| "unknown".to_string())
+                } else {
+                    String::new()
+                },
             },
             Some(attempt_id),
             channel.events.last().map(|event| event.event_id.clone()),
@@ -1186,6 +1199,41 @@ fn record_result_question(
     })?;
     ws.load_or_rebuild_task_channel(&context.intent_id, &context.task_id)?;
     Ok(Some(asked))
+}
+
+fn persist_needs_user_question(
+    ws: &Workspace,
+    lock: Option<&PlanningLock>,
+    context: &ChannelRunContext,
+    run_dir: &std::path::Path,
+    question_text: &str,
+    actor_kind: EventActorKind,
+) -> Result<()> {
+    let has_attempt = std::fs::read_to_string(run_dir.join("latest-attempt"))
+        .ok()
+        .is_some_and(|attempt| !attempt.trim().is_empty());
+    if has_attempt {
+        record_result_question(ws, lock, context, run_dir, question_text, actor_kind)?;
+    } else {
+        // Runs created before durable task channels have no attempt identity to
+        // link a typed Question to. Preserve the same non-empty invariant via
+        // the canonical legacy conversation path used by latest_question_for.
+        let run_id = run_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        state::append_conversation_turn(
+            ws,
+            &context.task_id,
+            ConversationTurn {
+                role: TurnRole::Worker,
+                text: question_text.to_string(),
+                run_id: run_id.to_string(),
+                ts: Local::now().to_rfc3339(),
+            },
+        )?;
+    }
+    Ok(())
 }
 
 pub(crate) fn action_attempt_id(action_id: &str) -> String {
@@ -4424,6 +4472,8 @@ pub(crate) struct FeedbackRecord {
     pub failures: Vec<String>,
     pub unmet_acceptance: Vec<String>,
     pub terminal_reason: String,
+    #[serde(default)]
+    pub question_for_user: Option<String>,
 }
 
 fn prior_feedback_cycles(
@@ -4600,7 +4650,7 @@ pub(crate) fn feedback_for_run(
     } else {
         String::new()
     };
-    Some(FeedbackRecord {
+    let mut feedback = FeedbackRecord {
         schema_version: 1,
         run_id: run_id.to_string(),
         task_id: task.id.clone(),
@@ -4611,15 +4661,53 @@ pub(crate) fn feedback_for_run(
         failures,
         unmet_acceptance,
         terminal_reason,
-    })
+        question_for_user: None,
+    };
+    if !feedback.retryable || feedback.cycle > feedback.max_cycles {
+        feedback.question_for_user = Some(feedback_question(task, &feedback));
+    }
+    Some(feedback)
 }
 
 pub(crate) fn feedback_next_state(feedback: &FeedbackRecord) -> TaskState {
     if feedback.retryable && feedback.cycle <= feedback.max_cycles {
         TaskState::Partial
-    } else {
+    } else if feedback
+        .question_for_user
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|question| !question.is_empty())
+    {
         TaskState::NeedsUser
+    } else {
+        TaskState::Failed
     }
+}
+
+fn feedback_question(task: &crate::schemas::Task, feedback: &FeedbackRecord) -> String {
+    let detail = feedback
+        .unmet_acceptance
+        .first()
+        .or_else(|| feedback.failures.first())
+        .map(|detail| detail.trim().chars().take(240).collect::<String>())
+        .filter(|detail| !detail.is_empty());
+    match detail {
+        Some(detail) => format!(
+            "`{}` 작업을 자동으로 완료하지 못했습니다. 확인이 필요한 근거는 `{detail}`입니다. 어떤 방식으로 진행할까요?",
+            task.id
+        ),
+        None => format!(
+            "`{}` 작업을 자동으로 완료하지 못했습니다. 어떤 방식으로 진행할까요?",
+            task.id
+        ),
+    }
+}
+
+fn review_without_remediation_question(task: &crate::schemas::Task) -> String {
+    format!(
+        "`{}` 리뷰가 통과하지 못했고 실행 가능한 수정 작업이 없습니다. 어떤 수정 또는 판정으로 이어갈까요?",
+        task.id
+    )
 }
 
 fn artifact_content_digest(bytes: &[u8]) -> String {
@@ -4945,6 +5033,13 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     let result: Option<RunResult> = std::fs::read_to_string(run_dir.join("result.json"))
         .ok()
         .and_then(|t| serde_json::from_str(&t).ok());
+    let mut question_to_persist = result
+        .as_ref()
+        .filter(|result| result.status == "needs_user")
+        .and_then(|result| result.question_for_user.as_deref())
+        .map(str::trim)
+        .filter(|question| !question.is_empty())
+        .map(|question| (question.to_string(), EventActorKind::Worker));
 
     let feedback = feedback_for_run(
         ws,
@@ -4967,9 +5062,16 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                 "feedback cycle {}/{}: failed checks will be injected into the next attempt",
                 f.cycle, f.max_cycles
             ));
-        } else {
-            next_state = TaskState::NeedsUser;
+        } else if next_state == TaskState::NeedsUser {
+            if question_to_persist.is_none() {
+                question_to_persist = f
+                    .question_for_user
+                    .as_ref()
+                    .map(|question| (question.clone(), EventActorKind::System));
+            }
             lines.push(format!("feedback stopped: {}", f.terminal_reason));
+        } else {
+            lines.push("feedback stopped without an actionable question".to_string());
         }
     }
     if flags.repairs_done_projection && next_state != TaskState::Done {
@@ -4980,43 +5082,19 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         next_state = TaskState::Done;
     }
 
-    if let Some(question) = result
-        .as_ref()
-        .filter(|result| result.status == "needs_user")
-        .and_then(|result| result.question_for_user.as_deref())
-        .map(str::trim)
-        .filter(|question| !question.is_empty())
-    {
+    let mut persisted_question = if next_state == TaskState::NeedsUser {
+        let (question, actor_kind) = question_to_persist.get_or_insert_with(|| {
+            (
+                format!("`{}` 작업을 계속하려면 어떤 결정을 내려야 할까요?", task.id),
+                EventActorKind::System,
+            )
+        });
         let channel_context = channel_run_context(ws, &intent_id, &task.id);
-        record_result_question(ws, &channel_context, run_dir, question)?;
-    }
-
-    // Record the worker's user-facing message into the conversation transcript
-    // whenever a run pauses for the user, so the next resume threads the full
-    // exchange back (deduped by run_id).
-    if flags.conversation {
-        if let Some(q) = result
-            .as_ref()
-            .filter(|r| r.status == "needs_user")
-            .and_then(|r| {
-                r.question_for_user
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|q| !q.is_empty())
-            })
-        {
-            let _ = state::append_conversation_turn(
-                ws,
-                &task.id,
-                ConversationTurn {
-                    role: TurnRole::Worker,
-                    text: q.to_string(),
-                    run_id: run_id.to_string(),
-                    ts: Local::now().to_rfc3339(),
-                },
-            );
-        }
-    }
+        persist_needs_user_question(ws, None, &channel_context, run_dir, question, *actor_kind)?;
+        Some(question.clone())
+    } else {
+        None
+    };
 
     if flags.artifacts {
         compact::write_checkpoint(run_dir, task, &eval, result.as_ref(), intent_summary)?;
@@ -5406,6 +5484,19 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         // the user instead.
         let remediation = schedulable_remediation_ids(queue, &ingested);
         if remediation.is_empty() {
+            if persisted_question.is_none() {
+                let question = review_without_remediation_question(task);
+                let channel_context = channel_run_context(ws, &intent_id, &task.id);
+                persist_needs_user_question(
+                    ws,
+                    Some(&queue_lock),
+                    &channel_context,
+                    run_dir,
+                    &question,
+                    EventActorKind::System,
+                )?;
+                persisted_question = Some(question);
+            }
             requeue_review_locked(ws, &queue_lock, queue, &task.id, TaskState::NeedsUser, &[])?;
             next_state = TaskState::NeedsUser;
             lines.push(format!(
@@ -5431,6 +5522,23 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     }
 
     drop(queue_lock);
+
+    // Mirror the canonical question into the legacy conversation transcript so
+    // both continuation paths receive the same actionable prompt.
+    if flags.conversation {
+        if let Some(question) = persisted_question.as_deref() {
+            let _ = state::append_conversation_turn(
+                ws,
+                &task.id,
+                ConversationTurn {
+                    role: TurnRole::Worker,
+                    text: question.to_string(),
+                    run_id: run_id.to_string(),
+                    ts: Local::now().to_rfc3339(),
+                },
+            );
+        }
+    }
 
     if let Some(attempt_id) = std::fs::read_to_string(run_dir.join("latest-attempt"))
         .ok()
@@ -7405,6 +7513,14 @@ mod tests {
         assert_eq!(second.cycle, 2);
         assert_eq!(feedback_next_state(&second), TaskState::NeedsUser);
         assert!(second.terminal_reason.contains("cap exceeded"));
+        assert!(second
+            .question_for_user
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|question| question.ends_with('?')));
+        let mut invalid = second.clone();
+        invalid.question_for_user = Some("   ".into());
+        assert_eq!(feedback_next_state(&invalid), TaskState::Failed);
         let _ = std::fs::remove_dir_all(ws.root);
     }
 

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -46,6 +46,26 @@ case "$task_id" in
     printf 'ask worker diagnostic stream\n' >&2
     write_question "A 또는 B를 선택해 주세요."
     ;;
+  YARD-EMPTY-QUESTION)
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "needs_user",\n  "question_for_user": "   ",\n  "compact_summary": "empty question regression"\n}\n' \
+      "$run_id" "$task_id" >"$run_dir/result.json"
+    write_handoff "빈 질문 회귀 fixture"
+    ;;
+  YARD-FEEDBACK-EXHAUSTED)
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": false, "failures": ["fixture failed"]},\n  "compact_summary": "feedback exhausted regression"\n}\n' \
+      "$run_id" "$task_id" >"$run_dir/result.json"
+    write_handoff "feedback 소진 회귀 fixture"
+    ;;
+  YARD-REVIEW-FAIL)
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": false, "evidence": "fixture criterion failed"}],\n  "compact_summary": "review failure regression"\n}\n' \
+      "$run_id" "$task_id" >"$run_dir/result.json"
+    write_handoff "review 실패 회귀 fixture"
+    ;;
+  YARD-REVIEW-PASS)
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": true, "evidence": "foundation passes while runtime remains unresolved"}],\n  "domain_artifact": {"runtime_conformity": {"status": "not_pass"}, "free_text": "status fail blocked not_pass"},\n  "compact_summary": "structured review contract regression"\n}\n' \
+      "$run_id" "$task_id" >"$run_dir/result.json"
+    write_handoff "구조화 review 계약 회귀 fixture"
+    ;;
   YARD-DRAIN)
     sleep 1
     printf 'drain worker public progress\n'

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -209,6 +209,28 @@ mod unix {
             .unwrap_or_else(|| panic!("task {task_id} not found"))
     }
 
+    fn assert_actionable_needs_user(fixture: &FixtureWorkspace, task_id: &str) {
+        assert_eq!(task_state(&fixture.root, task_id), "needs_user");
+        let channel = channel_dir(&fixture.root, task_id);
+        let questions = yaml_dir(&channel.join("questions"));
+        assert_eq!(questions.len(), 1, "{task_id} must persist one question");
+        let question = string(&questions[0], "text").trim();
+        assert!(
+            !question.is_empty(),
+            "{task_id} persisted an empty question"
+        );
+        assert!(
+            question.ends_with('?') || question.ends_with('？'),
+            "{task_id} question is not actionable: {question:?}"
+        );
+        assert_eq!(string(&questions[0], "state"), "open");
+        let shown = fixture.run(&["answer", "--task", task_id]);
+        assert!(
+            String::from_utf8_lossy(&shown.stdout).contains(question),
+            "{task_id} question was stored but not retrievable"
+        );
+    }
+
     fn action_attempt_id(action_id: &str) -> String {
         let mut hash = 0xcbf29ce484222325_u64;
         for byte in action_id.as_bytes() {
@@ -1306,6 +1328,68 @@ mod unix {
             "stored redirect attempt did not execute exactly once"
         );
         assert_eq!(task_state(&fixture.root, "YARD-REDIRECT"), "done");
+    }
+
+    #[test]
+    fn issue_23_empty_worker_question_is_replaced_before_needs_user() {
+        let fixture = FixtureWorkspace::new("issue-23-empty-worker-question");
+        fixture.write_queue(
+            "  - id: YARD-EMPTY-QUESTION\n    title: empty worker question\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-EMPTY-QUESTION", "--execute"]);
+
+        assert_actionable_needs_user(&fixture, "YARD-EMPTY-QUESTION");
+    }
+
+    #[test]
+    fn issue_23_feedback_exhaustion_persists_an_actionable_question() {
+        let fixture = FixtureWorkspace::new("issue-23-feedback-question");
+        fixture.write_queue(
+            "  - id: YARD-FEEDBACK-EXHAUSTED\n    title: exhausted feedback\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [validation passes]\n    goal:\n      condition: validation passes\n      max_feedback_cycles: 0\n      feedback_policy: inject_failed_checks\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-FEEDBACK-EXHAUSTED", "--execute"]);
+
+        assert_actionable_needs_user(&fixture, "YARD-FEEDBACK-EXHAUSTED");
+    }
+
+    #[test]
+    fn issue_23_review_retransition_persists_an_actionable_question() {
+        let fixture = FixtureWorkspace::new("issue-23-review-question");
+        fixture.write_queue(
+            "  - id: YARD-REVIEW-FAIL\n    title: failed review without remediation\n    state: queued\n    priority: 10\n    kind: review\n    preferred_worker: fixture\n    acceptance: [criterion passes]\n    goal:\n      condition: criterion passes\n      max_feedback_cycles: 1\n      feedback_policy: inject_failed_checks\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-REVIEW-FAIL", "--execute"]);
+
+        assert_actionable_needs_user(&fixture, "YARD-REVIEW-FAIL");
+    }
+
+    #[test]
+    fn issue_23_nested_domain_status_does_not_fail_a_passing_review() {
+        let fixture = FixtureWorkspace::new("issue-23-nested-domain-status");
+        fixture.write_queue(
+            "  - id: YARD-REVIEW-PASS\n    title: passing review with unresolved domain state\n    state: queued\n    priority: 10\n    kind: review\n    preferred_worker: fixture\n    acceptance: [foundation passes]\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-REVIEW-PASS", "--execute"]);
+
+        assert_eq!(task_state(&fixture.root, "YARD-REVIEW-PASS"), "done");
+        let evaluation_paths = files_below(&fixture.root.join(".agents/runs"), "/evaluation.json");
+        let evaluation = evaluation_paths
+            .iter()
+            .map(|path| {
+                serde_json::from_str::<serde_json::Value>(&fs::read_to_string(path).unwrap())
+                    .unwrap()
+            })
+            .find(|value| value["task_id"] == "YARD-REVIEW-PASS")
+            .expect("review evaluation");
+        assert!(evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| { check["name"] == "review_criteria_pass" && check["passed"] == true }));
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- keep review failure decisions scoped to structured `verdict[].pass` and `validation.passed`
- reject blank worker questions as an actionable `NeedsUser` handoff
- persist concrete questions when feedback is exhausted or a failed review has no runnable remediation
- preserve legacy recovery compatibility while retaining exact attempt linkage for current runs
- add RED/GREEN unit, process, and mechanism regression coverage

## Why

A passing structured review could be surfaced as failed or moved to `NeedsUser` without any actionable question. That left operators with an empty gate even though no acceptance criterion had failed.

## Verification

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` — 514 tests passed
- independent Claude Code `fable` review — AC-001 through AC-005 passed
- independent pre-fix RED replay — 3 question-invariant tests failed before the fix and passed 4/4 after restoration

Closes #23