### PR TITLE
chore: prepare repository for external contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default ownership keeps review responsibility explicit for external PRs.
+* @zzunkie
+
+# Keep repository policy and high-risk execution/state boundaries visible.
+/.github/ @zzunkie
+/src/guard.rs @zzunkie
+/src/state.rs @zzunkie
+/src/workers/ @zzunkie
+/templates/agents/ @zzunkie

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report reproducible behavior that is incorrect or unsafe
+title: "[Bug]: "
+labels:
+  - bug
+  - needs triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Search existing issues first.
+        If this may expose secrets, bypass approvals or sandboxing, or alter canonical state without authorization, stop and use the private process in SECURITY.md.
+  - type: input
+    id: version
+    attributes:
+      label: Yardlet version
+      description: Paste `yardlet --version` or the exact commit SHA.
+      placeholder: yardlet x.y.z
+    validations:
+      required: true
+  - type: dropdown
+    id: installation
+    attributes:
+      label: Installation method
+      options:
+        - cargo install yardlet
+        - cargo binstall yardlet
+        - GitHub release binary
+        - cargo install --path .
+        - cargo run from source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: macOS 15.5 arm64 or Ubuntu 24.04 x86_64
+    validations:
+      required: true
+  - type: input
+    id: workers
+    attributes:
+      label: Worker CLI and version
+      description: Include only workers involved in the failure. Write "none" when not applicable.
+      placeholder: codex 1.2.3, claude 4.5.0, or none
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest sequence that reproduces the problem.
+      placeholder: |
+        1. Run ...
+        2. Enter ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Redacted logs
+      description: Remove tokens, credentials, billing variables, customer data, private prompts, and full home-directory paths.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues for this behavior.
+          required: true
+        - label: I removed secrets and private data from this report.
+          required: true
+        - label: This is not a security vulnerability requiring private disclosure.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/zzunkie/yardlet/security/advisories/new
+    about: Use GitHub's private vulnerability reporting instead of a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,32 @@
+name: Documentation
+description: Report missing, incorrect, or confusing documentation
+title: "[Docs]: "
+labels:
+  - documentation
+  - needs triage
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the page or name the file and section.
+      placeholder: README.md, "Adding a worker"
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is unclear or incorrect?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Suggested improvement
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I checked the current English source and its Korean mirror when applicable.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,60 @@
+name: Feature proposal
+description: Propose a user outcome before implementing new behavior
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Features, public contracts, and architecture changes are issue-first. Describe the user problem before the implementation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem
+      description: Who is blocked, and what are they trying to accomplish?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable behavior without prescribing an architecture.
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current workaround
+      description: Explain how the problem is handled today, if at all.
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Scope and boundaries
+      description: Note affected commands, files, worker contracts, policies, or compatibility concerns.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution intent
+      options:
+        - I can implement this after scope agreement
+        - I can help test or review
+        - I am proposing the need only
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and the roadmap references in the repository.
+          required: true
+        - label: I understand that issue discussion must agree on scope before implementation.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,42 @@
+name: Question
+description: Ask for help with Yardlet setup or usage
+title: "[Question]: "
+labels:
+  - question
+  - needs triage
+body:
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Yardlet version
+      placeholder: yardlet x.y.z
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the operating system and relevant worker CLI.
+      placeholder: macOS 15.5 arm64, codex 1.2.3
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: Include redacted commands and output.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Data safety
+      options:
+        - label: I removed secrets, private prompts, customer data, and full personal paths.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+# Pull Request
+
+## What changed
+
+<!-- Describe the problem and the user-visible effect of this change. -->
+
+## Related issue
+
+<!--
+Link the agreed issue for features, public contracts, architecture, or security
+boundary changes. Use "Not required" for an issue-optional small fix.
+-->
+
+## Validation
+
+<!-- List the exact commands you ran and their results. -->
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo build --all-targets`
+- [ ] `cargo test`
+- [ ] `cargo +1.82.0 check --locked`
+
+## Evidence
+
+<!-- Add screenshots or terminal captures for visible TUI/output changes. -->
+
+## Scope and safety
+
+- [ ] The pull request solves one bounded problem.
+- [ ] Behavior changes include tests.
+- [ ] Public commands, output, configuration, or contracts have updated docs.
+- [ ] I did not include secrets, personal paths, or generated run artifacts.
+- [ ] I did not hand-edit Yardlet-owned canonical `.agents/` state.
+- [ ] I have the right to submit this work under the repository's MIT License.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - rust
+    groups:
+      cargo-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Seoul
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,32 +7,62 @@ on:
     branches: [main, "v*"]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  msrv:
+    name: MSRV (1.82.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: 1.82.0
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - run: cargo check --locked
+
   lint:
     name: fmt + clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt --check
       - run: cargo clippy --all-targets -- -D warnings
 
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo build --all-targets
       - run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # Keep a manually-created release (with hand-written notes) if it exists;
       # otherwise create one with auto-generated notes.
@@ -28,6 +29,7 @@ jobs:
     needs: create-release
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +41,9 @@ jobs:
           - { os: macos-14, target: aarch64-apple-darwin }
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
       - name: Install Rust target
         run: rustup update stable && rustup target add ${{ matrix.target }}
       - name: Build

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,124 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples include using an official email address, posting via an official
+social media account, or acting as an appointed representative at an online or
+offline event.
+
+## Enforcement
+
+Report abusive, harassing, or otherwise unacceptable behavior privately using
+the contact method listed on the
+[@zzunkie GitHub profile](https://github.com/zzunkie). Use the subject
+`[yardlet conduct]`. Do not include sensitive incident details in a public
+issue.
+
+All complaints will be reviewed and investigated promptly and fairly. Community
+leaders are obligated to respect the privacy and security of the reporter.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,60 +1,159 @@
 # Contributing to Yardlet
 
-Thanks for your interest in Yardlet. This guide covers building, testing, and
-sending changes. For the deeper design rationale, see [AGENTS.md](AGENTS.md) and
-[docs/identity.md](docs/identity.md).
+Thank you for helping improve Yardlet. This guide explains where to start, what
+the repository expects, and how a change reaches `main`.
 
-## Build and test
+By participating, you agree to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md). For project ownership and decision
+making, see [GOVERNANCE.md](GOVERNANCE.md).
+
+## Choose the right starting point
+
+- **Bug with a clear reproduction:** a pull request is welcome; link an issue
+  when one exists.
+- **Documentation, tests, typo, or small cleanup:** a pull request is welcome.
+- **New feature or user-visible behavior:** open a feature issue and agree on
+  scope first.
+- **CLI, file format, policy, security boundary, or architecture:** open an
+  issue before implementation.
+- **Security vulnerability:** follow [SECURITY.md](SECURITY.md); do not open a
+  public issue.
+- **Usage question:** use the question issue form.
+
+Issue-first changes need maintainer agreement before implementation. That avoids
+asking contributors to spend time on a direction the project will not adopt.
+An issue or discussion is not a promise that a proposal will be accepted.
+
+## Development setup
+
+You need:
+
+- Git;
+- the latest stable Rust toolchain with `rustfmt` and `clippy`;
+- macOS or Linux for the same platforms exercised by CI;
+- an installed worker CLI only for end-to-end tests that actually launch one.
+
+After forking the repository:
 
 ```bash
