### PR TITLE
fix: preserve exact worker model provenance

### DIFF
--- a/src/eval_fixtures.rs
+++ b/src/eval_fixtures.rs
@@ -243,6 +243,7 @@ fn task(id: &str, state: TaskState, kind: &str) -> Task {
         kind: kind.to_string(),
         preferred_worker: String::new(),
         model: String::new(),
+        fallback_enabled: None,
         effort: String::new(),
         depends_on: Vec::new(),
         skills: Vec::new(),
@@ -255,6 +256,7 @@ fn task(id: &str, state: TaskState, kind: &str) -> Task {
         interaction: None,
         worker_rationale: None,
         provenance: String::new(),
+        routing_provenance: None,
     }
 }
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -665,6 +665,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -677,6 +678,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         }
     }
 
@@ -736,6 +738,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -748,6 +751,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
 
         let e = evaluate(&dir, "run-x", &t, Some(&[]));
@@ -1169,6 +1173,7 @@ exit 89
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1181,6 +1186,7 @@ exit 89
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         // The worker wrote the canonical queue directly: a fatal violation even
         // though it claimed done — propose -> ingest is the only allowed path.
@@ -1224,6 +1230,7 @@ exit 89
             kind: kind.into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1236,6 +1243,7 @@ exit 89
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         t.kind = kind.into();
         // Some(&[]) = git evidence available, nothing forbidden changed (these
@@ -1267,6 +1275,7 @@ exit 89
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1279,6 +1288,7 @@ exit 89
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         // The real on-disk diff shows it actually wrote .env.
         let actual = vec!["src/main.rs".to_string(), ".env".to_string()];
@@ -1431,6 +1441,7 @@ exit 89
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1443,6 +1454,7 @@ exit 89
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         t.kind = "implementation".into();
         // None = no git evidence: the forbidden gate fails closed, so a worker's
