### PR TITLE
ci: keep Dependabot updates within Rust 1.82 MSRV

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,17 @@ updates:
     labels:
       - dependencies
       - rust
+    ignore:
+      # Clap 4.6 requires Cargo's edition-2024 support. Keep receiving 4.5
+      # patches and security updates while Yardlet's declared MSRV is 1.82.
+      - dependency-name: clap
+        update-types:
+          - version-update:semver-minor
+      # Ratatui 0.30 requires Rust 1.88. Keep receiving 0.29 patches and
+      # security updates until Yardlet deliberately raises its MSRV.
+      - dependency-name: ratatui
+        update-types:
+          - version-update:semver-major
     groups:
       cargo-minor-and-patch:
         patterns:


### PR DESCRIPTION
## Summary

- keep Clap minor updates on the Rust-1.82-compatible 4.5 line
- keep Ratatui major updates on the Rust-1.82-compatible 0.29 line
- continue allowing patch and security updates

## Why

Dependabot PR #61 widens the intentional Clap `<4.6` cap and fails the MSRV job because Clap 4.6 uses edition-2024 support. PR #62 upgrades Ratatui to 0.30.2, which requires Rust 1.88. These policy guards prevent recurring known-red PRs until Yardlet deliberately raises its declared MSRV.

## Verification

- Dependabot YAML parsed and both ignore rules asserted
- `cargo +1.82.0 check --locked`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test` (all unit, process, PTY, and integration suites passed)