-cargo build
+git clone https://github.com/YOUR-USER/yardlet.git
+cd yardlet
+git remote add upstream https://github.com/zzunkie/yardlet.git
+git switch -c fix/short-description
+rustup update stable
+rustup component add rustfmt clippy
+rustup toolchain install 1.82.0 --profile minimal
+```
+
+Do not put credentials or provider billing variables in repository files. A
+normal build and test run does not require an AI provider API key.
+
+## Required checks
+
+Run the same checks CI runs before requesting review:
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo build --all-targets
 cargo test
+cargo +1.82.0 check --locked
 ```
 
-Keep the whole suite green. Yardlet targets Rust 2021 (rustc >= 1.82). To try
-your build against a project:
+Yardlet is a binary crate. Useful focused commands include:
 
 ```bash
-cargo run -- status      # run from source
-cargo install --path .   # or install the `yardlet` binary
+cargo test --bin yardlet test_name
+cargo test --test integration_test_name
+cargo run -- --help
+cargo run -- status
 ```
 
-## What Yardlet is (the parts you will touch)
+The package declares Rust 1.82 as its minimum supported Rust version. CI checks
+that declaration with the committed lockfile, while lint and cross-platform
+test jobs run on the current stable toolchain. If stable Clippy disagrees with
+an older local toolchain, update stable and run the checks again.
 