@@ -1493,6 +1505,7 @@ exit 89
             kind: String::new(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1505,6 +1518,7 @@ exit 89
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
 
         let eval = evaluate(&dir, "run-x", &t, Some(&[]));

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1729,6 +1729,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec!["deploy-check".into()],
@@ -1741,6 +1742,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         let repo = crate::inspect::RepoSummary::default();
         let harness = Harness {
@@ -1916,6 +1918,7 @@ mod tests {
             kind: kind.into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1928,6 +1931,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         let repo = crate::inspect::RepoSummary::default();
         compile(&PacketInputs {
@@ -1957,6 +1961,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1969,6 +1974,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         task.approval = Some(crate::yaml::from_str("required: true").unwrap());
         let repo = crate::inspect::RepoSummary::default();
@@ -2014,6 +2020,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec!["YARD-1".into()],
             skills: vec![],
@@ -2026,6 +2033,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         let repo = crate::inspect::RepoSummary::default();
         let p = compile(&PacketInputs {
@@ -2059,6 +2067,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -2075,6 +2084,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         let repo = crate::inspect::RepoSummary::default();
         let p = compile(&PacketInputs {
@@ -2111,6 +2121,7 @@ mod tests {
             kind: "review".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -2123,6 +2134,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         };
         let repo = crate::inspect::RepoSummary::default();
         let turns = vec![

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -207,6 +207,7 @@ struct Prep {
     reason: String,
     bin: PathBuf,
     profile: WorkerProfile,
+    selection: crate::schemas::ResolvedWorkerSelection,
     run_id: String,
     run_dir: PathBuf,
     wt_path: PathBuf,
@@ -269,7 +270,7 @@ pub fn run_batch<F: FnMut(&str)>(
     // ---- prepare every task up front (deterministic, no workers yet) -----
     let mut preps: Vec<Prep> = Vec::new();
     for &idx in indices {
-        let task = queue.tasks[idx].clone();
+        let mut task = queue.tasks[idx].clone();
         let resolved =
             match routing::resolve_worker_for_task(ws, &workers_file, &billing, None, &task) {
                 Ok(r) => r,
@@ -296,6 +297,11 @@ pub fn run_batch<F: FnMut(&str)>(
         let (run_id, run_dir) = ws.claim_run_dir(&base_run_id)?;
         let session = (resolved.worker_id == "claude-code").then(|| run::gen_session_uuid(&run_id));
         let branch = format!("yard/{}/{}", task.id.to_lowercase(), run_id);
+        let selection = resolved.selection();
+        if !selection.model.trim().is_empty() {
+            run::apply_selection_to_task(&mut task, &selection);
+            queue.tasks[idx] = task.clone();
+        }
         preps.push(Prep {
             branch,
             wt_path: ws.agents_dir().join("worktrees").join(&run_id),
@@ -305,6 +311,7 @@ pub fn run_batch<F: FnMut(&str)>(
             reason: resolved.reason,
             bin: resolved.bin,
             profile: eff_profile,
+            selection,
             run_id,
             run_dir,
             packet_text: String::new(), // compiled below, after the worktree exists
@@ -313,6 +320,28 @@ pub fn run_batch<F: FnMut(&str)>(
     }
     if preps.is_empty() {
         return Err(anyhow!("no runnable task in the batch"));
+    }
+    {
+        let lock = ws.acquire_planning_lock()?;
+        let mut latest = ws.load_queue()?;
+        for prep in &preps {
+            let task = latest
+                .tasks
+                .iter_mut()
+                .find(|task| task.id == prep.task.id)
+                .ok_or_else(|| {
+                    anyhow!("queue_transaction_conflict: task {} vanished", prep.task.id)
+                })?;
+            if task.state != TaskState::Queued {
+                return Err(anyhow!(
+                    "queue_transaction_conflict: task {} is no longer queued",
+                    prep.task.id
+                ));
+            }
+            run::apply_selection_to_task(task, &prep.selection);
+        }
+        ws.save_queue_locked(&lock, &latest)?;
+        queue = latest;
     }
 
     // ---- worktrees + run dirs + packets ----------------------------------
@@ -366,7 +395,7 @@ pub fn run_batch<F: FnMut(&str)>(
             approved: false,
         });
         write_str(&workers::packet_path(&p.run_dir), &p.packet_text)?;
-        state::save_yaml(
+        state::save_yaml_atomic(
             &p.run_dir.join("run.yaml"),
             &run::RunRecord {
                 schema_version: 1,
@@ -374,6 +403,9 @@ pub fn run_batch<F: FnMut(&str)>(
                 task_id: p.task.id.clone(),
                 intent_id: queue.intent_id.clone(),
                 worker: p.worker_id.clone(),
+                model: p.selection.model.clone(),
+                fallback_enabled: p.selection.fallback_enabled,
+                routing_provenance: Some(p.selection.routing_provenance.clone()),
                 state: "running".to_string(),
                 started_at: Local::now().to_rfc3339(),
                 completed_at: None,
@@ -458,13 +490,15 @@ pub fn run_batch<F: FnMut(&str)>(
         let cwd = p.wt_path.clone();
         let worker_run_dir = p.run_dir.clone();
         let capture = attempt_runtime[i].2.clone();
+        let selection = p.selection.clone();
         let timeout = Duration::from_secs(p.profile.limits.max_wall_minutes as u64 * 60);
         let images = images.clone();
         let session = p.session.clone();
         handles.push(std::thread::spawn(move || {
             let started = std::time::Instant::now();
-            let outcome = workers::spawn_attempt(
+            let outcome = workers::spawn_resolved_attempt(
                 &profile,
+                &selection,
                 &bin,
                 &packet_text,
                 &worker_run_dir,
@@ -549,7 +583,9 @@ pub fn run_batch<F: FnMut(&str)>(
                     record_failover(&p.run_dir, &from, &to, &note);
 
                     worker_id = to;
+                    let selection = alt.selection();
                     reason = format!("failover from {from} ({})", alt.reason);
+                    run::update_run_selection(&p.run_dir, &selection)?;
                     let failover_started = std::time::Instant::now();
                     outcome = (|| -> Result<workers::WorkerOutcome> {
                         let profile = run::find_worker(&workers_file.workers, &worker_id)?;
@@ -601,8 +637,9 @@ pub fn run_batch<F: FnMut(&str)>(
                             crate::schemas::ContinuationMode::Fallback,
                             None,
                         )?;
-                        let completed = match workers::spawn_attempt(
+                        let completed = match workers::spawn_resolved_attempt(
                             &eff_profile,
+                            &selection,
                             &alt.bin,
                             &failover_packet,
                             &p.run_dir,
@@ -1789,6 +1826,7 @@ mod tests {
             kind: String::new(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: deps,
             skills: vec![],
@@ -1801,6 +1839,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         }
     }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -71,6 +71,8 @@ struct PlanTask {
     #[serde(default)]
     model: String,
     #[serde(default)]
+    fallback_enabled: Option<bool>,
+    #[serde(default)]
     effort: String,
     #[serde(default)]
     depends_on: Vec<String>,
@@ -233,6 +235,7 @@ pub fn plan_goal(
         kind: "implementation".to_string(),
         preferred_worker: worker.clone(),
         model: String::new(),
+        fallback_enabled: None,
         effort: String::new(),
         depends_on: vec![],
         skills: vec![],
@@ -249,6 +252,7 @@ pub fn plan_goal(
         interaction: None,
         worker_rationale: Some("express goal (yardlet goal)".to_string()),
         provenance: String::new(),
+        routing_provenance: None,
     }];
     // Express goals bypass the planner, so capability routing is explicit (no
     // magic keywords): pass `--requires <capability>` for a hard route, or
@@ -267,6 +271,7 @@ pub fn plan_goal(
             kind: "review".to_string(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec!["YARD-001".to_string()],
             skills: vec![],
@@ -285,6 +290,7 @@ pub fn plan_goal(
             interaction: None,
             worker_rationale: Some("verifier is never the doer".to_string()),
             provenance: String::new(),
+            routing_provenance: None,
         });
     }
 
@@ -905,6 +911,7 @@ fn append_plan_tasks(queue: &mut WorkQueue, plan: &PlanningResult) -> usize {
             // (precedence: planner preferred -> learned rule -> default).
             preferred_worker: pt.preferred_worker.clone(),
             model: pt.model.clone(),
+            fallback_enabled: pt.fallback_enabled,
             effort: pt.effort.clone(),
             depends_on: sanitize_deps(&pt.depends_on, &prior_ids),
             skills: pt.skills.clone(),
@@ -927,6 +934,7 @@ fn append_plan_tasks(queue: &mut WorkQueue, plan: &PlanningResult) -> usize {
             interaction: None,
             worker_rationale: pt.worker_rationale.clone(),
             provenance: String::new(),
+            routing_provenance: None,
         };
         queue.tasks.push(task);
     }
@@ -1029,6 +1037,36 @@ pub(crate) fn ingest_follow_ups(
     follow_ups: &[crate::schemas::FollowUpTask],
     ws: Option<&crate::state::Workspace>,
 ) -> Vec<String> {
+    ingest_follow_ups_inner(queue, _intent_allowed_scope, follow_ups, ws, None)
+        .expect("legacy follow-up ingestion has no governing selection conflicts")
+}
+
+pub(crate) fn ingest_follow_ups_with_governing(
+    queue: &mut WorkQueue,
+    intent_allowed_scope: &[String],
+    follow_ups: &[crate::schemas::FollowUpTask],
+    ws: Option<&crate::state::Workspace>,
+    governing: &crate::schemas::ResolvedWorkerSelection,
+) -> Result<Vec<String>> {
+    let mut staged = queue.clone();
+    let ingested = ingest_follow_ups_inner(
+        &mut staged,
+        intent_allowed_scope,
+        follow_ups,
+        ws,
+        Some(governing),
+    )?;
+    *queue = staged;
+    Ok(ingested)
+}
+
+fn ingest_follow_ups_inner(
+    queue: &mut WorkQueue,
+    _intent_allowed_scope: &[String],
+    follow_ups: &[crate::schemas::FollowUpTask],
+    ws: Option<&crate::state::Workspace>,
+    governing: Option<&crate::schemas::ResolvedWorkerSelection>,
+) -> Result<Vec<String>> {
     let mut next_num = queue
         .tasks
         .iter()
@@ -1090,6 +1128,79 @@ pub(crate) fn ingest_follow_ups(
         // clean resolver). Reserve capabilities for a worker's tool/license need.
         let decision = fu.decision_question.trim();
         let is_decision = !decision.is_empty();
+        let (preferred_worker, model, fallback_enabled, routing_provenance) = if let Some(
+            governing,
+        ) = governing
+        {
+            let requested_worker = fu.preferred_worker.trim();
+            let requested_model = fu.model.trim();
+            let model_explicit =
+                !requested_model.is_empty() && !requested_model.eq_ignore_ascii_case("auto");
+            if governing.worker_id.trim().is_empty() || governing.model.trim().is_empty() {
+                bail!(
+                        "governing routing selection for '{}' is incomplete: worker/model must be non-empty",
+                        governing.routing_provenance.governing_task_id
+                    );
+            }
+            if !requested_worker.is_empty() && requested_worker != governing.worker_id {
+                bail!(
+                        "worker-proposed follow-up '{}' conflicts with governing worker '{}': requested '{}'",
+                        title,
+                        governing.worker_id,
+                        requested_worker
+                    );
+            }
+            if model_explicit && requested_model != governing.model {
+                bail!(
+                        "worker-proposed follow-up '{}' conflicts with governing model '{}': requested '{}'",
+                        title,
+                        governing.model,
+                        requested_model
+                    );
+            }
+            if let Some(requested) = fu.fallback_enabled {
+                if requested != governing.fallback_enabled {
+                    bail!(
+                            "worker-proposed follow-up '{}' conflicts with governing fallback_enabled={}: requested {}",
+                            title,
+                            governing.fallback_enabled,
+                            requested
+                        );
+                }
+            }
+            let mut provenance = governing.routing_provenance.clone();
+            provenance.worker_source = if requested_worker.is_empty() {
+                "governing_task.inherited".to_string()
+            } else {
+                "worker_proposed.explicit_same".to_string()
+            };
+            provenance.model_source = if model_explicit {
+                "worker_proposed.explicit_same".to_string()
+            } else {
+                "governing_task.inherited".to_string()
+            };
+            provenance.fallback_source = if fu.fallback_enabled.is_some() {
+                "worker_proposed.explicit_same".to_string()
+            } else {
+                "governing_task.inherited".to_string()
+            };
+            provenance.worker_overridden = !requested_worker.is_empty();
+            provenance.model_overridden = model_explicit;
+            provenance.fallback_overridden = fu.fallback_enabled.is_some();
+            (
+                governing.worker_id.clone(),
+                governing.model.clone(),
+                Some(governing.fallback_enabled),
+                Some(provenance),
+            )
+        } else {
+            (
+                fu.preferred_worker.clone(),
+                fu.model.clone(),
+                fu.fallback_enabled,
+                None,
+            )
+        };
         queue.tasks.push(Task {
             id: id.clone(),
             title: title.to_string(),
@@ -1101,8 +1212,9 @@ pub(crate) fn ingest_follow_ups(
             priority,
             risk: fu.risk.clone(),
             kind: fu.kind.clone(),
-            preferred_worker: fu.preferred_worker.clone(),
-            model: String::new(),
+            preferred_worker,
+            model,
+            fallback_enabled,
             effort: String::new(),
             depends_on: sanitize_deps(&fu.depends_on, &prior_ids),
             skills: fu.skills.clone(),
@@ -1134,6 +1246,7 @@ pub(crate) fn ingest_follow_ups(
             }),
             worker_rationale: rationale,
             provenance: "worker-proposed".to_string(),
+            routing_provenance,
         });
         // HARD placement: make each named existing task depend on this new one.
         inject_runs_before(queue, &id, &fu.runs_before);
@@ -1159,7 +1272,7 @@ pub(crate) fn ingest_follow_ups(
             }
         }
     }
-    ingested
+    Ok(ingested)
 }
 
 pub(crate) fn follow_up_scope_is_workspace_local(follow_up: &crate::schemas::FollowUpTask) -> bool {
@@ -1537,6 +1650,7 @@ fn build_queue(intent_id: &str, plan: &PlanningResult) -> WorkQueue {
             // Blank stays blank so routing's configured default_worker applies.
             preferred_worker: t.preferred_worker.clone(),
             model: t.model.clone(),
+            fallback_enabled: t.fallback_enabled,
             effort: t.effort.clone(),
             depends_on: sanitize_deps(&t.depends_on, &prior_ids),
             skills: t.skills.clone(),
@@ -1559,6 +1673,7 @@ fn build_queue(intent_id: &str, plan: &PlanningResult) -> WorkQueue {
             interaction: None,
             worker_rationale: t.worker_rationale.clone(),
             provenance: String::new(),
+            routing_provenance: None,
         };
         tasks.push(task);
     }
@@ -1608,6 +1723,7 @@ fn ensure_review_task(tasks: &mut Vec<Task>) {
         kind: "review".to_string(),
         preferred_worker: String::new(), // routing decides (kind overrides apply)
         model: String::new(),
+        fallback_enabled: None,
         effort: String::new(),
         depends_on,
         skills: vec![],
@@ -1630,6 +1746,7 @@ fn ensure_review_task(tasks: &mut Vec<Task>) {
             "deterministic semantic-verification rung: the verifier is never the doer".to_string(),
         ),
         provenance: String::new(),
+        routing_provenance: None,
     });
 }
 
@@ -1926,6 +2043,7 @@ invocation: { command: codex }
                 kind: String::new(),
                 preferred_worker: String::new(),
                 model: String::new(),
+                fallback_enabled: None,
                 effort: String::new(),
                 depends_on: vec![],
                 skills: vec![],
@@ -1938,6 +2056,7 @@ invocation: { command: codex }
                 interaction: None,
                 worker_rationale: None,
                 provenance: String::new(),
+                routing_provenance: None,
             }
         }
         let wf: WorkersFile = serde_yaml_ng::from_str(
@@ -2470,6 +2589,123 @@ routing:
             .contains("coverage gap"));
         // Total: original + one ingested (blank + dup were not added).
         assert_eq!(queue.tasks.len(), 2);
+    }
+
+    #[test]
+    fn governing_exact_model_follow_up_matrix_inherits_or_accepts_only_same_values() {
+        use crate::schemas::{FollowUpTask, ResolvedWorkerSelection, RoutingProvenance};
+        let plan: PlanningResult = serde_json::from_str(
+            r#"{ "summary": "s", "tasks": [{ "id": "YARD-001", "title": "governing", "risk": "low" }] }"#,
+        )
+        .unwrap();
+        let governing = ResolvedWorkerSelection {
+            worker_id: "codex".into(),
+            model: "gpt-5.6-sol".into(),
+            fallback_enabled: false,
+            routing_provenance: RoutingProvenance {
+                governing_task_id: "YARD-001".into(),
+                governing_worker_id: "codex".into(),
+                governing_model: "gpt-5.6-sol".into(),
+                governing_fallback_enabled: false,
+                ..Default::default()
+            },
+        };
+        let mut queue = build_queue("intent-exact", &plan);
+        let ids = ingest_follow_ups_with_governing(
+            &mut queue,
+            &[],
+            &[
+                FollowUpTask {
+                    title: "same both".into(),
+                    preferred_worker: "codex".into(),
+                    model: "gpt-5.6-sol".into(),
+                    fallback_enabled: Some(false),
+                    ..Default::default()
+                },
+                FollowUpTask {
+                    title: "inherit model".into(),
+                    fallback_enabled: Some(false),
+                    ..Default::default()
+                },
+                FollowUpTask {
+                    title: "inherit fallback".into(),
+                    model: "gpt-5.6-sol".into(),
+                    ..Default::default()
+                },
+                FollowUpTask {
+                    title: "inherit both".into(),
+                    ..Default::default()
+                },
+            ],
+            None,
+            &governing,
+        )
+        .unwrap();
+        assert_eq!(ids.len(), 4);
+        for task in queue.tasks.iter().skip(1) {
+            assert_eq!(task.preferred_worker, "codex");
+            assert_eq!(task.model, "gpt-5.6-sol");
+            assert_eq!(task.fallback_enabled, Some(false));
+            assert_eq!(
+                task.routing_provenance.as_ref().unwrap().governing_task_id,
+                "YARD-001"
+            );
+        }
+    }
+
+    #[test]
+    fn governing_exact_model_follow_up_matrix_rejects_conflicts_atomically() {
+        use crate::schemas::{FollowUpTask, ResolvedWorkerSelection, RoutingProvenance};
+        let plan: PlanningResult = serde_json::from_str(
+            r#"{ "summary": "s", "tasks": [{ "id": "YARD-001", "title": "governing", "risk": "low" }] }"#,
+        )
+        .unwrap();
+        let governing = ResolvedWorkerSelection {
+            worker_id: "codex".into(),
+            model: "gpt-5.6-sol".into(),
+            fallback_enabled: false,
+            routing_provenance: RoutingProvenance {
+                governing_task_id: "YARD-001".into(),
+                governing_worker_id: "codex".into(),
+                governing_model: "gpt-5.6-sol".into(),
+                governing_fallback_enabled: false,
+                ..Default::default()
+            },
+        };
+        for (label, follow_up) in [
+            (
+                "model",
+                FollowUpTask {
+                    title: "model conflict".into(),
+                    model: "other".into(),
+                    ..Default::default()
+                },
+            ),
+            (
+                "fallback_enabled",
+                FollowUpTask {
+                    title: "fallback conflict".into(),
+                    fallback_enabled: Some(true),
+                    ..Default::default()
+                },
+            ),
+            (
+                "model",
+                FollowUpTask {
+                    title: "both conflicts".into(),
+                    model: "other".into(),
+                    fallback_enabled: Some(true),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let mut queue = build_queue("intent-exact", &plan);
+            let error =
+                ingest_follow_ups_with_governing(&mut queue, &[], &[follow_up], None, &governing)
+                    .unwrap_err();
+            assert!(error.to_string().contains(label), "{error:#}");
+            assert_eq!(queue.tasks.len(), 1, "conflict must not partially ingest");
+        }
     }
 
     #[test]

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1142,6 +1142,10 @@ fn ingest_follow_ups_inner(
                         governing.routing_provenance.governing_task_id
                     );
             }
+            // Runtime fallback may select another ready worker for an attempt,
+            // but it never authorizes a worker-authored follow-up to rewrite
+            // the governing preferred worker stored in the queue. Dispatch
+            // enforces the same recorded-lineage invariant.
             if !requested_worker.is_empty() && requested_worker != governing.worker_id {
                 bail!(
                         "worker-proposed follow-up '{}' conflicts with governing worker '{}': requested '{}'",
@@ -2674,6 +2678,14 @@ routing:
         };
         for (label, follow_up) in [
             (
+                "governing worker",
+                FollowUpTask {
+                    title: "worker conflict".into(),
+                    preferred_worker: "claude-code".into(),
+                    ..Default::default()
+                },
+            ),
+            (
                 "model",
                 FollowUpTask {
                     title: "model conflict".into(),
@@ -2706,6 +2718,44 @@ routing:
             assert!(error.to_string().contains(label), "{error:#}");
             assert_eq!(queue.tasks.len(), 1, "conflict must not partially ingest");
         }
+    }
+
+    #[test]
+    fn governing_follow_up_rejects_worker_conflict_when_runtime_failover_is_enabled() {
+        use crate::schemas::{FollowUpTask, ResolvedWorkerSelection, RoutingProvenance};
+        let plan: PlanningResult = serde_json::from_str(
+            r#"{ "summary": "s", "tasks": [{ "id": "YARD-001", "title": "governing", "risk": "low" }] }"#,
+        )
+        .unwrap();
+        let governing = ResolvedWorkerSelection {
+            worker_id: "codex".into(),
+            model: "gpt-5.6-sol".into(),
+            fallback_enabled: true,
+            routing_provenance: RoutingProvenance {
+                governing_task_id: "YARD-001".into(),
+                governing_worker_id: "codex".into(),
+                governing_model: "gpt-5.6-sol".into(),
+                governing_fallback_enabled: true,
+                ..Default::default()
+            },
+        };
+        let mut queue = build_queue("intent-exact", &plan);
+        let error = ingest_follow_ups_with_governing(
+            &mut queue,
+            &[],
+            &[FollowUpTask {
+                title: "worker conflict with failover".into(),
+                preferred_worker: "claude-code".into(),
+                fallback_enabled: Some(true),
+                ..Default::default()
+            }],
+            None,
+            &governing,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("governing worker"), "{error:#}");
+        assert_eq!(queue.tasks.len(), 1, "conflict must not partially ingest");
     }
 
     #[test]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -17,7 +17,9 @@ use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::guard::{self, Readiness};
-use crate::schemas::{BillingPolicy, Task, WorkersFile};
+use crate::schemas::{
+    BillingPolicy, ResolvedWorkerSelection, RoutingProvenance, Task, WorkersFile,
+};
 use crate::state::Workspace;
 
 /// Machine-managed learned overrides (written by `yardlet routing apply`), kept in
@@ -39,11 +41,25 @@ pub fn load_overrides(ws: &Workspace) -> RoutingOverrides {
         .unwrap_or_default()
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Resolved {
     pub worker_id: String,
     pub bin: PathBuf,
     pub reason: String,
+    pub model: String,
+    pub fallback_enabled: bool,
+    pub routing_provenance: RoutingProvenance,
+}
+
+impl Resolved {
+    pub fn selection(&self) -> ResolvedWorkerSelection {
+        ResolvedWorkerSelection {
+            worker_id: self.worker_id.clone(),
+            model: self.model.clone(),
+            fallback_enabled: self.fallback_enabled,
+            routing_provenance: self.routing_provenance.clone(),
+        }
+    }
 }
 
 pub fn resolve_worker_for_task(
@@ -53,6 +69,10 @@ pub fn resolve_worker_for_task(
     override_w: Option<&str>,
     task: &Task,
 ) -> Result<Resolved> {
+    let fallback_enabled = task.fallback_enabled.unwrap_or_else(|| {
+        task.preferred_worker.trim().is_empty() || workers.routing.allow_preferred_worker_failover
+    });
+    validate_recorded_lineage(task, override_w, fallback_enabled)?;
     let overrides = load_overrides(ws);
     let required: Vec<String> = task
         .required_capabilities
@@ -93,12 +113,12 @@ pub fn resolve_worker_for_task(
         }
     }
 
-    if candidate.reason == "planner preferred"
+    let resolved = if candidate.reason == "planner preferred"
         && !task.preferred_worker.trim().is_empty()
-        && !workers.routing.allow_preferred_worker_failover
+        && !fallback_enabled
     {
         let pinned = candidate.worker_id.clone();
-        return resolve_order(
+        resolve_order(
             workers,
             billing,
             pinned.clone(),
@@ -109,16 +129,17 @@ pub fn resolve_worker_for_task(
             anyhow!(
                 "preferred worker '{pinned}' is not invocable; cross-worker fallback requires explicit opt-in with routing.allow_preferred_worker_failover"
             )
-        });
-    }
-
-    resolve_candidate(
-        workers,
-        billing,
-        candidate.worker_id,
-        candidate.reason,
-        &required,
-    )
+        })?
+    } else {
+        resolve_candidate(
+            workers,
+            billing,
+            candidate.worker_id,
+            candidate.reason,
+            &required,
+        )?
+    };
+    complete_resolution(workers, task, resolved, fallback_enabled)
 }
 
 pub fn resolve_failover_worker_for_task(
@@ -127,8 +148,11 @@ pub fn resolve_failover_worker_for_task(
     failed_worker: &str,
     task: &Task,
 ) -> Result<Resolved> {
-    if !task.preferred_worker.trim().is_empty() && !workers.routing.allow_preferred_worker_failover
-    {
+    let fallback_enabled = task.fallback_enabled.unwrap_or_else(|| {
+        task.preferred_worker.trim().is_empty() || workers.routing.allow_preferred_worker_failover
+    });
+    validate_recorded_lineage(task, None, fallback_enabled)?;
+    if !fallback_enabled {
         return Err(anyhow!(
             "task pinned preferred worker '{}'; cross-worker failover requires explicit opt-in with routing.allow_preferred_worker_failover",
             task.preferred_worker
@@ -165,7 +189,142 @@ pub fn resolve_failover_worker_for_task(
             "no alternate worker{cap_note} after excluding '{failed_worker}'"
         ));
     }
-    resolve_order(workers, billing, order[0].clone(), "failover", &order)
+    let resolved = resolve_order(workers, billing, order[0].clone(), "failover", &order)?;
+    complete_resolution(workers, task, resolved, fallback_enabled)
+}
+
+fn explicit(value: &str) -> bool {
+    !value.trim().is_empty() && !value.eq_ignore_ascii_case("auto")
+}
+
+fn validate_recorded_lineage(
+    task: &Task,
+    override_w: Option<&str>,
+    fallback_enabled: bool,
+) -> Result<()> {
+    let Some(provenance) = &task.routing_provenance else {
+        return Ok(());
+    };
+    if provenance.governing_task_id.trim().is_empty()
+        || provenance.governing_worker_id.trim().is_empty()
+        || provenance.governing_model.trim().is_empty()
+    {
+        return Err(anyhow!(
+            "task '{}' has incomplete governing routing provenance",
+            task.id
+        ));
+    }
+    if !provenance.governing_fallback_enabled {
+        if task.preferred_worker != provenance.governing_worker_id {
+            return Err(anyhow!(
+                "task '{}' worker '{}' conflicts with governing worker '{}'",
+                task.id,
+                task.preferred_worker,
+                provenance.governing_worker_id
+            ));
+        }
+        if let Some(override_w) = override_w.filter(|value| !value.trim().is_empty()) {
+            if override_w != provenance.governing_worker_id {
+                return Err(anyhow!(
+                    "run override '{}' conflicts with task '{}' governing worker '{}'",
+                    override_w,
+                    task.id,
+                    provenance.governing_worker_id
+                ));
+            }
+        }
+    }
+    if !explicit(&task.model) || task.model != provenance.governing_model {
+        return Err(anyhow!(
+            "task '{}' model '{}' conflicts with governing model '{}'",
+            task.id,
+            task.model,
+            provenance.governing_model
+        ));
+    }
+    if fallback_enabled != provenance.governing_fallback_enabled {
+        return Err(anyhow!(
+            "task '{}' fallback_enabled={} conflicts with governing fallback_enabled={}",
+            task.id,
+            fallback_enabled,
+            provenance.governing_fallback_enabled
+        ));
+    }
+    Ok(())
+}
+
+fn complete_resolution(
+    workers: &WorkersFile,
+    task: &Task,
+    mut resolved: Resolved,
+    fallback_enabled: bool,
+) -> Result<Resolved> {
+    let profile = workers
+        .workers
+        .iter()
+        .find(|profile| profile.id == resolved.worker_id)
+        .ok_or_else(|| anyhow!("resolved worker '{}' is not configured", resolved.worker_id))?;
+    let model = if explicit(&task.model) {
+        task.model.trim().to_string()
+    } else {
+        profile.model.trim().to_string()
+    };
+    let provenance = if let Some(recorded) = &task.routing_provenance {
+        if !recorded.governing_fallback_enabled
+            && resolved.worker_id != recorded.governing_worker_id
+        {
+            return Err(anyhow!(
+                "resolved worker '{}' conflicts with task '{}' governing worker '{}'",
+                resolved.worker_id,
+                task.id,
+                recorded.governing_worker_id
+            ));
+        }
+        if model != recorded.governing_model {
+            return Err(anyhow!(
+                "resolved model '{}' conflicts with task '{}' governing model '{}'",
+                model,
+                task.id,
+                recorded.governing_model
+            ));
+        }
+        recorded.clone()
+    } else {
+        RoutingProvenance {
+            governing_task_id: task.id.clone(),
+            governing_worker_id: resolved.worker_id.clone(),
+            governing_model: model.clone(),
+            governing_fallback_enabled: fallback_enabled,
+            worker_source: resolved.reason.clone(),
+            model_source: if explicit(&task.model) {
+                "task.model".to_string()
+            } else if model.is_empty() {
+                "worker_cli.default".to_string()
+            } else {
+                "worker_profile.model".to_string()
+            },
+            fallback_source: if task.fallback_enabled.is_some() {
+                "task.fallback_enabled".to_string()
+            } else if task.preferred_worker.trim().is_empty() {
+                "routing.unpinned_default".to_string()
+            } else {
+                "workspace.routing.allow_preferred_worker_failover".to_string()
+            },
+            worker_overridden: resolved.reason == "run override",
+            model_overridden: explicit(&task.model),
+            fallback_overridden: task.fallback_enabled.is_some(),
+        }
+    };
+    if task.routing_provenance.is_some() && model.is_empty() {
+        return Err(anyhow!(
+            "task '{}' exact routing lineage resolved an empty model",
+            task.id
+        ));
+    }
+    resolved.model = model;
+    resolved.fallback_enabled = fallback_enabled;
+    resolved.routing_provenance = provenance;
+    Ok(resolved)
 }
 
 fn resolve_candidate(
@@ -226,6 +385,9 @@ fn resolve_order(
                     worker_id: id.clone(),
                     bin,
                     reason,
+                    model: String::new(),
+                    fallback_enabled: false,
+                    routing_provenance: RoutingProvenance::default(),
                 });
             }
         }
@@ -417,6 +579,55 @@ mod tests {
             candidate_for(&w, &ov, None, "", "implementation").0,
             "codex"
         );
+    }
+
+    #[test]
+    fn dispatch_rejects_exact_lineage_model_and_fallback_conflicts() {
+        let workers: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation: { command: bash }\n",
+        )
+        .unwrap();
+        let exact = || -> Task {
+            crate::yaml::from_str(
+                "id: YARD-002\ntitle: inherited\npreferred_worker: codex\nmodel: gpt-5.6-sol\nfallback_enabled: false\nrouting_provenance:\n  governing_task_id: YARD-001\n  governing_worker_id: codex\n  governing_model: gpt-5.6-sol\n  governing_fallback_enabled: false\n  worker_source: governing_task.inherited\n  model_source: governing_task.inherited\n  fallback_source: governing_task.inherited\n",
+            )
+            .unwrap()
+        };
+        let root = std::env::temp_dir().join(format!(
+            "yard-routing-exact-dispatch-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let ws = Workspace::at(&root);
+        let billing = BillingPolicy::default();
+
+        let resolved = resolve_worker_for_task(&ws, &workers, &billing, None, &exact()).unwrap();
+        assert_eq!(resolved.model, "gpt-5.6-sol");
+        assert!(!resolved.fallback_enabled);
+
+        let mut model_conflict = exact();
+        model_conflict.model = "other".into();
+        assert!(
+            resolve_worker_for_task(&ws, &workers, &billing, None, &model_conflict)
+                .unwrap_err()
+                .to_string()
+                .contains("governing model")
+        );
+
+        let mut fallback_conflict = exact();
+        fallback_conflict.fallback_enabled = Some(true);
+        assert!(
+            resolve_worker_for_task(&ws, &workers, &billing, None, &fallback_conflict)
+                .unwrap_err()
+                .to_string()
+                .contains("governing fallback_enabled")
+        );
+
+        let mut both = exact();
+        both.model = "other".into();
+        both.fallback_enabled = Some(true);
+        assert!(resolve_worker_for_task(&ws, &workers, &billing, None, &both).is_err());
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -214,15 +214,19 @@ fn validate_recorded_lineage(
             task.id
         ));
     }
+    // `fallback_enabled` permits a different worker to be resolved for a run;
+    // it does not permit the recorded task contract to replace its governing
+    // preferred worker. Keep this gate identical to follow-up ingestion while
+    // leaving runtime override/failover below governed by the fallback opt-in.
+    if task.preferred_worker != provenance.governing_worker_id {
+        return Err(anyhow!(
+            "task '{}' worker '{}' conflicts with governing worker '{}'",
+            task.id,
+            task.preferred_worker,
+            provenance.governing_worker_id
+        ));
+    }
     if !provenance.governing_fallback_enabled {
-        if task.preferred_worker != provenance.governing_worker_id {
-            return Err(anyhow!(
-                "task '{}' worker '{}' conflicts with governing worker '{}'",
-                task.id,
-                task.preferred_worker,
-                provenance.governing_worker_id
-            ));
-        }
         if let Some(override_w) = override_w.filter(|value| !value.trim().is_empty()) {
             if override_w != provenance.governing_worker_id {
                 return Err(anyhow!(
@@ -582,7 +586,7 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_rejects_exact_lineage_model_and_fallback_conflicts() {
+    fn dispatch_rejects_exact_lineage_worker_model_and_fallback_conflicts() {
         let workers: WorkersFile = crate::yaml::from_str(
             "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation: { command: bash }\n",
         )
@@ -604,6 +608,15 @@ mod tests {
         let resolved = resolve_worker_for_task(&ws, &workers, &billing, None, &exact()).unwrap();
         assert_eq!(resolved.model, "gpt-5.6-sol");
         assert!(!resolved.fallback_enabled);
+
+        let mut worker_conflict = exact();
+        worker_conflict.preferred_worker = "claude-code".into();
+        assert!(
+            resolve_worker_for_task(&ws, &workers, &billing, None, &worker_conflict)
+                .unwrap_err()
+                .to_string()
+                .contains("governing worker")
+        );
 
         let mut model_conflict = exact();
         model_conflict.model = "other".into();
@@ -627,6 +640,29 @@ mod tests {
         both.model = "other".into();
         both.fallback_enabled = Some(true);
         assert!(resolve_worker_for_task(&ws, &workers, &billing, None, &both).is_err());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn dispatch_rejects_recorded_worker_conflict_when_runtime_failover_is_enabled() {
+        let workers: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex, claude-code]\n  allow_preferred_worker_failover: true\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation: { command: bash }\n  - id: claude-code\n    model: gpt-5.6-sol\n    invocation: { command: bash }\n",
+        )
+        .unwrap();
+        let task: Task = crate::yaml::from_str(
+            "id: YARD-002\ntitle: tampered inherited worker\npreferred_worker: claude-code\nmodel: gpt-5.6-sol\nfallback_enabled: true\nrouting_provenance:\n  governing_task_id: YARD-001\n  governing_worker_id: codex\n  governing_model: gpt-5.6-sol\n  governing_fallback_enabled: true\n  worker_source: governing_task.inherited\n  model_source: governing_task.inherited\n  fallback_source: governing_task.inherited\n",
+        )
+        .unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "yard-routing-failover-recorded-worker-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let ws = Workspace::at(&root);
+
+        let error = resolve_worker_for_task(&ws, &workers, &BillingPolicy::default(), None, &task)
+            .unwrap_err();
+        assert!(error.to_string().contains("governing worker"), "{error:#}");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -591,6 +591,12 @@ pub(crate) struct RunRecord {
     pub intent_id: String,
     #[serde(default)]
     pub worker: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub fallback_enabled: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_provenance: Option<crate::schemas::RoutingProvenance>,
     /// Lifecycle: `prepared`/`running` at spawn, then sealed by `finalize_run`
     /// to the run's terminal outcome (`done`/`failed`/`partial`/`needs_user`/…).
     #[serde(default)]
@@ -636,6 +642,44 @@ pub(crate) struct RunRecord {
     /// Exact commits newly reachable from baseline through integration_oid.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub owned_oids: Vec<String>,
+}
+
+impl RunRecord {
+    fn resolved_selection(&self) -> Option<crate::schemas::ResolvedWorkerSelection> {
+        let routing_provenance = self.routing_provenance.clone()?;
+        if self.worker.trim().is_empty() || self.model.trim().is_empty() {
+            return None;
+        }
+        Some(crate::schemas::ResolvedWorkerSelection {
+            worker_id: self.worker.clone(),
+            model: self.model.clone(),
+            fallback_enabled: self.fallback_enabled,
+            routing_provenance,
+        })
+    }
+}
+
+pub(crate) fn update_run_selection(
+    run_dir: &std::path::Path,
+    selection: &crate::schemas::ResolvedWorkerSelection,
+) -> Result<()> {
+    let path = run_dir.join("run.yaml");
+    let mut record: RunRecord = state::load_yaml(&path)?;
+    record.worker = selection.worker_id.clone();
+    record.model = selection.model.clone();
+    record.fallback_enabled = selection.fallback_enabled;
+    record.routing_provenance = Some(selection.routing_provenance.clone());
+    state::save_yaml_atomic(&path, &record)
+}
+
+pub(crate) fn apply_selection_to_task(
+    task: &mut crate::schemas::Task,
+    selection: &crate::schemas::ResolvedWorkerSelection,
+) {
+    task.preferred_worker = selection.worker_id.clone();
+    task.model = selection.model.clone();
+    task.fallback_enabled = Some(selection.fallback_enabled);
+    task.routing_provenance = Some(selection.routing_provenance.clone());
 }
 
 fn is_unknown_integration_provenance(value: &IntegrationProvenance) -> bool {
@@ -1430,7 +1474,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 .ok_or_else(|| anyhow!("no eligible queued task to run"))?
         }
     };
-    let task = queue.tasks[idx].clone();
+    let mut task = queue.tasks[idx].clone();
 
     // Capability backstop: if this task requires a capability no enabled worker
     // declares, park it Blocked HERE — before any run dir or worker spawn —
@@ -1604,6 +1648,17 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         .as_ref()
         .map(|r| r.worker_id.clone())
         .unwrap_or_else(|_| candidate_id.clone());
+    let resolved_selection = resolved.as_ref().ok().map(|resolved| resolved.selection());
+    if opts.execute {
+        if let Some(selection) = resolved_selection
+            .as_ref()
+            .filter(|selection| !selection.model.trim().is_empty())
+        {
+            apply_selection_to_task(&mut task, selection);
+            queue.tasks[idx] = task.clone();
+            ws.save_queue_locked(&planning_lock, &queue)?;
+        }
+    }
 
     // ---- run directory ---------------------------------------------------
     let base_run_id = format!(
@@ -1698,6 +1753,16 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         task_id: task.id.clone(),
         intent_id: queue.intent_id.clone(),
         worker: worker_id.clone(),
+        model: resolved_selection
+            .as_ref()
+            .map(|selection| selection.model.clone())
+            .unwrap_or_default(),
+        fallback_enabled: resolved_selection
+            .as_ref()
+            .is_some_and(|selection| selection.fallback_enabled),
+        routing_provenance: resolved_selection
+            .as_ref()
+            .map(|selection| selection.routing_provenance.clone()),
         state: if opts.execute { "running" } else { "prepared" }.to_string(),
         started_at: Local::now().to_rfc3339(),
         completed_at: None,
@@ -1725,9 +1790,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         integration_cleanup_complete: false,
         owned_oids: Vec::new(),
     };
-    state::save_yaml(&run_dir.join("run.yaml"), &record)?;
+    state::save_yaml_atomic(&run_dir.join("run.yaml"), &record)?;
     if serial_worktree.is_some() {
-        state::save_yaml(&worker_run_dir.join("run.yaml"), &record)?;
+        state::save_yaml_atomic(&worker_run_dir.join("run.yaml"), &record)?;
         write_str(&workers::packet_path(worker_run_dir), &packet_text)?;
     }
 
@@ -1778,6 +1843,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     }
     let resolved = resolved?; // hard stop if no ready worker
     let mut active_worker_id = worker_id.clone();
+    let mut active_selection = resolved.selection();
     let mut active_reason = resolved.reason;
     let mut active_bin = resolved.bin;
     let profile = find_worker(&workers.workers, &active_worker_id)?;
@@ -1926,8 +1992,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         first_continuation,
         None,
     )?;
-    let mut outcome = match workers::spawn_attempt_with_sink(
+    let mut outcome = match workers::spawn_resolved_attempt_with_sink(
         &eff_profile,
+        &active_selection,
         &active_bin,
         &packet_text,
         worker_run_dir,
@@ -2006,8 +2073,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         )?;
         current_attempt = begun.0;
         current_capture = begun.1;
-        outcome = match workers::spawn_attempt_with_sink(
+        outcome = match workers::spawn_resolved_attempt_with_sink(
             &eff_profile,
+            &active_selection,
             &active_bin,
             cont,
             worker_run_dir,
@@ -2092,10 +2160,15 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 record_failover(&run_dir, &from, &to, &note);
 
                 active_worker_id = to;
+                active_selection = alt.selection();
                 active_reason = format!("failover from {from} ({})", alt.reason);
                 active_bin = alt.bin;
                 let profile = find_worker(&workers.workers, &active_worker_id)?;
                 eff_profile = workers::effective_profile(profile, &task.model, &task.effort);
+                update_run_selection(&run_dir, &active_selection)?;
+                if worker_run_dir != run_dir.as_path() {
+                    update_run_selection(worker_run_dir, &active_selection)?;
+                }
                 env = guard::sanitized_worker_env_for(&billing, &eff_profile.invocation.pass_env)
                     .map_err(|e| anyhow!(e))?;
                 timeout = Duration::from_secs(profile.limits.max_wall_minutes as u64 * 60);
@@ -2140,8 +2213,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 )?;
                 current_attempt = begun.0;
                 current_capture = begun.1;
-                outcome = match workers::spawn_attempt_with_sink(
+                outcome = match workers::spawn_resolved_attempt_with_sink(
                     &eff_profile,
+                    &active_selection,
                     &active_bin,
                     &failover_packet,
                     worker_run_dir,
@@ -4092,6 +4166,7 @@ fn save_task_state_on_latest_queue_locked(
         &[],
         &[],
         None,
+        None,
         cause,
         detail,
         actor,
@@ -4233,6 +4308,7 @@ fn finalize_on_latest_queue_locked(
     state: TaskState,
     intent_allowed_scope: &[String],
     follow_ups: &[crate::schemas::FollowUpTask],
+    governing: Option<&crate::schemas::ResolvedWorkerSelection>,
     workers: Option<&WorkersFile>,
     cause: TransitionCause,
     detail: &str,
@@ -4250,12 +4326,22 @@ fn finalize_on_latest_queue_locked(
     if let Some(t) = latest.tasks.iter_mut().find(|t| t.id == task_id) {
         let from = t.state;
         t.state = state;
-        let ingested = crate::planner::ingest_follow_ups(
-            &mut latest,
-            intent_allowed_scope,
-            follow_ups,
-            Some(ws),
-        );
+        let ingested = if let Some(governing) = governing {
+            crate::planner::ingest_follow_ups_with_governing(
+                &mut latest,
+                intent_allowed_scope,
+                follow_ups,
+                Some(ws),
+                governing,
+            )?
+        } else {
+            crate::planner::ingest_follow_ups(
+                &mut latest,
+                intent_allowed_scope,
+                follow_ups,
+                Some(ws),
+            )
+        };
         reconcile(&mut latest, &ingested);
         ws.save_queue_locked(lock, &latest)?;
         crate::planner::persist_ingested_decision_questions(ws, &latest, &ingested)?;
@@ -4279,12 +4365,22 @@ fn finalize_on_latest_queue_locked(
             .ok_or_else(|| anyhow!("task {task_id} is missing from fallback queue"))?;
         let from = task.state;
         task.state = state;
-        let ingested = crate::planner::ingest_follow_ups(
-            &mut bootstrapped,
-            intent_allowed_scope,
-            follow_ups,
-            Some(ws),
-        );
+        let ingested = if let Some(governing) = governing {
+            crate::planner::ingest_follow_ups_with_governing(
+                &mut bootstrapped,
+                intent_allowed_scope,
+                follow_ups,
+                Some(ws),
+                governing,
+            )?
+        } else {
+            crate::planner::ingest_follow_ups(
+                &mut bootstrapped,
+                intent_allowed_scope,
+                follow_ups,
+                Some(ws),
+            )
+        };
         reconcile(&mut bootstrapped, &ingested);
         ws.save_queue_locked(lock, &bootstrapped)?;
         crate::planner::persist_ingested_decision_questions(ws, &bootstrapped, &ingested)?;
@@ -5451,6 +5547,9 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     } else {
         Vec::new()
     };
+    let governing_selection = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml"))
+        .ok()
+        .and_then(|record| record.resolved_selection());
     let ingested = finalize_on_latest_queue_locked(
         ws,
         &queue_lock,
@@ -5459,6 +5558,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         next_state,
         &intent_allowed_scope,
         &follow_ups,
+        governing_selection.as_ref(),
         workers.as_ref(),
         TransitionCause::RunOutcome,
         &format!("worker evaluated task as {}", run_outcome_label(next_state)),
@@ -5686,6 +5786,9 @@ fn seal_run_record(
         task_id: task.id.clone(),
         intent_id: intent_id.to_string(),
         worker: worker_id.to_string(),
+        model: task.model.clone(),
+        fallback_enabled: task.fallback_enabled.unwrap_or(false),
+        routing_provenance: task.routing_provenance.clone(),
         state: String::new(),
         started_at: String::new(),
         completed_at: None,
@@ -6643,6 +6746,7 @@ mod tests {
             kind: String::new(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -6659,6 +6763,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         }
     }
 
@@ -9986,6 +10091,9 @@ exit 1
                 task_id: task_id.into(),
                 intent_id: "intent-test".into(),
                 worker: "builder".into(),
+                model: String::new(),
+                fallback_enabled: false,
+                routing_provenance: None,
                 state: "done".into(),
                 started_at: Local::now().to_rfc3339(),
                 completed_at: Some(Local::now().to_rfc3339()),
@@ -10736,6 +10844,9 @@ exit 1
                 task_id: "YARD-STAGED".into(),
                 intent_id: "intent-test".into(),
                 worker: "builder".into(),
+                model: String::new(),
+                fallback_enabled: false,
+                routing_provenance: None,
                 state: "running".into(),
                 started_at: Local::now().to_rfc3339(),
                 completed_at: None,
@@ -10883,6 +10994,9 @@ exit 1
                 task_id: task_id.into(),
                 intent_id: "intent-test".into(),
                 worker: "builder".into(),
+                model: String::new(),
+                fallback_enabled: false,
+                routing_provenance: None,
                 state: "running".into(),
                 started_at: Local::now().to_rfc3339(),
                 completed_at: None,
@@ -11227,6 +11341,8 @@ exit 1
                 skills: vec![],
                 depends_on: vec![],
                 preferred_worker: String::new(),
+                model: String::new(),
+                fallback_enabled: None,
                 required_capabilities: vec![],
                 decision_question: String::new(),
                 worker_rationale: None,

--- a/src/run.rs
+++ b/src/run.rs
@@ -4327,13 +4327,30 @@ fn finalize_on_latest_queue_locked(
         let from = t.state;
         t.state = state;
         let ingested = if let Some(governing) = governing {
-            crate::planner::ingest_follow_ups_with_governing(
+            match crate::planner::ingest_follow_ups_with_governing(
                 &mut latest,
                 intent_allowed_scope,
                 follow_ups,
                 Some(ws),
                 governing,
-            )?
+            ) {
+                Ok(ingested) => ingested,
+                Err(error) => {
+                    // Governing ingestion is atomic, so a rejected follow-up
+                    // left `latest` with only the run outcome applied. Preserve
+                    // that durable outcome and its transition before surfacing
+                    // the fail-closed lineage error.
+                    ws.save_queue_locked(lock, &latest)?;
+                    if from != state {
+                        state::append_transition(
+                            ws,
+                            state::transition(task_id, from, state, cause, detail, actor.clone()),
+                        )?;
+                    }
+                    *fallback_queue = latest;
+                    return Err(error);
+                }
+            }
         } else {
             crate::planner::ingest_follow_ups(
                 &mut latest,
@@ -4366,13 +4383,28 @@ fn finalize_on_latest_queue_locked(
         let from = task.state;
         task.state = state;
         let ingested = if let Some(governing) = governing {
-            crate::planner::ingest_follow_ups_with_governing(
+            match crate::planner::ingest_follow_ups_with_governing(
                 &mut bootstrapped,
                 intent_allowed_scope,
                 follow_ups,
                 Some(ws),
                 governing,
-            )?
+            ) {
+                Ok(ingested) => ingested,
+                Err(error) => {
+                    // Match the normal latest-queue path: reject the follow-up
+                    // without losing the governing task's evaluated outcome.
+                    ws.save_queue_locked(lock, &bootstrapped)?;
+                    if from != state {
+                        state::append_transition(
+                            ws,
+                            state::transition(task_id, from, state, cause, detail, actor),
+                        )?;
+                    }
+                    *fallback_queue = bootstrapped;
+                    return Err(error);
+                }
+            }
         } else {
             crate::planner::ingest_follow_ups(
                 &mut bootstrapped,
@@ -11375,6 +11407,69 @@ exit 1
             "no follow-up should be ingested on recovery"
         );
         assert_eq!(q.tasks[0].state, TaskState::Done);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn conflicting_follow_up_does_not_erase_governing_task_state_transition() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-follow-up-conflict-finalize-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ws = Workspace::at(&root);
+        let mut governing_task = task("YARD-001", TaskState::Running, 10, false);
+        governing_task.preferred_worker = "codex".into();
+        governing_task.model = "gpt-5.6-sol".into();
+        governing_task.fallback_enabled = Some(false);
+        let initial = queue(vec![governing_task]);
+        ws.save_queue(&initial).unwrap();
+
+        let governing = crate::schemas::ResolvedWorkerSelection {
+            worker_id: "codex".into(),
+            model: "gpt-5.6-sol".into(),
+            fallback_enabled: false,
+            routing_provenance: crate::schemas::RoutingProvenance {
+                governing_task_id: "YARD-001".into(),
+                governing_worker_id: "codex".into(),
+                governing_model: "gpt-5.6-sol".into(),
+                governing_fallback_enabled: false,
+                ..Default::default()
+            },
+        };
+        let conflicting = crate::schemas::FollowUpTask {
+            title: "conflicting worker follow-up".into(),
+            preferred_worker: "claude-code".into(),
+            ..Default::default()
+        };
+        let lock = ws.acquire_planning_lock().unwrap();
+        let mut fallback_queue = initial;
+        let error = finalize_on_latest_queue_locked(
+            &ws,
+            &lock,
+            &mut fallback_queue,
+            "YARD-001",
+            TaskState::Done,
+            &[],
+            &[conflicting],
+            Some(&governing),
+            None,
+            TransitionCause::RunOutcome,
+            "worker evaluated task as done",
+            TransitionActor::Worker("run-conflicting-follow-up".into()),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("governing worker"), "{error:#}");
+        let persisted = ws.load_queue().unwrap();
+        assert_eq!(persisted.tasks.len(), 1, "conflict must stay fail-closed");
+        assert_eq!(persisted.tasks[0].state, TaskState::Done);
+        assert_eq!(fallback_queue.tasks[0].state, TaskState::Done);
+        let transition = ws.latest_transition("YARD-001").unwrap();
+        assert_eq!(transition.from, TaskState::Running);
+        assert_eq!(transition.to, TaskState::Done);
+        assert_eq!(transition.cause, TransitionCause::RunOutcome);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -791,6 +791,11 @@ pub struct Task {
     /// worker profile's model, then the CLI's own default.
     #[serde(default)]
     pub model: String,
+    /// Whether this task may leave its resolved worker lineage after retries.
+    /// `None` preserves legacy workspace policy; worker-proposed descendants of
+    /// an exact lineage always materialize an explicit value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fallback_enabled: Option<bool>,
     /// Optional per-task reasoning effort. Empty or "auto" = worker default.
     /// codex: minimal|low|medium|high.
     #[serde(default)]
@@ -835,6 +840,47 @@ pub struct Task {
     /// current task.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub provenance: String,
+    /// Core-authored provenance for an exact worker/model/fallback lineage.
+    /// A task carrying this receipt is validated again at dispatch so a queue
+    /// edit cannot silently override the governing decision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub routing_provenance: Option<RoutingProvenance>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingProvenance {
+    #[serde(default)]
+    pub governing_task_id: String,
+    #[serde(default)]
+    pub governing_worker_id: String,
+    #[serde(default)]
+    pub governing_model: String,
+    #[serde(default)]
+    pub governing_fallback_enabled: bool,
+    #[serde(default)]
+    pub worker_source: String,
+    #[serde(default)]
+    pub model_source: String,
+    #[serde(default)]
+    pub fallback_source: String,
+    #[serde(default)]
+    pub worker_overridden: bool,
+    #[serde(default)]
+    pub model_overridden: bool,
+    #[serde(default)]
+    pub fallback_overridden: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedWorkerSelection {
+    #[serde(default)]
+    pub worker_id: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub fallback_enabled: bool,
+    #[serde(default)]
+    pub routing_provenance: RoutingProvenance,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -2160,6 +2206,12 @@ pub struct FollowUpTask {
     pub depends_on: Vec<String>,
     #[serde(default)]
     pub preferred_worker: String,
+    /// Optional exact model request. Empty/`auto` inherits the governing run.
+    #[serde(default)]
+    pub model: String,
+    /// Optional fallback request. Omission inherits the governing run.
+    #[serde(default)]
+    pub fallback_enabled: Option<bool>,
     #[serde(default)]
     pub required_capabilities: Vec<String>,
     /// If set, this follow-up is a HUMAN DECISION (a choice/approval only the

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1537,6 +1537,7 @@ mod tests {
             kind: "implementation".into(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: vec![],
             skills: vec![],
@@ -1549,6 +1550,7 @@ mod tests {
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -2195,6 +2195,7 @@ impl Workspace {
             kind: input.kind,
             preferred_worker: input.preferred_worker,
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: input.depends_on,
             skills: Vec::new(),
@@ -2207,6 +2208,7 @@ impl Workspace {
             interaction: None,
             worker_rationale: Some("added directly by user with yardlet add".to_string()),
             provenance: "user-added".to_string(),
+            routing_provenance: None,
         };
         queue.tasks.push(task.clone());
         self.save_queue_locked(&_lock, &queue)?;
@@ -4528,6 +4530,14 @@ pub fn save_yaml<T: serde::Serialize>(path: &Path, value: &T) -> Result<()> {
     Ok(())
 }
 
+pub fn save_yaml_atomic<T: serde::Serialize>(path: &Path, value: &T) -> Result<()> {
+    write_str_atomic(path, &yaml::to_string(value)?)
+}
+
+pub(crate) fn save_private_yaml_atomic<T: serde::Serialize>(path: &Path, value: &T) -> Result<()> {
+    write_private_str_atomic(path, &yaml::to_string(value)?)
+}
+
 pub fn save_config_preserving_format(path: &Path, config: &YardConfig) -> Result<bool> {
     let current: YardConfig = load_yaml(path)?;
     let mut edits = Vec::new();
@@ -5126,6 +5136,34 @@ pub fn write_str_atomic(path: &Path, contents: &str) -> Result<()> {
         .unwrap_or("state");
     let tmp = path.with_file_name(format!(".{file_name}.tmp-{}", std::process::id()));
     let mut file = fs::File::create(&tmp).with_context(|| format!("creating {}", tmp.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("writing {}", tmp.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} to {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn write_private_str_atomic(path: &Path, contents: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("private-state");
+    let tmp = path.with_file_name(format!(".{file_name}.tmp-{}", std::process::id()));
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&tmp)
+        .with_context(|| format!("creating private snapshot {}", tmp.display()))?;
     file.write_all(contents.as_bytes())
         .with_context(|| format!("writing {}", tmp.display()))?;
     file.sync_all()
@@ -6249,6 +6287,7 @@ records:
             kind: "implementation".to_string(),
             preferred_worker: String::new(),
             model: String::new(),
+            fallback_enabled: None,
             effort: String::new(),
             depends_on: Vec::new(),
             skills: Vec::new(),
@@ -6261,6 +6300,7 @@ records:
             interaction: None,
             worker_rationale: None,
             provenance: String::new(),
+            routing_provenance: None,
         });
         ws.save_queue(&queue).unwrap();
 

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -17,7 +17,10 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 
-use crate::schemas::{ChannelEventType, Invocation, RawEventRef, WorkerProfile};
+use crate::schemas::{
+    ChannelEventType, Invocation, RawEventRef, ResolvedWorkerSelection, RoutingProvenance,
+    WorkerProfile,
+};
 
 pub(crate) const WORKER_PROCESS_PROVENANCE_FILE: &str = "worker-process.yaml";
 
@@ -27,8 +30,20 @@ pub(crate) struct WorkerProcessProvenance {
     pub run_id: String,
     pub attempt_id: String,
     pub worker_id: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub fallback_enabled: bool,
+    #[serde(default)]
+    pub routing_provenance: RoutingProvenance,
+    #[serde(default)]
     pub pid: u32,
+    #[serde(default)]
     pub process_start_marker: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
 }
 
 pub(crate) fn process_start_marker(pid: u32) -> Option<String> {
@@ -731,6 +746,7 @@ pub fn spawn(
         output_log,
         None,
         None,
+        None,
         timeout,
         full_access,
         images,
@@ -740,6 +756,7 @@ pub fn spawn(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub fn spawn_attempt(
     profile: &WorkerProfile,
     bin: &Path,
@@ -772,6 +789,7 @@ pub fn spawn_attempt(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub fn spawn_attempt_with_sink(
     profile: &WorkerProfile,
     bin: &Path,
@@ -797,6 +815,77 @@ pub fn spawn_attempt_with_sink(
         &capture.combined_log,
         Some(capture),
         event_sink,
+        None,
+        timeout,
+        full_access,
+        images,
+        session,
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_resolved_attempt(
+    profile: &WorkerProfile,
+    selection: &ResolvedWorkerSelection,
+    bin: &Path,
+    packet: &str,
+    worker_run_dir: &Path,
+    cwd: &Path,
+    env: &[(String, String)],
+    capture: &AttemptCapture,
+    timeout: Duration,
+    full_access: bool,
+    images: &[String],
+    session: Option<&str>,
+    resume: bool,
+) -> Result<WorkerOutcome> {
+    spawn_resolved_attempt_with_sink(
+        profile,
+        selection,
+        bin,
+        packet,
+        worker_run_dir,
+        cwd,
+        env,
+        capture,
+        None,
+        timeout,
+        full_access,
+        images,
+        session,
+        resume,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_resolved_attempt_with_sink(
+    profile: &WorkerProfile,
+    selection: &ResolvedWorkerSelection,
+    bin: &Path,
+    packet: &str,
+    worker_run_dir: &Path,
+    cwd: &Path,
+    env: &[(String, String)],
+    capture: &AttemptCapture,
+    event_sink: Option<AttemptEventSink>,
+    timeout: Duration,
+    full_access: bool,
+    images: &[String],
+    session: Option<&str>,
+    resume: bool,
+) -> Result<WorkerOutcome> {
+    spawn_internal(
+        profile,
+        bin,
+        packet,
+        worker_run_dir,
+        cwd,
+        env,
+        &capture.combined_log,
+        Some(capture),
+        event_sink,
+        Some(selection),
         timeout,
         full_access,
         images,
@@ -816,6 +905,7 @@ fn spawn_internal(
     output_log: &Path,
     attempt_capture: Option<&AttemptCapture>,
     event_sink: Option<AttemptEventSink>,
+    selection: Option<&ResolvedWorkerSelection>,
     timeout: Duration,
     full_access: bool,
     images: &[String],
@@ -903,46 +993,107 @@ fn spawn_internal(
         None
     };
 
+    let provenance_identity = attempt_capture
+        .map(|capture| -> Result<(String, String)> {
+            let run_id = control_run_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("worker control directory has no run identity"))?;
+            let attempt_id = capture
+                .stdout_log
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("attempt capture path has no attempt identity"))?;
+            Ok((run_id.to_string(), attempt_id.to_string()))
+        })
+        .transpose()?;
+    let provenance_paths = {
+        let canonical = control_run_dir.join(WORKER_PROCESS_PROVENANCE_FILE);
+        let worker = worker_run_dir.join(WORKER_PROCESS_PROVENANCE_FILE);
+        if worker == canonical {
+            vec![canonical]
+        } else {
+            vec![canonical, worker]
+        }
+    };
+    if let (Some((run_id, attempt_id)), Some(selection)) = (provenance_identity.as_ref(), selection)
+    {
+        if selection.worker_id != profile.id || selection.model != profile.model {
+            anyhow::bail!(
+                "dispatch selection/profile mismatch before spawn: selection={}/{} profile={}/{}",
+                selection.worker_id,
+                selection.model,
+                profile.id,
+                profile.model
+            );
+        }
+        let prepared = WorkerProcessProvenance {
+            schema_version: 1,
+            run_id: run_id.clone(),
+            attempt_id: attempt_id.clone(),
+            worker_id: selection.worker_id.clone(),
+            model: selection.model.clone(),
+            fallback_enabled: selection.fallback_enabled,
+            routing_provenance: selection.routing_provenance.clone(),
+            pid: 0,
+            process_start_marker: String::new(),
+            state: "prepared".to_string(),
+            completed_at: None,
+        };
+        for path in &provenance_paths {
+            crate::state::save_private_yaml_atomic(path, &prepared)?;
+        }
+    }
+
     let mut child = cmd
         .spawn()
         .with_context(|| format!("spawning worker '{}'", bin.display()))?;
 
-    let provenance_path = control_run_dir.join(WORKER_PROCESS_PROVENANCE_FILE);
     let provenance_result = (|| -> Result<()> {
-        let Some(capture) = attempt_capture else {
+        let Some((run_id, attempt_id)) = provenance_identity.as_ref() else {
             return Ok(());
         };
-        let run_id = control_run_dir
-            .file_name()
-            .and_then(|name| name.to_str())
-            .filter(|name| !name.is_empty())
-            .ok_or_else(|| anyhow::anyhow!("worker control directory has no run identity"))?;
-        let attempt_id = capture
-            .stdout_log
-            .parent()
-            .and_then(Path::file_name)
-            .and_then(|name| name.to_str())
-            .filter(|name| !name.is_empty())
-            .ok_or_else(|| anyhow::anyhow!("attempt capture path has no attempt identity"))?;
         let process_start_marker = process_start_marker(child.id())
             .ok_or_else(|| anyhow::anyhow!("could not observe spawned worker process identity"))?;
+        let selection = selection
+            .cloned()
+            .unwrap_or_else(|| ResolvedWorkerSelection {
+                worker_id: profile.id.clone(),
+                model: profile.model.clone(),
+                fallback_enabled: false,
+                routing_provenance: RoutingProvenance::default(),
+            });
         let provenance = WorkerProcessProvenance {
             schema_version: 1,
-            run_id: run_id.to_string(),
-            attempt_id: attempt_id.to_string(),
-            worker_id: profile.id.clone(),
+            run_id: run_id.clone(),
+            attempt_id: attempt_id.clone(),
+            worker_id: selection.worker_id,
+            model: selection.model,
+            fallback_enabled: selection.fallback_enabled,
+            routing_provenance: selection.routing_provenance,
             pid: child.id(),
             process_start_marker,
+            state: "running".to_string(),
+            completed_at: None,
         };
-        let mut file = crate::state::create_private_file(&provenance_path)?;
-        file.write_all(crate::yaml::to_string(&provenance)?.as_bytes())?;
-        file.sync_all()?;
+        for path in &provenance_paths {
+            crate::state::save_private_yaml_atomic(path, &provenance)?;
+        }
         Ok(())
     })();
     if let Err(error) = provenance_result {
         let _ = child.kill();
         let _ = child.wait();
-        let _ = std::fs::remove_file(&provenance_path);
+        if let Ok(mut provenance) = load_worker_process_provenance(control_run_dir) {
+            provenance.state = "spawn_failed".to_string();
+            provenance.completed_at = Some(chrono::Local::now().to_rfc3339());
+            for path in &provenance_paths {
+                let _ = crate::state::save_private_yaml_atomic(path, &provenance);
+            }
+        }
         return Err(error).context("recording run-owned worker process provenance");
     }
 
@@ -952,7 +1103,13 @@ fn spawn_internal(
     if let Err(error) = crate::state::write_str_atomic(&pid_path, &child.id().to_string()) {
         let _ = child.kill();
         let _ = child.wait();
-        let _ = std::fs::remove_file(&provenance_path);
+        if let Ok(mut provenance) = load_worker_process_provenance(control_run_dir) {
+            provenance.state = "pid_projection_failed".to_string();
+            provenance.completed_at = Some(chrono::Local::now().to_rfc3339());
+            for path in &provenance_paths {
+                let _ = crate::state::save_private_yaml_atomic(path, &provenance);
+            }
+        }
         return Err(error).context("recording worker PID projection");
     }
 
@@ -1184,7 +1341,19 @@ fn spawn_internal(
         }
     }
     let _ = std::fs::remove_file(&pid_path);
-    let _ = std::fs::remove_file(&provenance_path);
+    if let Ok(mut provenance) = load_worker_process_provenance(control_run_dir) {
+        provenance.state = "exited".to_string();
+        provenance.completed_at = Some(chrono::Local::now().to_rfc3339());
+        for (index, path) in provenance_paths.iter().enumerate() {
+            // The canonical receipt must survive. The worker-side projection is
+            // updated only while its staging run directory still exists: a
+            // worker deleting that directory is an import failure signal, and
+            // receipt finalization must not recreate it and mask the failure.
+            if index == 0 || path.parent().is_some_and(Path::is_dir) {
+                let _ = crate::state::save_private_yaml_atomic(path, &provenance);
+            }
+        }
+    }
     if let Some(error) = reader_error {
         return Err(error).context("preserving attempt raw stream");
     }

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -14,11 +14,20 @@ if [[ "${1:-}" == "exec" ]]; then
 else
   run_dir="${1:?run directory is required}"
 fi
+if [[ -z "$run_dir" && -d "$PWD/.agents/runs" ]]; then
+  run_yaml="$(find "$PWD/.agents/runs" -mindepth 2 -maxdepth 2 -name run.yaml -print -quit)"
+  if [[ -n "$run_yaml" ]]; then
+    run_dir="${run_yaml%/run.yaml}"
+  fi
+fi
 if [[ -z "$run_dir" ]]; then
   printf 'fixture could not resolve run directory\n' >&2
   exit 65
 fi
 task_id="$(sed -n 's/^# Yardlet task packet: //p' <<<"$packet" | head -n 1)"
+if [[ -z "$task_id" && -f "$run_dir/run.yaml" ]]; then
+  task_id="$(sed -n 's/^task_id: //p' "$run_dir/run.yaml" | head -n 1)"
+fi
 run_id="${run_dir##*/}"
 mkdir -p "$run_dir"
 
@@ -40,7 +49,68 @@ write_question() {
   write_handoff "사용자 선택을 기다립니다."
 }
 
+assert_exact_receipts() {
+  for receipt in "$run_dir/run.yaml" "$run_dir/worker-process.yaml"; do
+    test -f "$receipt"
+    grep -Eq '^worker(_id)?: codex$' "$receipt"
+    grep -q '^model: gpt-5.6-sol$' "$receipt"
+    grep -q '^fallback_enabled: false$' "$receipt"
+    grep -q '^routing_provenance:$' "$receipt"
+  done
+}
+
+if grep -q 'propose exact lineage follow-ups' <<<"$packet"; then
+  printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "compact_summary": "exact lineage follow-ups proposed",\n  "follow_up_tasks": [\n    {"title": "exact lineage remediation", "reason": "fixture remediation", "kind": "implementation", "acceptance": ["receipt parity"]},\n    {"title": "exact lineage review", "reason": "fixture review", "kind": "review", "acceptance": ["receipt parity"]}\n  ]\n}\n' \
+    "$run_id" "$task_id" >"$run_dir/result.json"
+  write_handoff "exact lineage 후속 작업을 제안했습니다."
+  exit 0
+fi
+
+if grep -Eq 'exact lineage (remediation|review)' <<<"$packet"; then
+  assert_exact_receipts
+  if grep -q 'exact lineage review' <<<"$packet"; then
+    control_root="${PWD%%/.agents/worktrees/*}"
+    review_marker="$control_root/.agents/exact-review-ran"
+    if [[ ! -f "$review_marker" ]]; then
+      : >"$review_marker"
+      printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["pre-dispatch receipt inspection"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-RECEIPT", "pass": false, "evidence": "fixture requests one remediation"}],\n  "follow_up_tasks": [{"title": "exact lineage remediation after review", "reason": "exercise review-rerun", "kind": "implementation", "acceptance": ["receipt parity"]}],\n  "compact_summary": "pre-dispatch receipt parity observed before remediation"\n}\n' \
+        "$run_id" "$task_id" >"$run_dir/result.json"
+    else
+      printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["pre-dispatch receipt inspection"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-RECEIPT", "pass": true, "evidence": "worker read both receipts before body"}],\n  "compact_summary": "pre-dispatch receipt parity observed"\n}\n' \
+        "$run_id" "$task_id" >"$run_dir/result.json"
+    fi
+  else
+    write_done "pre-dispatch receipt parity observed"
+  fi
+  write_handoff "worker 본문에서 dispatch receipt parity를 확인했습니다."
+  exit 0
+fi
+
 case "$task_id" in
+  YARD-TRANSIENT)
+    assert_exact_receipts
+    if [[ " $* " == *" resume "* ]]; then
+      write_done "transient retry receipt parity observed"
+    else
+      printf '{"type":"thread.started","thread_id":"11111111-1111-4111-8111-111111111111"}\n'
+      exit 75
+    fi
+    ;;
+  YARD-EXACT-REDIRECT)
+    assert_exact_receipts
+    if grep -q 'Explicit continuation packet' <<<"$packet"; then
+      write_done "redirect receipt parity observed"
+    else
+      write_handoff "checkpoint before exact redirect"
+      child_pid=''
+      trap '[[ -z "$child_pid" ]] || kill "$child_pid" 2>/dev/null || true; exit 143' TERM INT
+      while true; do
+        sleep 30 &
+        child_pid=$!
+        wait "$child_pid"
+      done
+    fi
+    ;;
   YARD-ASK)
     printf 'ask worker public context before question\n'
     printf 'ask worker diagnostic stream\n' >&2
@@ -85,6 +155,7 @@ case "$task_id" in
     fi
     ;;
   YARD-NATIVE)
+    assert_exact_receipts
     if [[ "$native_adapter" != true ]]; then
       printf 'native fixture requires the codex adapter\n' >&2
       exit 66

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -264,6 +264,131 @@ mod unix {
         fixture.root.join(".agents/fixture-bin/worker.sh")
     }
 
+    fn write_exact_codex_workers(fixture: &FixtureWorkspace, max_retries: u32) {
+        fs::write(
+            fixture.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: {}\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\n  allow_preferred_worker_failover: false\n",
+                worker_path(fixture).display(),
+                max_retries
+            ),
+        )
+        .unwrap();
+    }
+
+    fn run_dirs_for_task(root: &Path, task_id: &str) -> Vec<PathBuf> {
+        files_below(&root.join(".agents/runs"), "/run.yaml")
+            .into_iter()
+            .filter_map(|path| {
+                (string(&read_yaml(&path), "task_id") == task_id)
+                    .then(|| path.parent().unwrap().to_path_buf())
+            })
+            .collect()
+    }
+
+    fn run_dir_for_task(root: &Path, task_id: &str) -> PathBuf {
+        run_dirs_for_task(root, task_id)
+            .into_iter()
+            .max()
+            .unwrap_or_else(|| panic!("run for {task_id} not found"))
+    }
+
+    fn assert_exact_receipt_pair(run_dir: &Path, governing_task_id: &str) {
+        let run = read_yaml(&run_dir.join("run.yaml"));
+        let process = read_yaml(&run_dir.join("worker-process.yaml"));
+        assert_eq!(string(&run, "worker"), "codex");
+        assert_eq!(string(&process, "worker_id"), "codex");
+        for receipt in [&run, &process] {
+            assert_eq!(string(receipt, "model"), "gpt-5.6-sol");
+            assert_eq!(receipt["fallback_enabled"].as_bool(), Some(false));
+            assert_eq!(
+                string(&receipt["routing_provenance"], "governing_task_id"),
+                governing_task_id
+            );
+        }
+        assert_eq!(string(&process, "state"), "exited");
+    }
+
+    fn assert_exact_queue_task(root: &Path, task_id: &str, governing_task_id: &str) {
+        let queue = read_yaml(&root.join(".agents/work-queue.yaml"));
+        let task = queue["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| string(task, "id") == task_id)
+            .unwrap_or_else(|| panic!("queue task {task_id} not found"));
+        assert_eq!(string(task, "preferred_worker"), "codex");
+        assert_eq!(string(task, "model"), "gpt-5.6-sol");
+        assert_eq!(task["fallback_enabled"].as_bool(), Some(false));
+        assert_eq!(
+            string(&task["routing_provenance"], "governing_task_id"),
+            governing_task_id
+        );
+    }
+
+    #[test]
+    fn worker_proposed_follow_ups_inherit_exact_model_and_expose_pre_dispatch_receipts() {
+        let fixture = FixtureWorkspace::new("exact-model-follow-ups");
+        write_exact_codex_workers(&fixture, 0);
+        fixture.write_queue(
+            "  - id: YARD-001\n    title: propose exact lineage follow-ups\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n    model: gpt-5.6-sol\n    fallback_enabled: false\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-001", "--execute"]);
+
+        let queue = read_yaml(&fixture.root.join(".agents/work-queue.yaml"));
+        let tasks = queue["tasks"].as_sequence().unwrap();
+        assert_eq!(tasks.len(), 3, "fixture must materialize both follow-ups");
+        for task in tasks.iter().filter(|task| string(task, "id") != "YARD-001") {
+            assert_eq!(string(task, "preferred_worker"), "codex");
+            assert_eq!(string(task, "model"), "gpt-5.6-sol");
+            assert_eq!(task["fallback_enabled"].as_bool(), Some(false));
+            assert_eq!(
+                string(&task["routing_provenance"], "governing_task_id"),
+                "YARD-001"
+            );
+        }
+
+        fixture.run(&["run", "--task", "YARD-002", "--execute"]);
+        fixture.run(&["run", "--task", "YARD-003", "--execute"]);
+        assert_eq!(task_state(&fixture.root, "YARD-003"), "queued");
+        let after_review = read_yaml(&fixture.root.join(".agents/work-queue.yaml"));
+        let remediation = after_review["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| string(task, "id") == "YARD-004")
+            .expect("failed review must materialize remediation");
+        assert_eq!(string(remediation, "model"), "gpt-5.6-sol");
+        assert_eq!(remediation["fallback_enabled"].as_bool(), Some(false));
+
+        fixture.run(&["run", "--task", "YARD-004", "--execute"]);
+        fixture.run(&["run", "--task", "YARD-003", "--execute"]);
+        assert_eq!(task_state(&fixture.root, "YARD-003"), "done");
+
+        for (task_id, expected_runs) in [
+            ("YARD-001", 1),
+            ("YARD-002", 1),
+            ("YARD-003", 2),
+            ("YARD-004", 1),
+        ] {
+            assert_exact_queue_task(&fixture.root, task_id, "YARD-001");
+            let run_dirs = run_dirs_for_task(&fixture.root, task_id);
+            assert_eq!(run_dirs.len(), expected_runs, "{task_id} run count");
+            for run_dir in run_dirs {
+                assert_exact_receipt_pair(&run_dir, "YARD-001");
+            }
+        }
+        let final_review = run_dir_for_task(&fixture.root, "YARD-003");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(
+                &fs::read_to_string(final_review.join("result.json")).unwrap()
+            )
+            .unwrap()["compact_summary"],
+            "pre-dispatch receipt parity observed"
+        );
+    }
+
     #[test]
     fn text_worker_answer_creates_a_new_attempt_and_preserves_both_raw_streams() {
         let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -495,8 +620,9 @@ mod unix {
     #[test]
     fn native_resume_preserves_session_ref_and_answer_causality() {
         let fixture = FixtureWorkspace::new("native-resume");
+        write_exact_codex_workers(&fixture, 0);
         fixture.write_queue(
-            "  - id: YARD-NATIVE\n    title: native worker asks then resumes\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n",
+            "  - id: YARD-NATIVE\n    title: native worker asks then resumes\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n    model: gpt-5.6-sol\n    fallback_enabled: false\n",
         );
 
         fixture.run(&["run", "--task", "YARD-NATIVE", "--execute"]);
@@ -566,6 +692,66 @@ mod unix {
             .iter()
             .any(|text| text.contains("native resumed stdout")));
         assert_eq!(task_state(&fixture.root, "YARD-NATIVE"), "done");
+        assert_exact_queue_task(&fixture.root, "YARD-NATIVE", "YARD-NATIVE");
+        let runs = run_dirs_for_task(&fixture.root, "YARD-NATIVE");
+        assert_eq!(runs.len(), 2);
+        for run_dir in runs {
+            assert_exact_receipt_pair(&run_dir, "YARD-NATIVE");
+        }
+    }
+
+    #[test]
+    fn transient_retry_preserves_exact_model_in_both_receipts() {
+        let fixture = FixtureWorkspace::new("exact-transient-retry");
+        write_exact_codex_workers(&fixture, 1);
+        fixture.write_queue(
+            "  - id: YARD-TRANSIENT\n    title: transient retry exact lineage\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n    model: gpt-5.6-sol\n    fallback_enabled: false\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-TRANSIENT", "--execute"]);
+
+        let run_dir = run_dir_for_task(&fixture.root, "YARD-TRANSIENT");
+        let logs = files_below(&run_dir, ".log")
+            .into_iter()
+            .map(|path| {
+                format!(
+                    "{}:\n{}",
+                    path.display(),
+                    fs::read_to_string(&path).unwrap_or_default()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(
+            task_state(&fixture.root, "YARD-TRANSIENT"),
+            "done",
+            "evaluation:\n{}\nresult:\n{}\nrun:\n{}\nlogs:\n{}",
+            fs::read_to_string(run_dir.join("evaluation.json")).unwrap_or_default(),
+            fs::read_to_string(run_dir.join("result.json")).unwrap_or_default(),
+            fs::read_to_string(run_dir.join("run.yaml")).unwrap_or_default(),
+            logs
+        );
+        assert_exact_queue_task(&fixture.root, "YARD-TRANSIENT", "YARD-TRANSIENT");
+        let channel = channel_dir(&fixture.root, "YARD-TRANSIENT");
+        let attempts = yaml_dir(&channel.join("attempts"));
+        assert_eq!(attempts.len(), 2);
+        assert!(attempts
+            .iter()
+            .any(|attempt| string(attempt, "continuation") == "native_resume"));
+        assert_exact_receipt_pair(&run_dir, "YARD-TRANSIENT");
+        assert_eq!(
+            string(
+                &read_yaml(&run_dir.join("worker-process.yaml")),
+                "attempt_id"
+            ),
+            string(
+                attempts
+                    .iter()
+                    .find(|attempt| string(attempt, "continuation") == "native_resume")
+                    .unwrap(),
+                "attempt_id"
+            )
+        );
     }
 
     #[test]
@@ -839,6 +1025,58 @@ mod unix {
         assert!(!duplicate.status.success());
         fixture.run(&["queue"]);
         assert_eq!(yaml_dir(&channel.join("attempts")), before_restart);
+    }
+
+    #[test]
+    fn redirect_preserves_exact_model_in_queue_and_both_receipts() {
+        let fixture = FixtureWorkspace::new("exact-model-redirect");
+        write_exact_codex_workers(&fixture, 0);
+        fixture.write_queue(
+            "  - id: YARD-EXACT-REDIRECT\n    title: exact redirect lineage\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n    model: gpt-5.6-sol\n    fallback_enabled: false\n",
+        );
+
+        let mut running = Command::new(&fixture.binary)
+            .args(["run", "--task", "YARD-EXACT-REDIRECT", "--execute"])
+            .current_dir(&fixture.root)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let started = wait_until(Duration::from_secs(10), || {
+            task_state(&fixture.root, "YARD-EXACT-REDIRECT") == "running"
+                && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
+                && files_below(&fixture.root.join(".agents/worktrees"), "/handoff.md")
+                    .iter()
+                    .any(|path| {
+                        fs::read_to_string(path)
+                            .is_ok_and(|text| text.contains("checkpoint before exact redirect"))
+                    })
+        });
+        if !started {
+            let _ = running.kill();
+            let output = running.wait_with_output().unwrap();
+            panic!(
+                "exact redirect fixture never reached running\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        fixture.run(&[
+            "redirect",
+            "YARD-EXACT-REDIRECT",
+            "finish exact redirect",
+            "--action-id",
+            "act-exact-model-redirect",
+        ]);
+        assert!(running.wait_with_output().unwrap().status.success());
+        assert_eq!(task_state(&fixture.root, "YARD-EXACT-REDIRECT"), "done");
+        assert_exact_queue_task(&fixture.root, "YARD-EXACT-REDIRECT", "YARD-EXACT-REDIRECT");
+        let runs = run_dirs_for_task(&fixture.root, "YARD-EXACT-REDIRECT");
+        assert_eq!(runs.len(), 2);
+        for run_dir in runs {
+            assert_exact_receipt_pair(&run_dir, "YARD-EXACT-REDIRECT");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #22

## Summary
- inherit the governing worker, exact model, fallback policy, and routing provenance for worker-proposed follow-ups
- persist resolved selection provenance in durable pre-dispatch and post-exit run receipts across serial, parallel, retry, redirect, answer/resume, remediation, and review-rerun paths
- reject lineage conflicts atomically at ingestion and fail closed again at dispatch
- preserve the governing task terminal transition when a proposed follow-up conflicts
- add real-process regression coverage for exact selection and receipt parity

## Verification
- Fable independent review: AC-001 through AC-006 pass; 524 tests passed
- Yardlet YARD-003 follow-up: 527 tests passed
- independent final: `cargo fmt --all -- --check`
- independent final: `cargo clippy --all-targets --all-features -- -D warnings`
- independent final: `cargo test -q` (527 passed, 0 failed)