### PR TITLE
fix: authorize receipted runtime selection overlays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Fixed
 
+- **Receipted preferred-worker failover survives confirmation validation.**
+  Confirmed `model: auto` tasks now resolve a fallback worker's own model from
+  the immutable task contract, while matching run and terminal process receipts
+  authorize the runtime overlay. Manual selection mutations still fail closed,
+  and `yardlet recover` can finalize a completed failover attempt.
+
 - **Serial integration stays bound to trusted evidence.** Worker staging cannot
   replace core-owned cancellation, failover, evaluation, validation, evidence,
   hook, or Git transaction records. Core-staged serial runs use native

--- a/src/run.rs
+++ b/src/run.rs
@@ -1698,6 +1698,12 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         .map(|r| r.worker_id.clone())
         .unwrap_or_else(|_| candidate_id.clone());
     let resolved_selection = resolved.as_ref().ok().map(|resolved| resolved.selection());
+    // Keep the confirmed/runtime-added contract as the failover policy input.
+    // The in-flight task below is stamped with the first effective selection
+    // for packet/receipt parity; resolving failover from that stamped copy
+    // would incorrectly pin an `auto` task to the first worker's model and
+    // provenance instead of producing a fresh policy-authorized selection.
+    let failover_task = task.clone();
     if opts.execute {
         if let Some(selection) = resolved_selection
             .as_ref()
@@ -2194,7 +2200,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             &workers,
             &billing,
             &active_worker_id,
-            &task,
+            &failover_task,
         ) {
             Ok(alt) => {
                 let from = active_worker_id.clone();
@@ -2211,7 +2217,11 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 active_reason = format!("failover from {from} ({})", alt.reason);
                 active_bin = alt.bin;
                 let profile = find_worker(&workers.workers, &active_worker_id)?;
-                eff_profile = workers::effective_profile(profile, &task.model, &task.effort);
+                eff_profile = workers::effective_profile(
+                    profile,
+                    &failover_task.model,
+                    &failover_task.effort,
+                );
                 update_run_selection(&run_dir, &active_selection)?;
                 if worker_run_dir != run_dir.as_path() {
                     update_run_selection(worker_run_dir, &active_selection)?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -659,6 +659,55 @@ impl RunRecord {
     }
 }
 
+pub(crate) fn has_receipted_runtime_selection(
+    ws: &Workspace,
+    intent_id: &str,
+    task_id: &str,
+    selection: &crate::schemas::ResolvedWorkerSelection,
+) -> bool {
+    let Ok(entries) = std::fs::read_dir(ws.runs_dir()) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let run_dir = entry.path();
+        let Some(path_run_id) = run_dir.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        if !path_run_id.starts_with("run-") {
+            return false;
+        }
+        let Ok(record) = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml")) else {
+            return false;
+        };
+        if record.schema_version != 1
+            || record.run_id != path_run_id
+            || record.task_id != task_id
+            || record.intent_id != intent_id
+            || record.started_at.trim().is_empty()
+            || record.resolved_selection().as_ref() != Some(selection)
+        {
+            return false;
+        }
+        let Ok(process) = workers::load_worker_process_provenance(&run_dir) else {
+            return false;
+        };
+        process.schema_version == 1
+            && process.run_id == record.run_id
+            && !process.attempt_id.trim().is_empty()
+            && process.worker_id == selection.worker_id
+            && process.model == selection.model
+            && process.fallback_enabled == selection.fallback_enabled
+            && process.routing_provenance == selection.routing_provenance
+            && process.pid != 0
+            && !process.process_start_marker.trim().is_empty()
+            && process.state == "exited"
+            && process
+                .completed_at
+                .as_deref()
+                .is_some_and(|completed| !completed.trim().is_empty())
+    })
+}
+
 pub(crate) fn update_run_selection(
     run_dir: &std::path::Path,
     selection: &crate::schemas::ResolvedWorkerSelection,
@@ -1655,8 +1704,6 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             .filter(|selection| !selection.model.trim().is_empty())
         {
             apply_selection_to_task(&mut task, selection);
-            queue.tasks[idx] = task.clone();
-            ws.save_queue_locked(&planning_lock, &queue)?;
         }
     }
 