-Yardlet is a local terminal workbench (Rust + Ratatui). It turns a few sentences
-of intent into an intent contract plus a task queue, runs each task through a
-hidden worker CLI (Codex, Claude Code, or any CLI via the generic adapter),
-validates the result with a deterministic evaluator, and writes checkpoints and
-handoffs under `.agents/`.
+## Architecture boundaries
 
-A few invariants shape almost every change:
+The deeper rationale lives in [AGENTS.md](AGENTS.md) and
+[docs/identity.md](docs/identity.md). Four invariants shape most changes:
 
-- **The core is deterministic; anything generative goes through the worker
-  contract.** Packet in -> subprocess -> result files out. A worker's CLI flags
-  live only in `src/workers/mod.rs::build_command`.
-- **Yardlet owns canonical state.** Only `src/state.rs` writes the `.agents/`
-  files (`work-queue.yaml`, `*-policy.yaml`, runs, checkpoints, handoffs). Do
-  not write them from anywhere else.
-- **The core drives the user's installed CLIs.** It does not require, store, or
-  call an AI provider API; the worker subprocess env is sanitized by default
-  (`src/guard.rs`).
-- **Routing is policy vs mechanism.** Resolution is deterministic
-  (`src/routing.rs`); telemetry only *suggests* changes a human applies
-  (`src/review.rs`).
+- **The core is deterministic.** Anything generative goes through a worker
+  contract: packet in, subprocess, result files out.
+- **Workers are interchangeable CLIs.** Worker command-line flags belong only
+  in `src/workers/mod.rs::build_command`.
+- **Yardlet owns canonical state.** `src/state.rs` is the only product module
+  that writes canonical `.agents/` state.
+- **Routing policy is auditable.** Runtime routing is deterministic; telemetry
+  may suggest policy changes but never silently activates them.
 
-## Sending a change
+### The `.agents/` boundary
 
-1. Branch off `main` (use a `git worktree` for parallel work).
-2. Run `git status` before staging; stage only the files you changed (avoid
-   `git add -A`).
-3. `cargo build && cargo test` must pass.
-4. Match the surrounding code: small typed structs, no over-abstraction, the
-   same comment density and naming as the file you are editing.
-5. Keep scope strict: an adjacent idea becomes a queue candidate, not a silent
-   expansion of the current change.
-6. Open a PR describing the user-facing effect.
+This repository uses `.agents/` for two different purposes:
 
-## Reporting issues
+- `.agents/rules/`, `.agents/skills/`, and `.agents/agents/` are reusable
+  harness assets. Changes are welcome when they are in the PR scope.
+- `templates/agents/` contains source templates used when Yardlet initializes
+  state. Edit these when changing generated defaults.
+- `.agents/yardlet.yaml`, `*-policy.yaml`, `workers.yaml`, `work-queue.yaml`,
+  and `intent-contract.yaml` are Yardlet-owned or machine-specific operational
+  state. Do not hand-edit them for a product change.
+- `.agents/runs/`, `checkpoints/`, `handoffs/`, `telemetry/`, and
+  `transitions/` are generated runtime evidence. Do not include them in a PR.
 
-Open a GitHub issue with the Yardlet version (`yardlet status`), your OS, the
-worker CLIs involved, and steps to reproduce. Never paste secret values.
+When a behavior change needs a different generated file, change the typed
+mechanism in `src/` and the source template under `templates/`, then test the
+generated result. Do not patch a generated instance and call that the fix.
+
+## Make a focused change
+
+1. Update your branch from `upstream/main`.
+2. Keep one problem and one coherent solution in each pull request.
+3. Match the surrounding Rust style: small typed structs, direct control flow,
+   and no speculative abstraction.
+4. Add or update tests for behavior changes.
+5. Update user documentation when commands, output, configuration, or public
+   contracts change.
+6. Keep adjacent ideas out of the patch and open a follow-up issue instead.
+7. Review `git status` and stage only files that belong to the change. Do not
+   use a blind `git add -A` in a mixed worktree.
+
+Do not include secrets, personal paths, generated run artifacts, benchmark
+scratch data, or unrelated formatting changes.
+
+## Open the pull request
+
+The pull request template asks for:
+
+- the problem and user-visible effect;
+- the related issue when issue-first agreement was required;
+- exact validation commands and results;
+- screenshots or terminal captures for visible TUI changes;
+- confirmation that canonical or generated state was not hand-edited.
+
+Draft pull requests are welcome for early feedback. A pull request becomes
+mergeable only after the protected-branch checks pass and review conversations
+are resolved. The maintainer may ask to split a patch, revise its scope, or
+close it when it conflicts with the project's direction or safety model.
+
+## Reporting bugs
+
+Use the bug issue form and include:
+
+- `yardlet --version` or the commit SHA;
+- operating system and installation method;
+- worker CLI names involved, if any;
+- minimal reproduction steps;
+- expected and actual behavior;
+- relevant logs with secrets and personal paths removed.
+
+Use [SECURITY.md](SECURITY.md) instead of an issue if the report involves
+credential exposure, command injection, sandbox or approval bypass, canonical
+state tampering, or another security boundary.
+
+## License
+
+Yardlet is distributed under the [MIT License](LICENSE). By submitting a
+contribution, you confirm that you have the right to submit it and agree that it
+may be distributed under the same license.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "1.0.0"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -40,9 +40,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "1.0.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -264,10 +264,11 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
+ "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -277,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -317,7 +318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -325,6 +326,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -369,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -411,12 +418,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -430,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
@@ -848,9 +855,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ pkg-fmt = "tgz"
 bin-dir = "yardlet"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+# Clap 4.6 requires Cargo's edition-2024 support. Keep the 4.5 line while the
