### PR TITLE
fix: preserve manual reviews and worker handoffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Fixed
 
+- **Passing reviews remain resolvable when auto-commit is disabled.** A review
+  whose structured verdict and validation pass now stays `Partial` for manual
+  integration instead of being reclassified as a failed review with no
+  remediation. Actual failed verdicts still enter remediation or stop with a
+  concrete, actionable `NeedsUser` question.
+
 - **Receipted preferred-worker failover survives confirmation validation.**
   Confirmed `model: auto` tasks now resolve a fallback worker's own model from
   the immutable task contract, while matching run and terminal process receipts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Fixed
 
+- **Worker-authored handoffs survive finalization.** Evaluator checks and the
+  compact result summary now go to `evaluator-summary.md` instead of replacing
+  the worker's `handoff.md`; integration and non-blocking follow-up notes still
+  append to the preserved worker handoff.
+
 - **Passing reviews remain resolvable when auto-commit is disabled.** A review
   whose structured verdict and validation pass now stays `Partial` for manual
   integration instead of being reclassified as a failed review with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
   handoff stays `false`, captured before the fallback writer can create the
   file.
 
+- **A failover-note-only handoff no longer passes as worker output.** The
+  failover note is appended with create-if-missing semantics, so a run where
+  the worker never wrote `handoff.md` could leave a core-authored note file
+  classified `worker_authored=true`. Classification now reads the content: a
+  handoff holding only `## Worker failover` sections is recorded
+  `worker_authored=false`, while a worker-authored handoff keeps `true` after
+  the note is appended.
+
 - **Passing reviews remain resolvable when auto-commit is disabled.** A review
   whose structured verdict and validation pass now stays `Partial` for manual
   integration instead of being reclassified as a failed review with no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
   the worker's `handoff.md`; integration and non-blocking follow-up notes still
   append to the preserved worker handoff.
 
+- **Finalization artifact records classify the real handoff author.** The
+  `handoff.md` artifact entry is no longer hard-coded `worker_authored=false`:
+  a worker-authored handoff is classified `true` and an evaluator-fallback
+  handoff stays `false`, captured before the fallback writer can create the
+  file.
+
 - **Passing reviews remain resolvable when auto-commit is disabled.** A review
   whose structured verdict and validation pass now stays `Partial` for manual
   integration instead of being reclassified as a failed review with no

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -84,8 +84,8 @@ pub fn write_checkpoint(
     Ok(())
 }
 
-/// Write `handoff.md` for humans and future workers.
-pub fn write_handoff(
+/// Write the evaluator-owned summary without replacing a worker-authored handoff.
+pub fn write_evaluator_summary(
     run_dir: &Path,
     task: &Task,
     eval: &Evaluation,
@@ -134,7 +134,11 @@ pub fn write_handoff(
         task_state_marker(eval.next_task_state)
     ));
 
-    write_str(&run_dir.join("handoff.md"), &md)?;
+    write_str(&run_dir.join("evaluator-summary.md"), &md)?;
+    let handoff_path = run_dir.join("handoff.md");
+    if !handoff_path.exists() {
+        write_str(&handoff_path, &md)?;
+    }
     Ok(())
 }
 

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::packet::{self, PacketInputs};
 use crate::schemas::{RunnableClass, Task, TaskState, WorkQueue, WorkerProfile};