@@ -4326,6 +4373,9 @@ fn finalize_on_latest_queue_locked(
     if let Some(t) = latest.tasks.iter_mut().find(|t| t.id == task_id) {
         let from = t.state;
         t.state = state;
+        if let Some(selection) = governing {
+            apply_selection_to_task(t, selection);
+        }
         let ingested = if let Some(governing) = governing {
             match crate::planner::ingest_follow_ups_with_governing(
                 &mut latest,
@@ -4382,6 +4432,9 @@ fn finalize_on_latest_queue_locked(
             .ok_or_else(|| anyhow!("task {task_id} is missing from fallback queue"))?;
         let from = task.state;
         task.state = state;
+        if let Some(selection) = governing {
+            apply_selection_to_task(task, selection);
+        }
         let ingested = if let Some(governing) = governing {
             match crate::planner::ingest_follow_ups_with_governing(
                 &mut bootstrapped,

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -469,6 +469,7 @@ impl ActivatedQueue {
         &self,
         authorized_runs_before: &std::collections::BTreeMap<String, Vec<String>>,
         authorized_capability_clears: &std::collections::BTreeSet<String>,
+        authorized_selections: &std::collections::BTreeMap<String, ResolvedWorkerSelection>,
     ) -> bool {
         let Some(materialized) = self.materialized_queue.as_ref() else {
             return false;
@@ -529,6 +530,14 @@ impl ActivatedQueue {
                             return false;
                         }
                         runtime.required_capabilities = planned.required_capabilities.clone();
+                    }
+                    if let Some(selection) = authorized_selections.get(&runtime.id) {
+                        let Some(normalized) =
+                            selection.normalized_runtime_overlay(planned, &runtime)
+                        else {
+                            return false;
+                        };
+                        runtime = normalized;
                     }
                     matches!(
                         (
@@ -881,6 +890,73 @@ pub struct ResolvedWorkerSelection {
     pub fallback_enabled: bool,
     #[serde(default)]
     pub routing_provenance: RoutingProvenance,
+}
+
+impl ResolvedWorkerSelection {
+    pub fn from_task(task: &Task) -> Option<Self> {
+        let routing_provenance = task.routing_provenance.clone()?;
+        if task.preferred_worker.trim().is_empty() || task.model.trim().is_empty() {
+            return None;
+        }
+        Some(Self {
+            worker_id: task.preferred_worker.clone(),
+            model: task.model.clone(),
+            fallback_enabled: task.fallback_enabled?,
+            routing_provenance,
+        })
+    }
+
+    pub fn normalized_runtime_overlay(&self, baseline: &Task, runtime: &Task) -> Option<Task> {
+        let provenance = &self.routing_provenance;
+        let baseline_model_is_explicit =
+            !baseline.model.trim().is_empty() && !baseline.model.eq_ignore_ascii_case("auto");
+        let expected_fallback_source = if baseline.fallback_enabled.is_some() {
+            "task.fallback_enabled"
+        } else if baseline.preferred_worker.trim().is_empty() {
+            "routing.unpinned_default"
+        } else {
+            "workspace.routing.allow_preferred_worker_failover"
+        };
+        if baseline.routing_provenance.is_some()
+            || self.worker_id.trim().is_empty()
+            || self.model.trim().is_empty()
+            || runtime.preferred_worker != self.worker_id
+            || runtime.model != self.model
+            || runtime.fallback_enabled != Some(self.fallback_enabled)
+            || runtime.routing_provenance.as_ref() != Some(provenance)
+            || provenance.governing_task_id != baseline.id
+            || provenance.governing_worker_id != self.worker_id
+            || provenance.governing_model != self.model
+            || provenance.governing_fallback_enabled != self.fallback_enabled
+            || provenance.worker_source.trim().is_empty()
+            || provenance.model_source
+                != if baseline_model_is_explicit {
+                    "task.model"
+                } else {
+                    "worker_profile.model"
+                }
+            || provenance.fallback_source != expected_fallback_source
+            || provenance.worker_overridden != (provenance.worker_source == "run override")
+            || provenance.model_overridden != baseline_model_is_explicit
+            || provenance.fallback_overridden != baseline.fallback_enabled.is_some()
+            || (!baseline.preferred_worker.trim().is_empty()
+                && baseline.preferred_worker != self.worker_id
+                && !provenance.worker_overridden)
+            || (baseline_model_is_explicit && baseline.model != self.model)
+            || baseline
+                .fallback_enabled
+                .is_some_and(|fallback| fallback != self.fallback_enabled)
+        {
+            return None;
+        }
+
+        let mut normalized = runtime.clone();
+        normalized.preferred_worker = baseline.preferred_worker.clone();
+        normalized.model = baseline.model.clone();
+        normalized.fallback_enabled = baseline.fallback_enabled;
+        normalized.routing_provenance = baseline.routing_provenance.clone();
+        Some(normalized)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -917,6 +917,8 @@ impl ResolvedWorkerSelection {
         } else {
             "workspace.routing.allow_preferred_worker_failover"
         };
+        let policy_authorized_failover =
+            provenance.worker_source == "failover" && self.fallback_enabled;
         if baseline.routing_provenance.is_some()
             || self.worker_id.trim().is_empty()
             || self.model.trim().is_empty()
@@ -941,7 +943,8 @@ impl ResolvedWorkerSelection {
             || provenance.fallback_overridden != baseline.fallback_enabled.is_some()
             || (!baseline.preferred_worker.trim().is_empty()
                 && baseline.preferred_worker != self.worker_id
-                && !provenance.worker_overridden)
+                && !provenance.worker_overridden
+                && !policy_authorized_failover)
             || (baseline_model_is_explicit && baseline.model != self.model)
             || baseline
                 .fallback_enabled

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,7 +23,7 @@ use crate::schemas::{
     ChannelEvent, ChannelEventType, ContinuationMode, Conversation, ConversationTurn,
     DraftRevision, EventActor, EventActorKind, FollowUpTask, IntentContract, PlanningActionReceipt,
     PlanningEvent, PlanningProposal, PlanningSession, PreservedFollowUps, Question, QuestionState,
-    RedirectActionOutcome, RedirectActionRequest, ResourceActionReceipt,
+    RedirectActionOutcome, RedirectActionRequest, ResolvedWorkerSelection, ResourceActionReceipt,
     ResourceActionRecoveryReceipt, ResourceIndex, ResourceObservation, ResourceStatus,
     ResourceTaskIndex, RuntimeCapabilityCommit, RuntimeCapabilityReceipt, RuntimeResource,
     RuntimeResourceProposal, RuntimeTaskCommit, RuntimeTaskReceipt, SelectionPolicy, Task,
@@ -1023,11 +1023,23 @@ impl Workspace {
         receipt: &RuntimeTaskReceipt,
         dependency_additions: &[String],
         capability_clear: bool,
+        selection: Option<&ResolvedWorkerSelection>,
     ) -> Result<()> {
         self.validate_runtime_task_receipt_identity(queue, task, receipt)?;
         let mut expected_dependencies = receipt.task.depends_on.clone();
         expected_dependencies.extend(dependency_additions.iter().cloned());
-        let mut normalized = task.task.clone();
+        let mut normalized = if let Some(selection) = selection {
+            selection
+                .normalized_runtime_overlay(&receipt.task, &task.task)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "active_runtime_origin_mismatch: task {} has an invalid dispatch selection overlay",
+                        task.task.id
+                    )
+                })?
+        } else {
+            task.task.clone()
+        };
         normalized.depends_on = receipt.task.depends_on.clone();
         if capability_clear {
             if receipt.task.required_capabilities.is_empty()
@@ -1500,6 +1512,29 @@ impl Workspace {
         Ok(baselines)
     }
 
+    fn receipted_runtime_selections(
+        &self,
+        queue: &ActivatedQueue,
+        baselines: &BTreeMap<String, Task>,
+    ) -> BTreeMap<String, ResolvedWorkerSelection> {
+        queue
+            .tasks
+            .iter()
+            .filter_map(|task| {
+                let baseline = baselines.get(&task.task.id)?;
+                let selection = ResolvedWorkerSelection::from_task(&task.task)?;
+                selection.normalized_runtime_overlay(baseline, &task.task)?;
+                crate::run::has_receipted_runtime_selection(
+                    self,
+                    &queue.intent_id,
+                    &task.task.id,
+                    &selection,
+                )
+                .then(|| (task.task.id.clone(), selection))
+            })
+            .collect()
+    }
+
     fn repair_runtime_capability_commits(&self, queue: &ActivatedQueue) -> Result<()> {
         let queue_digest = Self::runtime_queue_digest(queue)?;
         let baselines = self.runtime_contract_baselines(queue)?;
@@ -1645,6 +1680,7 @@ impl Workspace {
         }
         let mut capability_clears = BTreeSet::new();
         let baselines = self.runtime_contract_baselines(queue)?;
+        let authorized_selections = self.receipted_runtime_selections(queue, &baselines);
         for task in &queue.tasks {
             let Some(planned) = baselines.get(&task.task.id) else {
                 continue;
@@ -1699,6 +1735,7 @@ impl Workspace {
                     .map(Vec::as_slice)
                     .unwrap_or(&[]),
                 capability_clears.contains(&task.task.id),
+                authorized_selections.get(&task.task.id),
             )?;
         }
         let confirmed_runs_before = runs_before
@@ -1708,6 +1745,7 @@ impl Workspace {
         if !queue.runtime_envelope_matches_materialized_with_overlays(
             &confirmed_runs_before,
             &capability_clears,
+            &authorized_selections,
         ) {
             bail!(
                 "active_runtime_envelope_mismatch: current tasks differ from immutable confirmed contracts"

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -276,6 +276,94 @@ mod unix {
         .unwrap();
     }
 
+    fn confirm_exact_codex_task(fixture: &FixtureWorkspace) {
+        let planner = fixture.root.join(".agents/fixture-bin/exact-planner.sh");
+        fs::write(
+            &planner,
+            r##"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'exact-planner 1.0\n'
+  exit 0
+fi
+run_dir="$1"
+mkdir -p "$run_dir"
+cat >"$run_dir/planning-result.json" <<'JSON'
+{
+  "summary": "confirmed exact dispatch fixture",
+  "rationale": "exercise resolved selection stamping after confirmation",
+  "allowed_scope": ["src/run.rs"],
+  "out_of_scope": [],
+  "acceptance": [{"statement": "confirmed exact dispatch completes"}],
+  "ambiguity": {"score": "low", "open_questions": []},
+  "tasks": [{
+    "id": "YARD-EXACT-CONFIRMED",
+    "title": "exact lineage remediation from confirmed plan",
+    "kind": "implementation",
+    "risk": "low",
+    "preferred_worker": "codex",
+    "model": "auto",
+    "fallback_enabled": false,
+    "effort": "auto",
+    "depends_on": [],
+    "skills": [],
+    "required_capabilities": [],
+    "allowed_scope": ["src/run.rs"],
+    "acceptance": ["confirmed exact dispatch completes"],
+    "worker_rationale": "deterministic exact dispatch fixture"
+  }],
+  "questions_for_user": []
+}
+JSON
+"##,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&planner).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&planner, permissions).unwrap();
+        fs::write(
+            fixture.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture-planner\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-planner\n  fallback_order: [fixture-planner]\n  planning_gate:\n    primary: fixture-planner\n    fallback: \"\"\n",
+                planner.display()
+            ),
+        )
+        .unwrap();
+
+        fixture.run(&[
+            "new",
+            "confirmed exact dispatch fixture",
+            "--worker",
+            "fixture-planner",
+        ]);
+        let show = fixture.run(&["planning", "show", "--json"]);
+        let projection: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+        let proposal = projection["pending_proposals"][0]["proposal_id"]
+            .as_str()
+            .unwrap();
+        fixture.run(&[
+            "planning",
+            "accept",
+            proposal,
+            "--expected-head",
+            "none",
+            "--action-id",
+            "act-exact-dispatch-accept",
+        ]);
+        let show = fixture.run(&["planning", "show", "--json"]);
+        let projection: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+        let head = projection["session"]["current_head"].as_str().unwrap();
+        fixture.run(&[
+            "planning",
+            "confirm",
+            "--expected-head",
+            head,
+            "--action-id",
+            "act-exact-dispatch-confirm",
+        ]);
+        write_exact_codex_workers(fixture, 0);
+    }
+
     fn run_dirs_for_task(root: &Path, task_id: &str) -> Vec<PathBuf> {
         files_below(&root.join(".agents/runs"), "/run.yaml")
             .into_iter()
@@ -324,6 +412,108 @@ mod unix {
             string(&task["routing_provenance"], "governing_task_id"),
             governing_task_id
         );
+    }
+
+    fn mutate_queue_selection(root: &Path, task_id: &str, field: &str) {
+        let path = root.join(".agents/work-queue.yaml");
+        let mut queue = read_yaml(&path);
+        let task = queue["tasks"]
+            .as_sequence_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|task| string(task, "id") == task_id)
+            .unwrap_or_else(|| panic!("queue task {task_id} not found"));
+        match field {
+            "worker" => task["preferred_worker"] = Value::String("claude-code".into()),
+            "model" => task["model"] = Value::String("fable".into()),
+            "fallback" => task["fallback_enabled"] = Value::Bool(true),
+            "provenance" => {
+                task["routing_provenance"]["model_source"] = Value::String("manual".into())
+            }
+            _ => panic!("unknown selection field {field}"),
+        }
+        fs::write(path, serde_yaml_ng::to_string(&queue).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn confirmed_exact_dispatch_stamps_receipted_selection_and_completes() {
+        let fixture = FixtureWorkspace::new("confirmed-exact-dispatch");
+        confirm_exact_codex_task(&fixture);
+
+        fixture.run(&["run", "--task", "YARD-EXACT-CONFIRMED", "--execute"]);
+
+        assert_eq!(task_state(&fixture.root, "YARD-EXACT-CONFIRMED"), "done");
+        assert_exact_queue_task(
+            &fixture.root,
+            "YARD-EXACT-CONFIRMED",
+            "YARD-EXACT-CONFIRMED",
+        );
+        let run_dir = run_dir_for_task(&fixture.root, "YARD-EXACT-CONFIRMED");
+        assert_exact_receipt_pair(&run_dir, "YARD-EXACT-CONFIRMED");
+        let show = fixture.run(&["planning", "show", "--json"]);
+        let projection: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+        assert_eq!(projection["exact_active_parity"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn confirmed_runtime_addition_stamps_the_same_receipted_exact_selection() {
+        let fixture = FixtureWorkspace::new("confirmed-runtime-exact-dispatch");
+        confirm_exact_codex_task(&fixture);
+        fixture.run(&[
+            "add",
+            "exact lineage remediation runtime addition",
+            "--worker",
+            "codex",
+            "--scope",
+            "src/run.rs",
+        ]);
+        let queue = read_yaml(&fixture.root.join(".agents/work-queue.yaml"));
+        let task_id = queue["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| string(task, "title") == "exact lineage remediation runtime addition")
+            .map(|task| string(task, "id").to_string())
+            .expect("runtime-added task must be materialized");
+
+        fixture.run(&["run", "--task", &task_id, "--execute"]);
+
+        assert_eq!(task_state(&fixture.root, &task_id), "done");
+        assert_exact_queue_task(&fixture.root, &task_id, &task_id);
+        let run_dir = run_dir_for_task(&fixture.root, &task_id);
+        assert_exact_receipt_pair(&run_dir, &task_id);
+    }
+
+    #[test]
+    fn manual_selection_mutations_remain_fail_closed_after_receipted_dispatch() {
+        let fixture = FixtureWorkspace::new("confirmed-exact-dispatch-mutation");
+        confirm_exact_codex_task(&fixture);
+        fixture.run(&["run", "--task", "YARD-EXACT-CONFIRMED", "--execute"]);
+        let queue_path = fixture.root.join(".agents/work-queue.yaml");
+        let valid_queue = fs::read_to_string(&queue_path).unwrap();
+
+        for field in ["worker", "model", "fallback", "provenance"] {
+            fs::write(&queue_path, &valid_queue).unwrap();
+            mutate_queue_selection(&fixture.root, "YARD-EXACT-CONFIRMED", field);
+            let tampered = fs::read_to_string(&queue_path).unwrap();
+            let output = command(&fixture.root, &fixture.binary, &["queue"]);
+            assert!(
+                !output.status.success(),
+                "manual {field} mutation unexpectedly passed"
+            );
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                stderr.contains("active_runtime_envelope_mismatch")
+                    || stderr.contains("active_runtime_origin_mismatch"),
+                "manual {field} mutation returned the wrong failure: {stderr}"
+            );
+            assert_eq!(
+                fs::read_to_string(&queue_path).unwrap(),
+                tampered,
+                "manual {field} rejection changed canonical queue bytes"
+            );
+        }
+        fs::write(queue_path, valid_queue).unwrap();
     }
 
     #[test]

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -364,6 +364,149 @@ JSON
         write_exact_codex_workers(fixture, 0);
     }
 
+    fn confirm_policy_failover_task(fixture: &FixtureWorkspace) {
+        let planner = fixture.root.join(".agents/fixture-bin/failover-planner.sh");
+        fs::write(
+            &planner,
+            r##"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'failover-planner 1.0\n'
+  exit 0
+fi
+run_dir="$1"
+mkdir -p "$run_dir"
+cat >"$run_dir/planning-result.json" <<'JSON'
+{
+  "summary": "confirmed policy failover fixture",
+  "rationale": "exercise receipt-bound failover selection after confirmation",
+  "allowed_scope": ["src/run.rs"],
+  "out_of_scope": [],
+  "acceptance": [{"statement": "policy-authorized failover completes"}],
+  "ambiguity": {"score": "low", "open_questions": []},
+  "tasks": [{
+    "id": "YARD-FAILOVER",
+    "title": "policy-authorized worker failover",
+    "kind": "implementation",
+    "risk": "low",
+    "preferred_worker": "fixture-primary",
+    "model": "auto",
+    "effort": "auto",
+    "depends_on": [],
+    "skills": [],
+    "required_capabilities": [],
+    "allowed_scope": ["src/run.rs"],
+    "acceptance": ["policy-authorized failover completes"],
+    "worker_rationale": "deterministic failover fixture"
+  }],
+  "questions_for_user": []
+}
+JSON
+"##,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&planner).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&planner, permissions).unwrap();
+        fs::write(
+            fixture.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture-planner\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-planner\n  fallback_order: [fixture-planner]\n  planning_gate:\n    primary: fixture-planner\n    fallback: \"\"\n",
+                planner.display()
+            ),
+        )
+        .unwrap();
+
+        fixture.run(&[
+            "new",
+            "confirmed policy failover fixture",
+            "--worker",
+            "fixture-planner",
+        ]);
+        let show = fixture.run(&["planning", "show", "--json"]);
+        let projection: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+        let proposal = projection["pending_proposals"][0]["proposal_id"]
+            .as_str()
+            .unwrap();
+        fixture.run(&[
+            "planning",
+            "accept",
+            proposal,
+            "--expected-head",
+            "none",
+            "--action-id",
+            "act-failover-accept",
+        ]);
+        let show = fixture.run(&["planning", "show", "--json"]);
+        let projection: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
+        let head = projection["session"]["current_head"].as_str().unwrap();
+        fixture.run(&[
+            "planning",
+            "confirm",
+            "--expected-head",
+            head,
+            "--action-id",
+            "act-failover-confirm",
+        ]);
+    }
+
+    fn write_policy_failover_workers(fixture: &FixtureWorkspace) {
+        let primary = fixture.root.join(".agents/fixture-bin/no-result-worker.sh");
+        fs::write(
+            &primary,
+            r##"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'no-result-worker 1.0\n'
+  exit 0
+fi
+cat >/dev/null
+printf 'primary intentionally omitted result.json\n' >&2
+"##,
+        )
+        .unwrap();
+        let fallback = fixture.root.join(".agents/fixture-bin/done-worker.sh");
+        fs::write(
+            &fallback,
+            r##"#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'done-worker 1.0\n'
+  exit 0
+fi
+run_dir="${1:?run directory is required}"
+cat >/dev/null
+run_id="${run_dir##*/}"
+task_id="$(sed -n 's/^task_id: //p' "$run_dir/run.yaml" | head -n 1)"
+cat >"$run_dir/result.json" <<JSON
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "$task_id",
+  "status": "done",
+  "compact_summary": "policy-authorized failover completed"
+}
+JSON
+printf '# Handoff\n\nPolicy-authorized failover completed.\n' >"$run_dir/handoff.md"
+"##,
+        )
+        .unwrap();
+        for worker in [&primary, &fallback] {
+            let mut permissions = fs::metadata(worker).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(worker, permissions).unwrap();
+        }
+        fs::write(
+            fixture.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
+                primary.display(),
+                fallback.display()
+            ),
+        )
+        .unwrap();
+    }
+
     fn run_dirs_for_task(root: &Path, task_id: &str) -> Vec<PathBuf> {
         files_below(&root.join(".agents/runs"), "/run.yaml")
             .into_iter()
@@ -414,6 +557,46 @@ JSON
         );
     }
 
+    fn assert_policy_failover_selection(root: &Path) {
+        let queue = read_yaml(&root.join(".agents/work-queue.yaml"));
+        let task = queue["tasks"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|task| string(task, "id") == "YARD-FAILOVER")
+            .expect("failover task missing from queue");
+        assert_eq!(string(task, "preferred_worker"), "fixture-fallback");
+        assert_eq!(string(task, "model"), "fallback-model");
+        assert_eq!(task["fallback_enabled"].as_bool(), Some(true));
+        assert_eq!(
+            string(&task["routing_provenance"], "worker_source"),
+            "failover"
+        );
+        assert_eq!(
+            string(&task["routing_provenance"], "fallback_source"),
+            "workspace.routing.allow_preferred_worker_failover"
+        );
+
+        let run_dir = run_dir_for_task(root, "YARD-FAILOVER");
+        let run = read_yaml(&run_dir.join("run.yaml"));
+        let process = read_yaml(&run_dir.join("worker-process.yaml"));
+        assert_eq!(string(&process, "state"), "exited");
+        for receipt in [&run, &process] {
+            let worker_key = if std::ptr::eq(receipt, &run) {
+                "worker"
+            } else {
+                "worker_id"
+            };
+            assert_eq!(string(receipt, worker_key), "fixture-fallback");
+            assert_eq!(string(receipt, "model"), "fallback-model");
+            assert_eq!(receipt["fallback_enabled"].as_bool(), Some(true));
+            assert_eq!(
+                string(&receipt["routing_provenance"], "worker_source"),
+                "failover"
+            );
+        }
+    }
+
     fn mutate_queue_selection(root: &Path, task_id: &str, field: &str) {
         let path = root.join(".agents/work-queue.yaml");
         let mut queue = read_yaml(&path);
@@ -426,7 +609,10 @@ JSON
         match field {
             "worker" => task["preferred_worker"] = Value::String("claude-code".into()),
             "model" => task["model"] = Value::String("fable".into()),
-            "fallback" => task["fallback_enabled"] = Value::Bool(true),
+            "fallback" => {
+                task["fallback_enabled"] =
+                    Value::Bool(!task["fallback_enabled"].as_bool().unwrap_or(false))
+            }
             "provenance" => {
                 task["routing_provenance"]["model_source"] = Value::String("manual".into())
             }
@@ -453,6 +639,145 @@ JSON
         let show = fixture.run(&["planning", "show", "--json"]);
         let projection: serde_json::Value = serde_json::from_slice(&show.stdout).unwrap();
         assert_eq!(projection["exact_active_parity"].as_bool(), Some(true));
+    }
+
+    #[test]
+    fn policy_authorized_failover_serial_dispatch_is_receipted_and_mutations_fail_closed() {
+        let fixture = FixtureWorkspace::new("confirmed-policy-failover");
+        confirm_policy_failover_task(&fixture);
+        write_policy_failover_workers(&fixture);
+
+        let output = command(
+            &fixture.root,
+            &fixture.binary,
+            &["run", "--task", "YARD-FAILOVER", "--execute"],
+        );
+        if !output.status.success() {
+            let run_dir = run_dir_for_task(&fixture.root, "YARD-FAILOVER");
+            panic!(
+                "failover dispatch failed\nstderr:\n{}\nqueue:\n{}\nrun:\n{}\nprocess:\n{}",
+                String::from_utf8_lossy(&output.stderr),
+                fs::read_to_string(fixture.root.join(".agents/work-queue.yaml")).unwrap(),
+                fs::read_to_string(run_dir.join("run.yaml")).unwrap(),
+                fs::read_to_string(run_dir.join("worker-process.yaml")).unwrap(),
+            );
+        }
+
+        assert_eq!(task_state(&fixture.root, "YARD-FAILOVER"), "done");
+        assert_policy_failover_selection(&fixture.root);
+        let queue_path = fixture.root.join(".agents/work-queue.yaml");
+        let valid_queue = fs::read_to_string(&queue_path).unwrap();
+        for field in ["worker", "model", "fallback", "provenance"] {
+            fs::write(&queue_path, &valid_queue).unwrap();
+            mutate_queue_selection(&fixture.root, "YARD-FAILOVER", field);
+            let tampered = fs::read_to_string(&queue_path).unwrap();
+            let output = command(&fixture.root, &fixture.binary, &["queue"]);
+            assert!(
+                !output.status.success(),
+                "manual failover {field} mutation unexpectedly passed"
+            );
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            assert!(
+                stderr.contains("active_runtime_envelope_mismatch")
+                    || stderr.contains("active_runtime_origin_mismatch"),
+                "manual failover {field} mutation returned the wrong failure: {stderr}"
+            );
+            assert_eq!(
+                fs::read_to_string(&queue_path).unwrap(),
+                tampered,
+                "manual failover {field} rejection changed canonical queue bytes"
+            );
+        }
+        fs::write(queue_path, valid_queue).unwrap();
+    }
+
+    #[test]
+    fn policy_authorized_failover_recover_finalizes_receipted_orphan() {
+        let fixture = FixtureWorkspace::new("confirmed-policy-failover-recover");
+        confirm_policy_failover_task(&fixture);
+        write_policy_failover_workers(&fixture);
+        let config_path = fixture.root.join(".agents/yardlet.yaml");
+        let mut config = read_yaml(&config_path);
+        config["auto_commit"] = Value::Bool(true);
+        fs::write(config_path, serde_yaml_ng::to_string(&config).unwrap()).unwrap();
+        let hooks = fixture.root.join(".agents/hooks/post-run.d");
+        fs::create_dir_all(&hooks).unwrap();
+        let hook = hooks.join("00-pause-before-finalize.sh");
+        fs::write(
+            &hook,
+            r##"#!/usr/bin/env bash
+set -euo pipefail
+touch .agents/failover-hook-entered
+for _ in $(seq 1 400); do
+  if [[ -f .agents/failover-hook-release ]]; then
+    touch .agents/failover-hook-exited
+    exit 0
+  fi
+  sleep 0.05
+done
+exit 1
+"##,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&hook).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&hook, permissions).unwrap();
+
+        let mut running = Command::new(&fixture.binary)
+            .args(["run", "--task", "YARD-FAILOVER", "--execute"])
+            .current_dir(&fixture.root)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        assert!(
+            wait_until(Duration::from_secs(10), || {
+                if !fixture.root.join(".agents/failover-hook-entered").is_file() {
+                    return false;
+                }
+                let Some(run_dir) = run_dirs_for_task(&fixture.root, "YARD-FAILOVER")
+                    .into_iter()
+                    .max()
+                else {
+                    return false;
+                };
+                run_dir.join("result.json").is_file()
+                    && run_dir.join("worker-process.yaml").is_file()
+                    && string(&read_yaml(&run_dir.join("worker-process.yaml")), "state") == "exited"
+                    && task_state(&fixture.root, "YARD-FAILOVER") == "running"
+            }),
+            "failover worker did not reach the receipted pre-finalize crash window"
+        );
+        running.kill().unwrap();
+        running.wait().unwrap();
+        fs::write(
+            fixture.root.join(".agents/failover-hook-release"),
+            "release\n",
+        )
+        .unwrap();
+        assert!(wait_until(Duration::from_secs(3), || fixture
+            .root
+            .join(".agents/failover-hook-exited")
+            .is_file()));
+
+        let recovered = fixture.run(&["recover"]);
+
+        assert!(
+            !String::from_utf8_lossy(&recovered.stdout).contains("recovery finalize error"),
+            "recover rejected the receipted failover selection: {}",
+            String::from_utf8_lossy(&recovered.stdout)
+        );
+        let recovered_state = task_state(&fixture.root, "YARD-FAILOVER");
+        if recovered_state != "done" {
+            let run_dir = run_dir_for_task(&fixture.root, "YARD-FAILOVER");
+            panic!(
+                "recover left failover task {recovered_state}\nstdout:\n{}\npartial-reason:\n{}\nrun:\n{}",
+                String::from_utf8_lossy(&recovered.stdout),
+                fs::read_to_string(run_dir.join("partial-reason")).unwrap_or_default(),
+                fs::read_to_string(run_dir.join("run.yaml")).unwrap(),
+            );
+        }
+        assert_policy_failover_selection(&fixture.root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the confirmed task as the immutable runtime-envelope baseline
- permit only receipt-bound dispatch selection overlays for exact run overrides and policy-authorized failover
- stamp failover with a fresh effective worker/model/provenance selection instead of carrying the initial selection forward
- keep manual worker, model, fallback, and provenance mutations fail-closed
- cover serial dispatch and orphan recovery with process-level regression tests

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -q`
- independent Fable review: pass

Closes #27