+# package's declared MSRV remains Rust 1.82.
+clap = { version = ">=4.5, <4.6", features = ["derive"] }
 ratatui = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,8 +44,8 @@ public issue.
 - Product behavior: typed code in `src/` plus executable tests.
 - Public usage: `README.md`; `README.ko.md` mirrors its user-facing meaning.
 - Contributor process: `CONTRIBUTING.md`, this file, and `.github/` templates.
-- Release history: `CHANGELOG.md`, package version, signed-off release commit,
-  version tag, GitHub Release, and crates.io.
+- Release history: `CHANGELOG.md`, package version, release commit, version tag,
+  GitHub Release, and crates.io.
 - Reusable agent harness: `.agents/rules/`, `.agents/skills/`, and
   `.agents/agents/`.
 - Generated workspace state: Yardlet's typed state mechanism, never a

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,107 @@
+# Yardlet Governance
+
+Yardlet is currently a maintainer-led open source project. This document says
+who makes decisions, which files are authoritative, and how contributions move
+from proposal to release.
+
+## Stewardship
+
+The repository owner, [@zzunkie](https://github.com/zzunkie), is the current
+maintainer and final steward for:
+
+- product direction and public contracts;
+- repository access and contributor roles;
+- security triage and coordinated disclosure;
+- pull request acceptance and releases to GitHub and crates.io.
+
+Maintainer authority does not make every maintainer-authored change correct.
+The same protected branch, CI checks, review conversation, and documented
+invariants apply to maintainer changes.
+
+The operational access baseline and recurring audit are documented in
+[docs/maintainer-playbook.md](docs/maintainer-playbook.md).
+
+## Contribution lanes
+
+Yardlet uses two contribution lanes:
+
+1. **Direct pull request:** clear bug fixes, documentation, tests, typos, and
+   small internal cleanups with no new public behavior.
+2. **Issue before implementation:** new features, new CLI or configuration
+   behavior, architecture, file-format or schema changes, worker-contract
+   changes, and changes to security or approval boundaries.
+
+The maintainer confirms issue-first scope before implementation. Agreement is
+specific to that scope; adjacent work returns to the issue process.
+
+Security reports use the private process in [SECURITY.md](SECURITY.md), never a
+public issue.
+
+## Sources of truth
+
+- Product identity and non-negotiable principles: `docs/identity.md` and
+  `AGENTS.md`.
+- Product behavior: typed code in `src/` plus executable tests.
+- Public usage: `README.md`; `README.ko.md` mirrors its user-facing meaning.
+- Contributor process: `CONTRIBUTING.md`, this file, and `.github/` templates.
+- Release history: `CHANGELOG.md`, package version, signed-off release commit,
+  version tag, GitHub Release, and crates.io.
+- Reusable agent harness: `.agents/rules/`, `.agents/skills/`, and
+  `.agents/agents/`.
+- Generated workspace state: Yardlet's typed state mechanism, never a
+  hand-edited `.agents/` instance.
+
+Compatibility mirrors such as `CLAUDE.md` and `.claude/` are not independent
+sources of truth. Update their canonical `.agents/` or `AGENTS.md` target.
+
+## Decisions and reviews
+
+Decisions favor, in order:
+
+1. user-owned state and deterministic, inspectable behavior;
+2. security, billing, approval, and canonical-state boundaries;
+3. compatibility with documented public contracts;
+4. a small implementation that matches the existing code;
+5. contributor effort and maintainability.
+
+Substantial decisions should be recorded in the issue or pull request that
+adopts them and reflected in the relevant source-of-truth document. Rejected or
+deferred proposals should receive a short reason so future contributors do not
+repeat the same investigation.
+
+## Merge policy
+
+`main` is protected. Changes reach it through pull requests that:
+
+- are up to date with `main`;
+- pass formatting, Clippy, Ubuntu, and macOS checks;
+- resolve review conversations;
+- stay within the accepted contribution scope.
+
+The repository currently has one maintainer, so a numeric approval requirement
+is not used; the maintainer's merge action is the acceptance decision. This can
+change when a second maintainer can provide independent approval.
+
+## Releases
+
+Yardlet follows Semantic Versioning. Before 1.0, a minor release may include a
+breaking public-contract change when it is explicitly documented.
+
+A release updates the package version and lockfile, records user-visible
+changes in `CHANGELOG.md`, creates a `v<version>` tag, publishes the GitHub
+Release and its supported binaries, and publishes the crate. Only the
+maintainer performs release publication.
+
+Version tags are immutable release records. Corrections use a new version
+rather than moving or recreating a published tag.
+
+## Contributor roles
+
+Anyone may report issues, propose changes, review public work, and submit pull
+requests. Triage or write access may be offered after a sustained record of
+constructive, technically sound contributions and responsible handling of
+project boundaries. Access is least-privilege and may be removed when it is no
+longer needed.
+
+Changes to this governance model require an issue-first proposal and a pull
+request.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -74,7 +74,7 @@ repeat the same investigation.
 `main` is protected. Changes reach it through pull requests that:
 
 - are up to date with `main`;
-- pass formatting, Clippy, Ubuntu, and macOS checks;
+- pass formatting, Clippy, Rust 1.82 MSRV, Ubuntu, and macOS checks;
 - resolve review conversations;
 - stay within the accepted contribution scope.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -57,7 +57,7 @@ Anthropic의 Claude Code 리드가 자신의 워크플로를 이렇게 설명합
 ## 설치
 
 ```bash
-cargo install yardlet
+cargo install yardlet --locked
 ```
 
 macOS와 Linux용 사전 빌드 바이너리가 각

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ User intent (a few sentences)
 ## Install
 
 ```bash
-cargo install yardlet
+cargo install yardlet --locked
 ```
 
 Prebuilt binaries for macOS and Linux are attached to each

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes target the latest released version of Yardlet and the current
+`main` branch. Older releases may be affected and are supported on a best-effort
+basis. Reports should identify the exact Yardlet version or commit.
+
+## Report a vulnerability privately
+
+Do not open a public issue or pull request for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting:
+
+<https://github.com/zzunkie/yardlet/security/advisories/new>
+
+If that form is unavailable, use the contact method listed on the
+[@zzunkie GitHub profile](https://github.com/zzunkie) with the subject
+`[yardlet security]` and no secrets in the subject line.
+
+Include as much of the following as possible:
+
+- affected version or commit;
+- operating system and installation method;
+- security impact and the boundary that is crossed;
+- minimal reproduction steps or proof of concept;
+- whether the issue is already public or being actively exploited;
+- relevant logs with tokens, credentials, personal paths, and customer data
+  removed;
+- a suggested mitigation, if known.
+
+The maintainer aims to acknowledge a report within three business days and
+provide an initial assessment within seven business days. These are response
+targets, not disclosure deadlines.
+
+## What Yardlet treats as security-sensitive
+
+Yardlet launches installed AI worker CLIs and writes canonical workspace state.
+Reports are especially useful when they involve:
+
+- command or argument injection into a worker process;
+- sandbox, allowed-scope, approval, or forbidden-path bypass;
+- secret, credential, billing-variable, or private-data exposure;
+- unauthorized changes to canonical `.agents/` state;
+- unsafe cross-worktree or cross-run changes;
+- untrusted artifact or dependency execution;
+- a denial of service with a practical security impact.
+
+An ordinary functional bug without a security-boundary impact can use the
+public bug form. A vulnerability in a third-party worker CLI should also be
+reported to that provider; report it to Yardlet when Yardlet causes or worsens
+the exposure.
+
+## Coordinated disclosure
+
+Please allow time to reproduce, fix, and release a correction before public
+disclosure. The maintainer will keep the reporter informed through the private
+advisory, coordinate a disclosure date when practical, and credit the reporter
+unless anonymity is requested.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,26 @@
+# Support
+
+Yardlet is maintained as an open source project without a guaranteed response
+or resolution time.
+
+Before opening an issue:
+
+1. read the current `README.md` and `CHANGELOG.md`;
+2. search existing issues;
+3. run `yardlet --version` and `yardlet worker status`;
+4. separate a Yardlet failure from a worker CLI's own authentication, billing,
+   or provider-service failure.
+
+Use the repository's issue forms:
+
+- **Bug report** for reproducible Yardlet behavior;
+- **Feature proposal** for a user problem or new behavior;
+- **Documentation** for missing, incorrect, or confusing guidance;
+- **Question** for setup and usage help.
+
+Include your Yardlet version, operating system, installation method, involved
+worker CLI, and redacted logs. Never post tokens, credentials, billing
+variables, private prompts, customer data, or full home-directory paths.
+
+Security vulnerabilities follow [SECURITY.md](SECURITY.md) and must not be
+reported in a public issue.

--- a/docs/maintainer-playbook.md
+++ b/docs/maintainer-playbook.md
@@ -28,7 +28,7 @@ triage. Record why access was granted and remove it when the role ends.
 `main` must:
 
 - require a pull request, including for administrators;
-- require the formatting/Clippy, Ubuntu, and macOS checks;
+- require the formatting/Clippy, Rust 1.82 MSRV, Ubuntu, and macOS checks;
 - require the branch to be current with `main`;
 - require review conversations to be resolved;
 - reject force pushes and deletion;

--- a/docs/maintainer-playbook.md
+++ b/docs/maintainer-playbook.md
@@ -1,0 +1,116 @@
+# Maintainer Playbook
+
+This is the repository-side baseline for access, review, automation, and
+release administration. GitHub settings live outside Git, so re-check them
+against this document after access changes and before a release-policy change.
+
+## Access model
+
+- **Anonymous visitor:** read, clone, and inspect the public repository.
+- **External contributor:** fork, open issues and pull requests, and run
+  approved fork CI; no upstream push.
+- **Triage collaborator:** classify and close issues without code or settings
+  access.
+- **Maintainer:** administer settings, review and merge PRs, triage security
+  reports, and publish releases.
+- **CI `GITHUB_TOKEN`:** read repository contents; cannot approve or create
+  pull requests.
+- **Release `GITHUB_TOKEN`:** `contents: write` only inside the version-tag
+  release workflow.
+- **Dependabot:** open dependency pull requests; no repository secret is
+  configured.
+
+Use least privilege. Do not grant write access merely to let someone review or
+triage. Record why access was granted and remove it when the role ends.
+
+## Default branch baseline
+
+`main` must:
+
+- require a pull request, including for administrators;
+- require the formatting/Clippy, Ubuntu, and macOS checks;
+- require the branch to be current with `main`;
+- require review conversations to be resolved;
+- reject force pushes and deletion;
+- have no user, team, or app bypass that silently restores direct push.
+
+The project currently has one maintainer, so the required approving-review count
+is zero. The maintainer's merge is the acceptance decision. Raise the count to
+one when a second maintainer can independently approve changes.
+
+Yardlet's current `git_finish` mechanism assumes a direct push. Until it supports
+a protected-branch PR delivery mode, maintainer and Yardlet-authored changes
+must push a feature branch and open a normal pull request. Do not weaken `main`
+protection to accommodate the old delivery assumption.
+
+## Tags and releases
+
+Release tags match `v*`. Repository rules must block deletion and non-fast-
+forward updates to those tags. A correction receives a new version and tag.
+
+The release workflow is the only workflow with write permission. It runs from a
+version-tag event, creates or reuses the matching GitHub Release, builds the
+supported binaries, and uploads them. Crates.io publication remains a
+maintainer action.
+
+Before publishing, verify the tag points to the intended protected-main commit
+and that the release version, `Cargo.lock`, `CHANGELOG.md`, GitHub assets, and
+crate version agree.
+
+## Actions baseline
+
+- Default workflow token permission: `contents: read`.
+- Workflows cannot create or approve pull requests.
+- First-time external contributors require workflow approval.
+- Only GitHub-owned actions plus explicitly selected third-party actions run.
+- Every action reference uses a full 40-character commit SHA.
+- Dependabot tracks both Cargo and GitHub Actions references.
+- Secrets are not available to workflows triggered from public forks.
+
+Pinning protects against a moved tag. The human-readable version comment next to
+each SHA and Dependabot preserve update visibility.
+
+## Security baseline
+
+Keep these repository features enabled:
+
+- dependency graph, vulnerability alerts, and Dependabot security updates;
+- automated security fixes;
+- secret scanning and push protection;
+- private vulnerability reporting;
+- CodeQL default setup for supported repository languages.
+
+New vulnerabilities follow `SECURITY.md`. Do not copy a private report into a
+public issue before coordinated disclosure.
+
+## Recurring audit
+
+Review the following at least before granting access, after installing an app,
+and before changing release automation:
+
+1. collaborators and pending invitations;
+2. teams, GitHub Apps, deploy keys, webhooks, and environments;
+3. branch protection, rulesets, and bypass actors;
+4. Actions allow-list, SHA-pinning, workflow token, and fork approval policy;
+5. Actions, Dependabot, and environment secret names;
+6. private vulnerability reporting, secret scanning, Dependabot, and CodeQL;
+7. stale remote branches and unexpected open pull requests.
+8. new and unresolved code-scanning alerts; a successful CodeQL workflow means
+   the analysis completed, not that the result is alert-free.
+
+Useful read-only checks:
+
+```bash
+gh api repos/zzunkie/yardlet/collaborators
+gh api repos/zzunkie/yardlet/branches/main/protection
+gh api repos/zzunkie/yardlet/rulesets
+gh api repos/zzunkie/yardlet/actions/permissions
+gh api repos/zzunkie/yardlet/actions/permissions/workflow
+gh api repos/zzunkie/yardlet/actions/permissions/fork-pr-contributor-approval
+gh api repos/zzunkie/yardlet/keys
+gh api repos/zzunkie/yardlet/hooks
+gh api repos/zzunkie/yardlet/environments
+```
+
+Never print secret values. Repository APIs expose secret names and timestamps,
+not values; treat even names as operational metadata.


### PR DESCRIPTION
## What changed

- establish contributor, governance, support, conduct, and private security
  reporting policies;
- add issue forms, a pull request template, CODEOWNERS, and Dependabot updates;
- harden CI and release workflows with least-privilege permissions, concurrency
  controls, timeouts, credential-safe checkout, and full-SHA action pins;
- make the declared Rust 1.82 MSRV reproducible by constraining incompatible
  dependency updates, locking compatible transitive versions, and adding an
  MSRV CI job;
- document the maintainer-side access, branch, tag, Actions, security, and
  recurring-audit baseline.

Repository settings were also hardened outside this Git diff: protected `main`,
immutable `v*` tags, restricted Actions, private vulnerability reporting,
Dependabot/secret scanning, and CodeQL are enabled. The playbook records the
expected state so it can be audited later.

## Related issues

- #56 tracks Yardlet `git finish` support for protected-branch PR delivery.
- #58 tracks a pre-existing local macOS PTY process-test failure found during
  this work.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [ ] `cargo test`
- [x] `cargo +1.82.0 check --locked`
- [x] GitHub issue-form, issue-config, and Dependabot schema validation
- [x] `actionlint`
- [x] Markdown lint and repository-local link validation
- [x] all workflow action references are full 40-character commit SHAs

`cargo test` passes 625 unit tests and every integration suite before
`tui_startup_review_revision_process`; that process test then consistently
misses the trailing `Esc/q 뒤로` footer label on this local macOS host. The same
focused failure reproduces from a separate clean checkout of `main` at
`f7b492b`, while GitHub Actions passed that SHA, so it is recorded separately in
#58 rather than hidden or patched in this contributor-policy change.

## Scope and safety

- [x] The pull request solves one bounded contributor-readiness problem.
- [x] No Yardlet-owned canonical or generated `.agents/` state is included.
- [x] No secret, personal filesystem path, or internal contact address is
  included.
- [x] The dependency changes preserve the package's existing declared MSRV and
  are covered by the new locked MSRV check.

## Post-merge settings

After these pinned workflows are on `main`, enable repository-wide required SHA
pinning for Actions. That setting is intentionally deferred so the current
`main` workflows are not blocked before the pinned definitions exist on the
default branch.