-use crate::state::{self, append_str, write_str, Workspace};
+use crate::state::{self, write_str, Workspace};
 use crate::{evaluator, guard, inspect, routing, run, workers};
 
 fn is_verifier(task: &Task) -> bool {
@@ -740,7 +740,7 @@ pub fn run_batch<F: FnMut(&str)>(
         };
         let next = report.next_state;
         if let Some(note) = &failover_note {
-            if let Err(e) = append_failover_note(&p.run_dir, note) {
+            if let Err(e) = run::append_failover_note(&p.run_dir, note) {
                 on_event(&format!(
                     "{}: failed to append failover note: {e}",
                     p.task.id
@@ -769,15 +769,6 @@ fn record_failover(run_dir: &Path, from: &str, to: &str, reason: &str) {
         &run_dir.join("failover.json"),
         &serde_json::to_string_pretty(&event).unwrap_or_default(),
     );
-}
-
-fn append_failover_note(run_dir: &Path, note: &str) -> Result<()> {
-    let mut md = String::from("\n## Worker failover\n\n");
-    md.push_str(note);
-    md.push('\n');
-    append_str(&run_dir.join("checkpoint.md"), &md)?;
-    append_str(&run_dir.join("handoff.md"), &md)?;
-    Ok(())
 }
 
 pub(crate) enum Integration {
@@ -3267,6 +3258,47 @@ exit 0
 
         sh_git(&wt, &["checkout", "-q", branch]);
         remove_worktree(&root, &wt, branch);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn parallel_failover_note_only_handoff_stays_core_authored() {
+        // The parallel path appends its failover note through the shared core
+        // helper (run::append_failover_note); a handoff.md holding nothing but
+        // those appended sections must be classified worker_authored=false at
+        // finalization, exactly like the serial path.
+        let root = std::env::temp_dir().join(format!(
+            "yard-parallel-failover-note-only-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        // Both note shapes the parallel path emits.
+        run::append_failover_note(
+            &root,
+            "worker failover: codex -> claude-code; codex exited without result.json",
+        )
+        .unwrap();
+        run::append_failover_note(
+            &root,
+            "worker failover unavailable after claude-code exited without result.json: \
+             no ready worker",
+        )
+        .unwrap();
+        assert!(root.join("handoff.md").is_file());
+
+        let entries = run::plan_finalization_artifact_entries(&root);
+        let handoff_worker_authored = entries
+            .iter()
+            .find(|(name, _, _)| *name == "handoff.md")
+            .map(|(_, _, worker_authored)| *worker_authored)
+            .expect("missing handoff.md finalization entry");
+        assert!(
+            !handoff_worker_authored,
+            "a note-only handoff.md written by the parallel failover path must be \
+             recorded worker_authored=false"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -5018,6 +5018,7 @@ fn record_finalization_artifacts(
     for (name, role, worker_authored) in [
         ("result.json", "worker_result", true),
         ("evaluation.json", "evaluation", false),
+        ("evaluator-summary.md", "evaluation", false),
         ("checkpoint.md", "checkpoint", false),
         ("handoff.md", "handoff", false),
     ] {
@@ -5305,7 +5306,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
 
     if flags.artifacts {
         compact::write_checkpoint(run_dir, task, &eval, result.as_ref(), intent_summary)?;
-        compact::write_handoff(run_dir, task, &eval, result.as_ref())?;
+        compact::write_evaluator_summary(run_dir, task, &eval, result.as_ref())?;
         if let Some(r) = &result {
             append_nonblocking_follow_up_notes(run_dir, r)?;
         }
@@ -11708,10 +11709,13 @@ exit 1
         }));
 
         let checkpoint = std::fs::read_to_string(run_dir.join("checkpoint.md")).unwrap();
+        let evaluator_summary =
+            std::fs::read_to_string(run_dir.join("evaluator-summary.md")).unwrap();
         let handoff = std::fs::read_to_string(run_dir.join("handoff.md")).unwrap();
-        for text in [checkpoint, handoff] {
+        for text in [checkpoint, evaluator_summary] {
             assert!(text.contains(question));
         }
+        assert_eq!(handoff, "# Worker handoff\n");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -4902,9 +4902,13 @@ fn feedback_question(task: &crate::schemas::Task, feedback: &FeedbackRecord) -> 
 
 fn review_without_remediation_question(task: &crate::schemas::Task) -> String {
     format!(
-        "`{}` 리뷰가 통과하지 못했고 실행 가능한 수정 작업이 없습니다. 어떤 수정 또는 판정으로 이어갈까요?",
+        "`{}` 리뷰가 통과하지 못했고 실행 가능한 수정 작업이 없습니다. 수정 작업을 큐에 추가한 뒤 리뷰를 재실행하거나 현재 판정을 수동으로 확정해 주세요. 어느 조치로 이어갈까요?",
         task.id
     )
+}
+
+fn review_evaluation_failed(is_review: bool, evaluated_state: TaskState) -> bool {
+    is_review && matches!(evaluated_state, TaskState::Failed | TaskState::Partial)
 }
 
 fn artifact_content_digest(bytes: &[u8]) -> String {
@@ -5278,6 +5282,12 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         ));
         next_state = TaskState::Done;
     }
+    // Preserve the worker/evaluator outcome before Git integration can turn a
+    // passing Done into a manual-integration Partial. Review remediation is
+    // about failed review evidence, not a later delivery hold.
+    let evaluated_state = next_state;
+    let is_review = matches!(crate::packet::role_for(&task.kind), "reviewer" | "security");
+    let review_failed = review_evaluation_failed(is_review, evaluated_state);
 
     let mut persisted_question = if next_state == TaskState::NeedsUser {
         let (question, actor_kind) = question_to_persist.get_or_insert_with(|| {
@@ -5598,7 +5608,6 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     // not ingest new follow-ups or re-queue a review, which would rewrite the
     // queue graph during a crash-recovery pass.
     let queue_lock = ws.acquire_planning_lock()?;
-    let is_review = matches!(crate::packet::role_for(&task.kind), "reviewer" | "security");
     let mut follow_ups = if flags.follow_ups && next_state != TaskState::NeedsUser {
         result
             .as_ref()
@@ -5671,15 +5680,12 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     // overwrite next_state to Queued/NeedsUser — telemetry must record what the
     // run actually evaluated to (a failed review), not the queue-management
     // decision, or the trust report would not see the failure.
-    let evaluated_state = next_state;
-
     // Review auto-remediation (1c): a review that failed its criteria must not
     // blind-loop on the same unchanged code. Re-queue THIS review to run AFTER the
     // reviewer's proposed remediation (soft priority ordering, no hard dep) so the
     // fix runs first and the review then re-verifies; the persisted feedback cap
     // bounds the cycles across serial, parallel, and resumed drains.
-    if flags.follow_ups && is_review && matches!(next_state, TaskState::Failed | TaskState::Partial)
-    {
+    if flags.follow_ups && review_failed {
         // Sequence behind fixes in the runnable graph (Queued && deps_met),
         // including approval-gated fixes. With no such remediation, surface to
         // the user instead.

--- a/src/run.rs
+++ b/src/run.rs
@@ -5054,7 +5054,7 @@ fn handoff_is_failover_note_only(content: &str) -> bool {
 /// one, so the real author is only readable from the pre-writer run directory.
 /// A handoff.md holding only the core failover note is classified core-authored
 /// even though the file exists — see `handoff_is_worker_authored`.
-fn plan_finalization_artifact_entries(
+pub(crate) fn plan_finalization_artifact_entries(
     run_dir: &std::path::Path,
 ) -> [(&'static str, &'static str, bool); 5] {
     let handoff_worker_authored = handoff_is_worker_authored(&run_dir.join("handoff.md"));
@@ -6191,7 +6191,10 @@ fn record_failover(run_dir: &std::path::Path, from: &str, to: &str, reason: &str
     );
 }
 
-fn append_failover_note(run_dir: &std::path::Path, note: &str) -> Result<()> {
+/// Shared by the serial and parallel failover paths so the appended heading
+/// can never drift from `WORKER_FAILOVER_HEADING` and the authorship
+/// classifier (`handoff_is_worker_authored`).
+pub(crate) fn append_failover_note(run_dir: &std::path::Path, note: &str) -> Result<()> {
     let mut md = format!("\n## {WORKER_FAILOVER_HEADING}\n\n");
     md.push_str(note);
     md.push('\n');

--- a/src/run.rs
+++ b/src/run.rs
@@ -4997,8 +4997,29 @@ fn record_artifact_created(
         &proposal,
         &path.display().to_string(),
     )?;
+    // ArtifactProposal and the artifact.created payload have no authorship
+    // field yet, so the classification cannot be persisted here; callers keep
+    // it correct for the provenance consumer that will add that field.
     let _ = worker_authored;
     Ok(())
+}
+
+/// Classify the finalization artifacts to record for `run_dir`.
+///
+/// Must run BEFORE `compact::write_evaluator_summary`: that writer creates
+/// `handoff.md` as an evaluator fallback only when the worker did not author
+/// one, so the real author is only readable from the pre-writer run directory.
+fn plan_finalization_artifact_entries(
+    run_dir: &std::path::Path,
+) -> [(&'static str, &'static str, bool); 5] {
+    let handoff_worker_authored = run_dir.join("handoff.md").is_file();
+    [
+        ("result.json", "worker_result", true),
+        ("evaluation.json", "evaluation", false),
+        ("evaluator-summary.md", "evaluation", false),
+        ("checkpoint.md", "checkpoint", false),
+        ("handoff.md", "handoff", handoff_worker_authored),
+    ]
 }
 
 fn record_finalization_artifacts(
@@ -5007,6 +5028,7 @@ fn record_finalization_artifacts(
     run_dir: &std::path::Path,
     worker_root: &std::path::Path,
     result: Option<&RunResult>,
+    entries: [(&'static str, &'static str, bool); 5],
 ) -> Result<()> {
     let Some(attempt_id) = std::fs::read_to_string(run_dir.join("latest-attempt"))
         .ok()
@@ -5015,13 +5037,7 @@ fn record_finalization_artifacts(
     else {
         return Ok(());
     };
-    for (name, role, worker_authored) in [
-        ("result.json", "worker_result", true),
-        ("evaluation.json", "evaluation", false),
-        ("evaluator-summary.md", "evaluation", false),
-        ("checkpoint.md", "checkpoint", false),
-        ("handoff.md", "handoff", false),
-    ] {
+    for (name, role, worker_authored) in entries {
         let path = run_dir.join(name);
         let recorded_path = path
             .strip_prefix(&ws.root)
@@ -5304,6 +5320,9 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         None
     };
 
+    // Plan artifact classification before the evaluator writers run: past this
+    // point a missing handoff.md may be filled in by the evaluator fallback.
+    let finalization_entries = plan_finalization_artifact_entries(run_dir);
     if flags.artifacts {
         compact::write_checkpoint(run_dir, task, &eval, result.as_ref(), intent_summary)?;
         compact::write_evaluator_summary(run_dir, task, &eval, result.as_ref())?;
@@ -5316,7 +5335,14 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         .as_ref()
         .map(|merge| merge.wt_path)
         .unwrap_or(ws.root.as_path());
-    record_finalization_artifacts(ws, &artifact_context, run_dir, worker_root, result.as_ref())?;
+    record_finalization_artifacts(
+        ws,
+        &artifact_context,
+        run_dir,
+        worker_root,
+        result.as_ref(),
+        finalization_entries,
+    )?;
 
     // Harness learning loop (S3): record skills/rules the worker proposed. The
     // worker authored the content; Yardlet (the core) does the writing.
@@ -6417,6 +6443,72 @@ mod tests {
             finalization_artifact_causation(&events, attempt_id),
             Some("evt-validation".to_string())
         );
+    }
+
+    fn planned_worker_authored(entries: &[(&'static str, &'static str, bool)], name: &str) -> bool {
+        entries
+            .iter()
+            .find(|(entry_name, _, _)| *entry_name == name)
+            .unwrap_or_else(|| panic!("missing finalization artifact entry {name}"))
+            .2
+    }
+
+    #[test]
+    fn finalization_plan_marks_worker_authored_handoff() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-handoff-worker-authored-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        write_str(&root.join("handoff.md"), "# Worker handoff\n").unwrap();
+
+        let entries = plan_finalization_artifact_entries(&root);
+        assert!(
+            planned_worker_authored(&entries, "handoff.md"),
+            "a handoff.md the worker wrote must be recorded worker_authored=true"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn finalization_plan_marks_evaluator_fallback_handoff() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-handoff-evaluator-fallback-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        let entries = plan_finalization_artifact_entries(&root);
+        assert!(
+            !planned_worker_authored(&entries, "handoff.md"),
+            "an evaluator-fallback handoff.md must be recorded worker_authored=false"
+        );
+        assert!(planned_worker_authored(&entries, "result.json"));
+        for core_owned in ["evaluation.json", "evaluator-summary.md", "checkpoint.md"] {
+            assert!(!planned_worker_authored(&entries, core_owned));
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn finalization_plan_is_fixed_before_evaluator_fallback_write() {
+        // finalize_run plans the artifact classification BEFORE
+        // compact::write_evaluator_summary can create the fallback handoff.md;
+        // a fallback appearing afterwards must not flip the classification.
+        let root =
+            std::env::temp_dir().join(format!("yard-handoff-plan-order-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        let entries = plan_finalization_artifact_entries(&root);
+        write_str(&root.join("handoff.md"), "# Handoff: fallback copy\n").unwrap();
+        assert!(
+            !planned_worker_authored(&entries, "handoff.md"),
+            "classification captured pre-fallback must stay worker_authored=false"
+        );
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -5004,15 +5004,60 @@ fn record_artifact_created(
     Ok(())
 }
 
+/// Heading of the core-appended failover section. Shared by the writer
+/// (`append_failover_note`) and the authorship classifier so they cannot
+/// drift apart.
+const WORKER_FAILOVER_HEADING: &str = "Worker failover";
+
+/// Was this `handoff.md` authored by the worker?
+///
+/// Existence alone is not proof: `append_failover_note` writes through
+/// `state::append_str`, which creates a missing file, so a handoff.md holding
+/// nothing but core-appended `## Worker failover` sections was created by the
+/// core failover path. Unreadable (non-UTF-8) content keeps the prior
+/// existence-based classification — authorship is only denied when every
+/// section is provably core-appended.
+fn handoff_is_worker_authored(path: &std::path::Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    match std::fs::read_to_string(path) {
+        Ok(content) => !handoff_is_failover_note_only(&content),
+        Err(_) => true,
+    }
+}
+
+/// Does this handoff consist solely of `## Worker failover` sections?
+fn handoff_is_failover_note_only(content: &str) -> bool {
+    let mut in_failover_section = false;
+    let mut saw_failover_section = false;
+    for line in content.lines() {
+        if let Some(heading) = line.strip_prefix("## ") {
+            if heading.trim() != WORKER_FAILOVER_HEADING {
+                return false;
+            }
+            in_failover_section = true;
+            saw_failover_section = true;
+            continue;
+        }
+        if !in_failover_section && !line.trim().is_empty() {
+            return false;
+        }
+    }
+    saw_failover_section
+}
+
 /// Classify the finalization artifacts to record for `run_dir`.
 ///
 /// Must run BEFORE `compact::write_evaluator_summary`: that writer creates
 /// `handoff.md` as an evaluator fallback only when the worker did not author
 /// one, so the real author is only readable from the pre-writer run directory.
+/// A handoff.md holding only the core failover note is classified core-authored
+/// even though the file exists — see `handoff_is_worker_authored`.
 fn plan_finalization_artifact_entries(
     run_dir: &std::path::Path,
 ) -> [(&'static str, &'static str, bool); 5] {
-    let handoff_worker_authored = run_dir.join("handoff.md").is_file();
+    let handoff_worker_authored = handoff_is_worker_authored(&run_dir.join("handoff.md"));
     [
         ("result.json", "worker_result", true),
         ("evaluation.json", "evaluation", false),
@@ -6147,7 +6192,7 @@ fn record_failover(run_dir: &std::path::Path, from: &str, to: &str, reason: &str
 }
 
 fn append_failover_note(run_dir: &std::path::Path, note: &str) -> Result<()> {
-    let mut md = String::from("\n## Worker failover\n\n");
+    let mut md = format!("\n## {WORKER_FAILOVER_HEADING}\n\n");
     md.push_str(note);
     md.push('\n');
     append_str(&run_dir.join("checkpoint.md"), &md)?;
@@ -6507,6 +6552,96 @@ mod tests {
         assert!(
             !planned_worker_authored(&entries, "handoff.md"),
             "classification captured pre-fallback must stay worker_authored=false"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn finalization_plan_marks_failover_note_only_handoff_core_authored() {
+        // append_failover_note writes through append_str, which creates a
+        // missing handoff.md; a file holding nothing but that core-appended
+        // note must not pass as worker output.
+        let root = std::env::temp_dir().join(format!(
+            "yard-handoff-failover-note-only-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+
+        append_failover_note(
+            &root,
+            "worker failover: codex -> claude-code; codex exited without result.json \
+             after 1/2 resume attempt(s)",
+        )
+        .unwrap();
+        assert!(root.join("handoff.md").is_file());
+
+        let entries = plan_finalization_artifact_entries(&root);
+        assert!(
+            !planned_worker_authored(&entries, "handoff.md"),
+            "a handoff.md created only by the core failover note must be recorded \
+             worker_authored=false"
+        );
+
+        // A second core-appended note keeps the file core-only.
+        append_failover_note(
+            &root,
+            "worker failover unavailable after claude-code exited without result.json: \
+             no ready worker",
+        )
+        .unwrap();
+        let entries = plan_finalization_artifact_entries(&root);
+        assert!(
+            !planned_worker_authored(&entries, "handoff.md"),
+            "stacked failover notes are still core-authored content"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn failover_note_only_detection_requires_provably_core_content() {
+        // Empty or ambiguous content keeps the existence-based classification;
+        // authorship is only denied when every section is the core note.
+        assert!(!handoff_is_failover_note_only(""));
+        assert!(!handoff_is_failover_note_only("# Worker handoff\n"));
+        assert!(handoff_is_failover_note_only(
+            "\n## Worker failover\n\nworker failover: a -> b; no result.json\n"
+        ));
+        // Any other section heading is content beyond the core note.
+        assert!(!handoff_is_failover_note_only(
+            "\n## Worker failover\n\nnote\n\n## Summary\n\nworker text\n"
+        ));
+        // Worker prose before the appended note keeps worker authorship.
+        assert!(!handoff_is_failover_note_only(
+            "did the work\n\n## Worker failover\n\nnote\n"
+        ));
+    }
+
+    #[test]
+    fn finalization_plan_keeps_worker_handoff_with_failover_note_worker_authored() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-handoff-worker-plus-failover-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        write_str(
+            &root.join("handoff.md"),
+            "# Worker handoff\n\nWhat I changed and why.\n",
+        )
+        .unwrap();
+        append_failover_note(
+            &root,
+            "worker failover: codex -> claude-code; codex exited without result.json \
+             after 1/2 resume attempt(s)",
+        )
+        .unwrap();
+
+        let entries = plan_finalization_artifact_entries(&root);
+        assert!(
+            planned_worker_authored(&entries, "handoff.md"),
+            "a worker-authored handoff.md must stay worker_authored=true after the \
+             failover note is appended"
         );
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -134,9 +134,9 @@ case "$task_id" in
     ;;
   YARD-REVIEW-PASS-MANUAL)
     printf 'passing review change\n' >review-change.txt
-    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": true, "evidence": "fixture criterion passed"}],\n  "compact_summary": "passing review awaiting manual integration"\n}\n' \
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": true, "evidence": "fixture criterion passed"}],\n  "follow_up_tasks": [{"title": "optional review documentation", "reason": "non-blocking fixture follow-up", "kind": "implementation"}],\n  "compact_summary": "passing review awaiting manual integration"\n}\n' \
       "$run_id" "$task_id" >"$run_dir/result.json"
-    write_handoff "통과한 review의 수동 통합 대기 fixture"
+    write_handoff "WORKER-HANDOFF-MARKER-ISSUE-31-7E3C 통과한 review의 수동 통합 대기 fixture"
     ;;
   YARD-REVIEW-PASS)
     printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": true, "evidence": "foundation passes while runtime remains unresolved"}],\n  "domain_artifact": {"runtime_conformity": {"status": "not_pass"}, "free_text": "status fail blocked not_pass"},\n  "compact_summary": "structured review contract regression"\n}\n' \

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -127,9 +127,16 @@ case "$task_id" in
     write_handoff "feedback 소진 회귀 fixture"
     ;;
   YARD-REVIEW-FAIL)
+    printf 'failed review change\n' >review-change.txt
     printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": false, "evidence": "fixture criterion failed"}],\n  "compact_summary": "review failure regression"\n}\n' \
       "$run_id" "$task_id" >"$run_dir/result.json"
     write_handoff "review 실패 회귀 fixture"
+    ;;
+  YARD-REVIEW-PASS-MANUAL)
+    printf 'passing review change\n' >review-change.txt
+    printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": true, "evidence": "fixture criterion passed"}],\n  "compact_summary": "passing review awaiting manual integration"\n}\n' \
+      "$run_id" "$task_id" >"$run_dir/result.json"
+    write_handoff "통과한 review의 수동 통합 대기 fixture"
     ;;
   YARD-REVIEW-PASS)
     printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "%s",\n  "status": "done",\n  "validation": {"commands_run": ["fixture"], "passed": true, "failures": []},\n  "verdict": [{"criterion_id": "AC-001", "pass": true, "evidence": "foundation passes while runtime remains unresolved"}],\n  "domain_artifact": {"runtime_conformity": {"status": "not_pass"}, "free_text": "status fail blocked not_pass"},\n  "compact_summary": "structured review contract regression"\n}\n' \

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -2292,6 +2292,75 @@ exit 1
         fixture.run(&["run", "--task", "YARD-REVIEW-FAIL", "--execute"]);
 
         assert_actionable_needs_user(&fixture, "YARD-REVIEW-FAIL");
+        let run_dir = run_dir_for_task(&fixture.root, "YARD-REVIEW-FAIL");
+        let evaluation: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(run_dir.join("evaluation.json")).unwrap())
+                .unwrap();
+        assert!(evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check["name"] == "review_criteria_pass" && check["passed"] == false));
+        let questions = yaml_dir(&channel_dir(&fixture.root, "YARD-REVIEW-FAIL").join("questions"));
+        let question = string(&questions[0], "text");
+        assert!(question.contains("수정 작업을 큐에 추가"));
+        assert!(question.contains("수동으로 확정"));
+    }
+
+    #[test]
+    fn passing_review_with_auto_commit_off_stays_resolvable_partial() {
+        let fixture = FixtureWorkspace::new("passing-review-manual-integration");
+        fixture.write_queue(
+            "  - id: YARD-REVIEW-PASS-MANUAL\n    title: passing review awaiting manual integration\n    state: queued\n    priority: 10\n    kind: review\n    preferred_worker: fixture\n    acceptance: [criterion passes]\n",
+        );
+
+        fixture.run(&["run", "--task", "YARD-REVIEW-PASS-MANUAL", "--execute"]);
+
+        assert_eq!(
+            task_state(&fixture.root, "YARD-REVIEW-PASS-MANUAL"),
+            "partial"
+        );
+        let run_dir = run_dir_for_task(&fixture.root, "YARD-REVIEW-PASS-MANUAL");
+        assert_eq!(
+            fs::read_to_string(run_dir.join("partial-reason"))
+                .unwrap()
+                .trim(),
+            "auto_commit_disabled"
+        );
+        let evaluation: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(run_dir.join("evaluation.json")).unwrap())
+                .unwrap();
+        assert!(evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check["name"] == "review_criteria_pass" && check["passed"] == true));
+        assert!(
+            !channel_dir(&fixture.root, "YARD-REVIEW-PASS-MANUAL")
+                .join("questions")
+                .exists(),
+            "passing review must not open a NeedsUser question"
+        );
+
+        let run = read_yaml(&run_dir.join("run.yaml"));
+        let worktree = PathBuf::from(string(&run, "worktree"));
+        fs::copy(
+            worktree.join("review-change.txt"),
+            fixture.root.join("review-change.txt"),
+        )
+        .unwrap();
+        must_succeed(
+            &fixture.root,
+            Path::new("git"),
+            &["add", "review-change.txt"],
+        );
+        must_succeed(
+            &fixture.root,
+            Path::new("git"),
+            &["commit", "-qm", "manually integrate passing review"],
+        );
+        fixture.run(&["resolve", "YARD-REVIEW-PASS-MANUAL", "수동 통합 완료"]);
+        assert_eq!(task_state(&fixture.root, "YARD-REVIEW-PASS-MANUAL"), "done");
     }
 
     #[test]

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -2327,6 +2327,19 @@ exit 1
                 .trim(),
             "auto_commit_disabled"
         );
+        let handoff = fs::read_to_string(run_dir.join("handoff.md")).unwrap();
+        assert!(
+            handoff.starts_with(
+                "# Handoff\n\nWORKER-HANDOFF-MARKER-ISSUE-31-7E3C 통과한 review의 수동 통합 대기 fixture\n"
+            ),
+            "finalize must preserve the worker-authored handoff verbatim; got:\n{handoff}"
+        );
+        assert!(handoff.contains("Non-blocking follow-up notes"));
+        assert!(handoff.contains("optional review documentation"));
+        assert!(handoff.contains("Git integration paused"));
+        let evaluator_summary = fs::read_to_string(run_dir.join("evaluator-summary.md")).unwrap();
+        assert!(evaluator_summary.contains("Evaluator checks"));
+        assert!(evaluator_summary.contains("review_criteria_pass"));
         let evaluation: serde_json::Value =
             serde_json::from_str(&fs::read_to_string(run_dir.join("evaluation.json")).unwrap())
                 .unwrap();


### PR DESCRIPTION
## Summary

- keep a passing review with `auto_commit: false` in resolvable `Partial` instead of misclassifying it as a failed review
- preserve strict `NeedsUser` behavior for genuinely failed review verdicts and guarantee actionable questions
- preserve worker-authored `handoff.md`, publish evaluator output separately as `evaluator-summary.md`, and keep evaluator fallback behavior
- classify handoff authorship before fallback creation, including failover-note-only and parallel paths

## Verification

Independent Claude Fable review (YARD-002) passed AC-001 through AC-007 at exact head `be40efe8e6654ff7d95011bb9fedbe010308039c`.

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- focused passing-review and issue #23 process regressions
- `cargo test` — 540 passed, 0 failed
- `cargo build`
- read-only review: tracked diff remained unchanged
- live installed-binary proof: worker `handoff.md` and separate `evaluator-summary.md` both survive finalization

Closes #23
Closes #31