### PR TITLE
Deliver work through a pull request when the target branch is protected

### DIFF
--- a/.agents/skills/process-fixture-mutation/SKILL.md
+++ b/.agents/skills/process-fixture-mutation/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: process-fixture-mutation
+description: process fixture 외부 mutation 계수 분리
+source: learned
+---
+crash fixture에서는 command CALL, mutation 시작, mutation 성공을 별도 로그 event로 기록하고 중복 외부 mutation은 성공 event 수로 판정하라.

--- a/.agents/skills/process-fixture-summary-json/SKILL.md
+++ b/.agents/skills/process-fixture-summary-json/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: process-fixture-summary-json
+description: process fixture summary.json 증거 확보
+source: learned
+---
+보호 브랜치 process fixture의 summary.json을 durable 증거로 남기려면 scripts/run.sh <yardlet-bin> <evidence-dir>를 절대 경로 evidence-dir로 직접 재실행하라. 상대 경로는 subshell cd 때문에 workspace 파일 생성이 깨진다. 내부 cargo 테스트는 성공 시 summary를 삭제하므로, 리뷰에서 계수(public_remote_commands, protected_head_pushes 등)를 인용하려면 별도 재실행이 유일한 방법이다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -430,12 +430,14 @@ worktree는 검사를 위해 보존됩니다). 기본은 꺼져 있고, Settings
 
 자동 push는 사용자가 소유하는 별도의 완료 정책이며 기본은 꺼져 있습니다.
 `yardlet init`은 명시적으로 비활성화된 블록을 작성하고, 이 블록이 없는 기존
-워크스페이스도 비활성 상태를 유지합니다. 이름이 있는 remote, 완전한 branch ref,
-그리고 통과해야 할 순서대로 검사를 설정합니다.
+워크스페이스도 비활성 상태를 유지합니다. 기본 `direct` 배송은 기존 exact-OID push
+계약을 보존합니다. 이름이 있는 remote, 완전한 branch ref, 그리고 통과해야 할 순서대로
+검사를 설정합니다.
 
 ```yaml
 git_finish:
   auto_push: false
+  delivery: direct
   remote: safe-remote
   target_ref: refs/heads/main
   pre_push_checks:
@@ -452,6 +454,39 @@ push 가능한 것은 아닙니다. Yardlet은 worktree 기준점과 해당 run�
 다른 세션 또는 로컬 자동화가 출처 불명 commit을 끼워 넣으면 push 전에 fail-closed로
 중단합니다.
 
+GitHub 저장소의 기본 브랜치가 direct push를 거부할 수 있다면 자동 배송에
+옵트인합니다.
+
+```yaml
+git_finish:
+  auto_push: true
+  delivery: auto
+  remote: ""
+  target_ref: ""
+  pre_push_checks:
+    - name: tests
+      command: cargo test
+```
+
+자동 배송에는 현재 브랜치의 모호하지 않은 단일 upstream, 하나의 GitHub 저장소를
+식별하는 upstream raw remote URL, 설치되어 있고 `github.com`에 인증된 GitHub CLI
+`gh`가 필요합니다. Yardlet은 upstream remote와 branch를 GitHub의 repository identity
+및 default-branch metadata와 교차 확인합니다. 비어 있지 않은 선택적 `remote`와
+`target_ref` 값은 assertion으로 동작하며 발견 결과와 일치해야 합니다. upstream이
+없거나 모호한 경우, remote URL이 여러 개인 경우, GitHub가 아닌 provider, 없거나
+인증되지 않은 `gh`, 불충분한 push 권한, 사용할 수 없는 metadata, identity 불일치는
+모두 원격 변경 전에 fail-closed합니다. 이 모드는 GitLab, Bitbucket 및 다른 hosting
+provider를 지원하지 않습니다.
+
+GitHub가 push 권한과 보호되지 않은 default branch를 확인하면 자동 배송은 기존
+exact-OID direct 경로를 사용합니다. 보호된 branch에서는 결정적인
+`refs/heads/yardlet/runs/<run-id>` head를 대신 사용합니다. Yardlet은 예상 OID를 보호된
+base ref에 push하지 않습니다. 예상 OID를 run 소유 head에 non-force push하고 remote
+head OID를 독립 검증한 뒤, 같은 head와 base의 열린 PR 하나가 있으면 재사용하거나 PR
+하나를 만들고 별도로 조회합니다. 완료로 인정하려면 PR이 예상 head OID와 base ref를
+유지한 open 상태여야 합니다. 자동 merge, 승인 대기, merge된 branch 삭제, PR
+auto-merge는 수행하지 않습니다.
+
 같은 Git common directory, remote, target ref를 마무리하는 실행은 제한 시간이 있는
 로컬 lock으로 직렬화됩니다. lock을 잡은 동안 현재 branch와 `HEAD`가 target 및 소유
 OID와 일치하고, push 목적지가 하나이며, `.agents/` 밖에 변경이 없어야 합니다. 그다음
@@ -463,18 +498,19 @@ force-with-lease, ref 삭제, history rewrite 경로는 없습니다. 그 뒤 Ya
 `git ls-remote --refs` 조회를 실행하고 remote OID가 고정된 예상 OID와 같을 때만 성공을
 보고합니다. 같은 마무리를 반복하면 추가 push 없이 `already_applied`로 수렴합니다.
 
-`auto_push: true`일 때는 `pushed`, 독립 검증된 `already_applied`, core가 검증한 무변경
-`not_needed`만 작업을 완료합니다. 그 밖의 모든 마무리 상태는 작업, 봉인된
-`run.yaml`, telemetry, 최종 리포트와 Trust 집계에서 미완료 `Partial`로 투영됩니다.
-기본 비활성 정책에서는 `disabled`가 필수 마무리가 아니므로 일반 작업 완료 방식은
-달라지지 않습니다.
+`auto_push: true`일 때는 `pushed`, 독립 검증된 `already_applied`, 검증된
+`pull_request_open`, core가 검증한 무변경 `not_needed`만 작업을 완료합니다. 그 밖의
+모든 마무리 상태는 작업, 봉인된 `run.yaml`, telemetry, 최종 리포트와 Trust 집계에서
+미완료 `Partial`로 투영됩니다. 기본 비활성 정책에서는 `disabled`가 필수 마무리가
+아니므로 일반 작업 완료 방식은 달라지지 않습니다.
 
 | 기록 상태 | 사용자에게 보이는 의미 |
 |---|---|
 | `pushed` | 정확한 OID가 push되고 독립적으로 검증됐습니다. |
 | `already_applied` | remote에 이미 정확한 OID가 있어 push를 실행하지 않았습니다. |
+| `pull_request_open` | run 소유 head OID와 열린 PR 하나의 head 및 base가 독립적으로 검증됐습니다. |
 | `not_needed` | core가 이 run에 Git 변경이 없음을 검증해 push를 실행하지 않았습니다. |
-| `prepared` | 내구 pre-push 기록은 있지만 remote 결과가 아직 확정되지 않았으며 `recover`가 대조합니다. |
+| `prepared` | head push 전과 PR 생성 전에 각각 내구 기록이 있으며 `recover`가 현재 remote와 PR 상태를 대조합니다. |
 | `check_blocked` / `safety_blocked` | 설정 검사, 소유권 증명, lock 또는 동시 상태 게이트가 차단했으며 명시적 해결 전까지 Partial입니다. |
 | `git_failed` | Git 조회 또는 push 명령이 실패했으며 Partial로 남고 remote 성공을 주장하지 않습니다. |
 | `remote_mismatch` | push는 성공을 반환했지만 독립 검증이 불일치하므로 Partial 해결 전에 remote를 확인해야 합니다. |
@@ -483,19 +519,22 @@ force-with-lease, ref 삭제, history rewrite 경로는 없습니다. 그 뒤 Ya
 모든 결과의 권위 기록은 `.agents/checkpoints/git-finish/<run-id>.json`에 저장되며,
 대응하는 `.agents/runs/<run-id>/git-finish.json`은 사용자가 보는 projection입니다. 이
 결과는 run telemetry와 최종 리포트에도 투영됩니다. 기록에는 remote 이름, target ref,
-기준점, run 소유 및 예상 OID, push 전후 remote OID, 검사 결과, push 플래그, 사유,
-시각이 포함됩니다. remote URL, 검사 명령문이나 출력, credential, 환경값은 저장하지
+기준점, run 소유 및 예상 OID, push 전후 remote OID, 해당하는 경우 run head ref, PR
+번호와 open 상태, 검사 결과, push 플래그, 사유, 시각이 포함됩니다. repository
+identity, remote URL, PR URL, 검사 명령문이나 출력, credential, 환경값은 저장하지
 않습니다.
 
-Yardlet은 push를 호출하기 전에 `prepared`를 기록합니다. 중단 후 `yardlet recover`는
-같은 target lock 아래에서 소유권 기록을 다시 읽고 remote를 확인합니다. remote가 이미
-예상 OID라면 추가 push 없이 `already_applied`로 수렴합니다. 아직 기준점과 같다면 같은
-exact-OID push를 재시도할 수 있습니다. 그 밖의 remote 또는 로컬 상태는 fail-closed로
-중단합니다. remote 검증은 끝났지만 queue, `run.yaml` 또는 telemetry 봉인이 끊겼다면
-검증된 결과를 멱등하게 다시 투영합니다. 다른 차단·실패 상태는 조용히 재시도하거나
-완료로 승격하지 않고, 사용자가 명시적으로 해결할 때까지 Partial로 남습니다. 프로젝트
-도그푸딩과 테스트에는 local bare remote를 사용하세요. 이 계약은 Yardlet이 자신의 공개
-`origin`에 push한다고 주장하지 않습니다.
+Yardlet은 base 또는 run-head push를 호출하기 전에 `prepared`를 기록하고, head 검증
+뒤 PR 생성 전에도 다시 기록합니다. 중단 후 `yardlet recover`는 같은 target lock
+아래에서 소유권 기록을 다시 읽고 remote를 확인합니다. direct 배송은 base가 이미 예상
+OID를 포함하면 추가 push 없이 `already_applied`로 수렴합니다. PR 배송은 이미 적용된
+head push를 건너뛰고 같은 head와 base의 기존 open PR을 재사용한 뒤 head OID, base ref,
+open 상태를 독립적으로 다시 확인합니다. 충돌하는 head, 중복 PR, 불일치 PR, 그 밖의
+모호한 remote 또는 로컬 상태는 fail-closed합니다. remote 검증은 끝났지만 queue,
+`run.yaml` 또는 telemetry 봉인이 끊겼다면 검증된 결과를 멱등하게 다시 투영합니다.
+다른 차단·실패 상태는 완료로 승격하지 않고 사용자가 명시적으로 해결할 때까지
+Partial로 남습니다. 프로젝트 도그푸딩과 테스트에는 local bare remote를 사용하세요.
+이 계약은 Yardlet이 자신의 공개 `origin`에 push한다고 주장하지 않습니다.
 
 ## 크래시 안전성
 

--- a/README.md
+++ b/README.md
@@ -452,12 +452,14 @@ human gates. Design: [docs/parallel-queue.md](docs/parallel-queue.md).
 
 Automatic push is a separate, user-owned completion policy and is off by
 default. `yardlet init` writes an explicit disabled block; older workspaces
-without the block also stay disabled. Configure a named remote, a fully
+without the block also stay disabled. The default `direct` delivery preserves
+the existing exact-OID push contract. Configure a named remote, a fully
 qualified branch ref, and checks in the order they must pass:
 
 ```yaml
 git_finish:
   auto_push: false
+  delivery: direct
   remote: safe-remote
   target_ref: refs/heads/main
   pre_push_checks:
@@ -474,6 +476,41 @@ commits newly reachable from the baseline are exactly that owned set. The
 remote target must still equal the baseline. A hook, another session, or local
 automation that inserts an unowned commit therefore fails closed before push.
 
+For a GitHub repository whose default branch may reject direct pushes, opt in
+to automatic delivery:
+
+```yaml
+git_finish:
+  auto_push: true
+  delivery: auto
+  remote: ""
+  target_ref: ""
+  pre_push_checks:
+    - name: tests
+      command: cargo test
+```
+
+Automatic delivery requires the current branch to have one unambiguous
+upstream, that upstream's raw remote URL to identify one GitHub repository, and
+the GitHub CLI `gh` to be installed and authenticated for `github.com`.
+Yardlet cross-checks the upstream remote and branch with GitHub's repository
+identity and default-branch metadata. Optional non-empty `remote` and
+`target_ref` values act as assertions and must match discovery. A missing or
+ambiguous upstream, multiple remote URLs, a non-GitHub provider, missing or
+unauthenticated `gh`, insufficient push permission, unavailable metadata, or
+any identity mismatch fails closed before remote mutation. GitLab, Bitbucket,
+and other hosting providers are not supported by this mode.
+
+When GitHub confirms push permission and an unprotected default branch,
+automatic delivery uses the existing exact-OID direct path. A protected branch
+uses the deterministic `refs/heads/yardlet/runs/<run-id>` head instead. Yardlet
+never pushes the expected OID to the protected base ref. It non-force pushes
+the expected OID to that run-owned head, independently verifies the remote head
+OID, reuses the single open PR with the same head and base when present, or
+creates one PR and queries it separately. Completion requires the PR to remain
+open with the expected head OID and base ref. Automatic merge, approval
+waiting, merged-branch deletion, and PR auto-merge are not performed.
+
 Finishers for the same Git common directory, remote, and target ref are
 serialized with a bounded local lock. While holding it, Yardlet requires the
 current branch and `HEAD` to match the target and owned OID, one push
@@ -488,18 +525,19 @@ remote OID equals the frozen expected OID. Repeating the same finish converges
 to `already_applied` without another push.
 
 When `auto_push: true`, only `pushed`, independently verified
-`already_applied`, and core-verified no-change `not_needed` complete the task.
-Every other finish status projects the task, sealed `run.yaml`, telemetry,
-final report, and Trust accounting as unfinished `Partial`. With the
-default-off policy, `disabled` is not a required finish and normal task
-completion is unchanged.
+`already_applied`, verified `pull_request_open`, and core-verified no-change
+`not_needed` complete the task. Every other finish status projects the task,
+sealed `run.yaml`, telemetry, final report, and Trust accounting as unfinished
+`Partial`. With the default-off policy, `disabled` is not a required finish and
+normal task completion is unchanged.
 
 | Recorded status | User-visible meaning |
 |---|---|
 | `pushed` | The exact OID was pushed and independently verified. |
 | `already_applied` | The remote already had the exact OID; no push ran. |
+| `pull_request_open` | The run-owned head OID and the single open PR's head and base were independently verified. |
 | `not_needed` | The core verified that this run produced no Git changes; no push ran. |
-| `prepared` | The durable pre-push record exists, but the remote result is not yet known; `recover` reconciles it. |
+| `prepared` | A durable record exists before head push and again before PR creation; `recover` reconciles the current remote and PR state. |
 | `check_blocked` / `safety_blocked` | A configured check, ownership proof, lock, or concurrent-state gate blocked; the task remains Partial for explicit resolution. |
 | `git_failed` | A Git lookup or push command failed; the task remains Partial and no remote success is claimed. |
 | `remote_mismatch` | Push returned success, but independent verification did not match; inspect the remote before resolving the Partial task. |
@@ -510,20 +548,25 @@ Every outcome is written authoritatively to
 `.agents/runs/<run-id>/git-finish.json` is a user-facing projection. The result
 is also projected into run telemetry and the final report. The record includes
 the remote name, target ref, baseline, run-owned and expected OIDs, before/after
-remote OIDs, check results, push flags, reason, and timestamp. It does not store
-a remote URL, check command text or output, credentials, or environment values.
+remote OIDs, run head ref, PR number and open state when applicable, check
+results, push flags, reason, and timestamp. It does not store a repository
+identity, remote URL, PR URL, check command text or output, credentials, or
+environment values.
 
-Yardlet writes `prepared` before invoking push. After an interruption,
-`yardlet recover` reloads that ownership record under the same target lock and
-checks the remote. If the remote already equals the expected OID, recovery
-converges to `already_applied` without another push. If it still equals the
-baseline, Yardlet can retry the same exact-OID push. Any other remote or local
-state fails closed. If remote verification finished but sealing the queue,
-`run.yaml`, or telemetry was interrupted, recovery reprojects the verified
-result idempotently. Other blocked or failed statuses are not silently retried
-or promoted; they remain Partial for explicit user resolution. Use a local bare
-remote for project dogfooding and tests; this contract does not claim that
-Yardlet pushes its own public `origin`.
+Yardlet writes `prepared` before invoking either base or run-head push, and
+writes it again after head verification before PR creation. After an
+interruption, `yardlet recover` reloads that ownership record under the same
+target lock and checks the remote. Direct delivery converges to
+`already_applied` without another push when the base already contains the
+expected OID. PR delivery skips an already-applied head push, reuses an existing
+open PR for the same head and base, and independently rechecks its head OID,
+base ref, and open state. Any conflicting head, duplicate PR, mismatched PR, or
+other ambiguous remote or local state fails closed. If remote verification
+finished but sealing the queue, `run.yaml`, or telemetry was interrupted,
+recovery reprojects the verified result idempotently. Other blocked or failed
+statuses are not promoted; they remain Partial for explicit user resolution.
+Use a local bare remote for project dogfooding and tests; this contract does not
+claim that Yardlet pushes its own public `origin`.
 
 ## Crash safety
 

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant};
 use chrono::Local;
 use serde::{Deserialize, Serialize};
 
-use crate::schemas::{GitFinishPolicy, TaskState};
+use crate::schemas::{GitFinishDelivery, GitFinishPolicy, TaskState};
 use crate::state::Workspace;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -28,6 +28,7 @@ pub enum GitFinishStatus {
     Prepared,
     Pushed,
     AlreadyApplied,
+    PullRequestOpen,
     CheckBlocked,
     SafetyBlocked,
     GitFailed,
@@ -38,7 +39,11 @@ impl GitFinishStatus {
     pub fn verified_complete(self) -> bool {
         matches!(
             self,
-            Self::Pushed | Self::AlreadyApplied | Self::Disabled | Self::NotNeeded
+            Self::Pushed
+                | Self::AlreadyApplied
+                | Self::PullRequestOpen
+                | Self::Disabled
+                | Self::NotNeeded
         )
     }
 
@@ -60,6 +65,8 @@ pub struct GitFinishOwnership {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitFinishPolicySnapshot {
     pub auto_push: bool,
+    #[serde(default)]
+    pub delivery: GitFinishDelivery,
     pub remote: String,
     pub target_ref: String,
     pub pre_push_checks: Vec<String>,
@@ -92,6 +99,12 @@ pub struct GitFinishRecord {
     pub remote_oid: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_before_oid: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub head_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request_number: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pull_request_state: Option<String>,
     pub reason: String,
 }
 
@@ -109,6 +122,14 @@ impl GitFinishRecord {
                 "git finish: already applied and verified {} {}",
                 self.policy.remote, self.policy.target_ref
             ),
+            GitFinishStatus::PullRequestOpen => format!(
+                "git finish: pull request #{} open and verified {} -> {}",
+                self.pull_request_number
+                    .map(|number| number.to_string())
+                    .unwrap_or_else(|| "?".to_string()),
+                self.head_ref.as_deref().unwrap_or("<unknown-head>"),
+                self.policy.target_ref
+            ),
             GitFinishStatus::CheckBlocked => "git finish: blocked by pre-push check".to_string(),
             GitFinishStatus::SafetyBlocked => {
                 format!("git finish: safety blocked ({})", self.reason)
@@ -118,6 +139,31 @@ impl GitFinishRecord {
                 "git finish: remote verification mismatch".to_string()
             }
         }
+    }
+
+    pub(crate) fn validate_authority(&self) -> Result<(), &'static str> {
+        if !self.policy.remote.is_empty() && !remote_name_is_safe(&self.policy.remote) {
+            return Err("Git finish authority requires a remote name, never a URL or credential");
+        }
+        if !self.policy.target_ref.is_empty() && !branch_ref_label_is_safe(&self.policy.target_ref)
+        {
+            return Err("Git finish authority target ref is invalid");
+        }
+        if self.status == GitFinishStatus::PullRequestOpen {
+            let verified = self.policy.delivery == GitFinishDelivery::Auto
+                && self
+                    .head_ref
+                    .as_deref()
+                    .is_some_and(|head| head.starts_with("refs/heads/yardlet/runs/"))
+                && self.pull_request_number.is_some_and(|number| number > 0)
+                && self.pull_request_state.as_deref() == Some("open")
+                && self.expected_oid.is_some()
+                && self.remote_oid == self.expected_oid;
+            if !verified {
+                return Err("Git finish authority has an unverified pull request open record");
+            }
+        }
+        Ok(())
     }
 }
 
@@ -129,12 +175,424 @@ impl GitFinishStatus {
             Self::Prepared => "prepared",
             Self::Pushed => "pushed",
             Self::AlreadyApplied => "already_applied",
+            Self::PullRequestOpen => "pull_request_open",
             Self::CheckBlocked => "check_blocked",
             Self::SafetyBlocked => "safety_blocked",
             Self::GitFailed => "git_failed",
             Self::RemoteMismatch => "remote_mismatch",
         }
     }
+
+    pub fn telemetry_verified_complete(value: &str) -> bool {
+        value.is_empty()
+            || matches!(
+                value,
+                "disabled" | "not_needed" | "pushed" | "already_applied" | "pull_request_open"
+            )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeliveryRoute {
+    Direct,
+    PullRequest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DiscoveredGitHubRepository {
+    remote: String,
+    repository: String,
+    base_ref: String,
+    route: DeliveryRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubRepositoryMetadata {
+    name_with_owner: String,
+    default_branch: String,
+    viewer_permission: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PullRequestMetadata {
+    number: u64,
+    head_ref: String,
+    base_ref: String,
+    head_oid: String,
+    state: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiscoveryError {
+    reason: &'static str,
+}
+
+trait GitHubClient {
+    fn authenticate(&self) -> Result<(), &'static str>;
+    fn repository_metadata(
+        &self,
+        repository: &str,
+    ) -> Result<GitHubRepositoryMetadata, &'static str>;
+    fn branch_protected(&self, repository: &str, branch: &str) -> Result<bool, &'static str>;
+    fn open_pull_requests(
+        &self,
+        repository: &str,
+        head: &str,
+        base: &str,
+    ) -> Result<Vec<PullRequestMetadata>, &'static str>;
+    fn create_pull_request(
+        &self,
+        repository: &str,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<(), &'static str>;
+}
+
+struct GhCli;
+
+impl GhCli {
+    fn output(args: &[&str]) -> Result<std::process::Output, &'static str> {
+        Command::new("gh").args(args).output().map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                "gh_not_installed"
+            } else {
+                "gh_command_failed"
+            }
+        })
+    }
+}
+
+impl GitHubClient for GhCli {
+    fn authenticate(&self) -> Result<(), &'static str> {
+        let output = Self::output(&["auth", "status", "--hostname", "github.com"])?;
+        output
+            .status
+            .success()
+            .then_some(())
+            .ok_or("gh_not_authenticated")
+    }
+
+    fn repository_metadata(
+        &self,
+        repository: &str,
+    ) -> Result<GitHubRepositoryMetadata, &'static str> {
+        #[derive(Deserialize)]
+        struct Permissions {
+            push: bool,
+        }
+        #[derive(Deserialize)]
+        struct Response {
+            full_name: String,
+            default_branch: String,
+            permissions: Permissions,
+        }
+        let endpoint = format!("repos/{repository}");
+        let output = Self::output(&["api", &endpoint])?;
+        if !output.status.success() {
+            return Err("github_repository_metadata_unavailable");
+        }
+        let response: Response = serde_json::from_slice(&output.stdout)
+            .map_err(|_| "github_repository_metadata_invalid")?;
+        Ok(GitHubRepositoryMetadata {
+            name_with_owner: response.full_name,
+            default_branch: response.default_branch,
+            viewer_permission: if response.permissions.push {
+                "WRITE".to_string()
+            } else {
+                "READ".to_string()
+            },
+        })
+    }
+
+    fn branch_protected(&self, repository: &str, branch: &str) -> Result<bool, &'static str> {
+        #[derive(Deserialize)]
+        struct Response {
+            protected: bool,
+        }
+        let endpoint = format!(
+            "repos/{repository}/branches/{}",
+            percent_encode_component(branch)
+        );
+        let output = Self::output(&["api", &endpoint])?;
+        if !output.status.success() {
+            return Err("github_default_branch_metadata_unavailable");
+        }
+        serde_json::from_slice::<Response>(&output.stdout)
+            .map(|response| response.protected)
+            .map_err(|_| "github_default_branch_metadata_invalid")
+    }
+
+    fn open_pull_requests(
+        &self,
+        repository: &str,
+        head: &str,
+        base: &str,
+    ) -> Result<Vec<PullRequestMetadata>, &'static str> {
+        #[derive(Deserialize)]
+        struct RefInfo {
+            #[serde(rename = "ref")]
+            name: String,
+            sha: String,
+        }
+        #[derive(Deserialize)]
+        struct Response {
+            number: u64,
+            state: String,
+            head: RefInfo,
+            base: RefInfo,
+        }
+        let owner = repository
+            .split_once('/')
+            .map(|(owner, _)| owner)
+            .ok_or("github_repository_identity_invalid")?;
+        let endpoint = format!("repos/{repository}/pulls");
+        let head_filter = format!("{owner}:{head}");
+        let output = Self::output(&[
+            "api",
+            "--method",
+            "GET",
+            &endpoint,
+            "-f",
+            "state=open",
+            "-f",
+            &format!("head={head_filter}"),
+            "-f",
+            &format!("base={base}"),
+        ])?;
+        if !output.status.success() {
+            return Err("pull_request_lookup_failed");
+        }
+        let responses: Vec<Response> =
+            serde_json::from_slice(&output.stdout).map_err(|_| "pull_request_metadata_invalid")?;
+        Ok(responses
+            .into_iter()
+            .map(|response| PullRequestMetadata {
+                number: response.number,
+                head_ref: response.head.name,
+                base_ref: response.base.name,
+                head_oid: response.head.sha,
+                state: response.state,
+            })
+            .collect())
+    }
+
+    fn create_pull_request(
+        &self,
+        repository: &str,
+        head: &str,
+        base: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<(), &'static str> {
+        let endpoint = format!("repos/{repository}/pulls");
+        let output = Self::output(&[
+            "api",
+            "--method",
+            "POST",
+            &endpoint,
+            "-f",
+            &format!("head={head}"),
+            "-f",
+            &format!("base={base}"),
+            "-f",
+            &format!("title={title}"),
+            "-f",
+            &format!("body={body}"),
+        ])?;
+        output
+            .status
+            .success()
+            .then_some(())
+            .ok_or("pull_request_create_failed")
+    }
+}
+
+fn percent_encode_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn github_repository_from_remote_url(url: &str) -> Option<String> {
+    let trimmed = url.trim().trim_end_matches('/');
+    let path = if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
+        rest
+    } else if let Some(rest) = trimmed.strip_prefix("ssh://git@github.com/") {
+        rest
+    } else {
+        trimmed.strip_prefix("https://github.com/")?
+    };
+    let repository = path.strip_suffix(".git").unwrap_or(path);
+    let (owner, name) = repository.split_once('/')?;
+    if owner.is_empty()
+        || name.is_empty()
+        || name.contains('/')
+        || !owner
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+    {
+        return None;
+    }
+    Some(format!("{owner}/{name}"))
+}
+
+fn discover_github_repository(
+    root: &Path,
+    policy: &GitFinishPolicy,
+    github: &dyn GitHubClient,
+) -> Result<DiscoveredGitHubRepository, DiscoveryError> {
+    let upstream = git_stdout(root, &["rev-parse", "--symbolic-full-name", "@{upstream}"])
+        .map(|value| value.trim().to_string())
+        .filter(|value| value.starts_with("refs/remotes/"))
+        .ok_or(DiscoveryError {
+            reason: "upstream_not_configured",
+        })?;
+    let remotes = git_stdout(root, &["remote"])
+        .ok_or(DiscoveryError {
+            reason: "remote_list_unavailable",
+        })?
+        .lines()
+        .map(str::trim)
+        .filter(|remote| !remote.is_empty())
+        .filter_map(|remote| {
+            upstream
+                .strip_prefix(&format!("refs/remotes/{remote}/"))
+                .filter(|branch| !branch.is_empty())
+                .map(|branch| (remote.to_string(), branch.to_string()))
+        })
+        .collect::<Vec<_>>();
+    if remotes.len() != 1 {
+        return Err(DiscoveryError {
+            reason: "upstream_remote_ambiguous",
+        });
+    }
+    let (remote, upstream_branch) = &remotes[0];
+    if !policy.remote.trim().is_empty() && policy.remote != *remote {
+        return Err(DiscoveryError {
+            reason: "configured_remote_conflicts_with_upstream",
+        });
+    }
+    let raw_remote_urls_text = git_stdout(
+        root,
+        &["config", "--get-all", &format!("remote.{remote}.url")],
+    )
+    .ok_or(DiscoveryError {
+        reason: "remote_url_unavailable",
+    })?;
+    let raw_remote_urls = raw_remote_urls_text
+        .lines()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    if raw_remote_urls.len() != 1 {
+        return Err(DiscoveryError {
+            reason: "remote_url_ambiguous",
+        });
+    }
+    let repository =
+        github_repository_from_remote_url(raw_remote_urls[0]).ok_or(DiscoveryError {
+            reason: "remote_provider_not_github",
+        })?;
+    github
+        .authenticate()
+        .map_err(|reason| DiscoveryError { reason })?;
+    let metadata = github
+        .repository_metadata(&repository)
+        .map_err(|reason| DiscoveryError { reason })?;
+    if !metadata.name_with_owner.eq_ignore_ascii_case(&repository) {
+        return Err(DiscoveryError {
+            reason: "github_repository_identity_mismatch",
+        });
+    }
+    if metadata.default_branch.trim().is_empty() || metadata.default_branch != *upstream_branch {
+        return Err(DiscoveryError {
+            reason: "github_default_branch_mismatch",
+        });
+    }
+    let base_ref = format!("refs/heads/{}", metadata.default_branch);
+    if !policy.target_ref.trim().is_empty() && policy.target_ref != base_ref {
+        return Err(DiscoveryError {
+            reason: "configured_target_conflicts_with_github_default",
+        });
+    }
+    if !matches!(
+        metadata.viewer_permission.as_str(),
+        "WRITE" | "MAINTAIN" | "ADMIN"
+    ) {
+        return Err(DiscoveryError {
+            reason: "github_push_permission_insufficient",
+        });
+    }
+    let protected = github
+        .branch_protected(&repository, &metadata.default_branch)
+        .map_err(|reason| DiscoveryError { reason })?;
+    let route = if protected {
+        DeliveryRoute::PullRequest
+    } else {
+        DeliveryRoute::Direct
+    };
+    Ok(DiscoveredGitHubRepository {
+        remote: remote.clone(),
+        repository,
+        base_ref,
+        route,
+    })
+}
+
+fn deterministic_head_ref(run_id: &str) -> Option<String> {
+    if run_id.trim().is_empty() || run_id.contains([' ', ':', '^', '~']) {
+        return None;
+    }
+    let head_ref = format!("refs/heads/yardlet/runs/{run_id}");
+    (!head_ref.ends_with('/') && git_ref_component_safe(run_id)).then_some(head_ref)
+}
+
+fn git_ref_component_safe(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        && !value.starts_with('.')
+        && !value.ends_with('.')
+        && !value.contains("..")
+        && !value.contains("@{")
+}
+
+fn remote_name_is_safe(value: &str) -> bool {
+    !value.is_empty()
+        && !value.contains("://")
+        && !value.contains('@')
+        && !value.contains(':')
+        && !value.contains('\\')
+        && value
+            .bytes()
+            .all(|byte| !byte.is_ascii_whitespace() && !byte.is_ascii_control())
+}
+
+fn branch_ref_label_is_safe(value: &str) -> bool {
+    let Some(branch) = value.strip_prefix("refs/heads/") else {
+        return false;
+    };
+    !branch.is_empty()
+        && !branch.starts_with('/')
+        && !branch.ends_with('/')
+        && !branch.ends_with('.')
+        && !branch.contains("..")
+        && !branch.contains("@{")
+        && !branch
+            .bytes()
+            .any(|byte| byte.is_ascii_control() || byte.is_ascii_whitespace())
+        && !branch.contains([':', '^', '~', '?', '*', '[', '\\'])
 }
 
 /// Fail closed before a worker is spawned when an enabled Git-finish policy
@@ -152,10 +610,26 @@ pub(crate) fn preflight_target_before_spawn(
     if !policy.auto_push {
         return Ok(());
     }
+    let effective_target = if policy.delivery == GitFinishDelivery::Auto {
+        match discover_github_repository(&ws.root, policy, &GhCli) {
+            Ok(discovered) => discovered.base_ref,
+            Err(error) => {
+                let mut record = base_record(run_id, task_id, policy, None);
+                block(&mut record, error.reason);
+                persist(ws, run_dir, &record)?;
+                anyhow::bail!(
+                    "GitHub Git finish discovery failed before worker spawn: {}",
+                    error.reason
+                );
+            }
+        }
+    } else {
+        policy.target_ref.clone()
+    };
     let checkout_ref = git_stdout(&ws.root, &["symbolic-ref", "--quiet", "HEAD"])
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
-    if checkout_ref.as_deref() == Some(policy.target_ref.as_str()) {
+    if checkout_ref.as_deref() == Some(effective_target.as_str()) {
         return Ok(());
     }
 
@@ -169,7 +643,7 @@ pub(crate) fn preflight_target_before_spawn(
     anyhow::bail!(
         "branch_does_not_match_target_ref: configured Git finish target_ref '{}' \
          does not match checkout ref '{}'; update git_finish.target_ref before running",
-        policy.target_ref,
+        effective_target,
         observed
     )
 }
@@ -182,14 +656,41 @@ pub fn finish_owned_run(
     task_state: TaskState,
     ownership: Option<GitFinishOwnership>,
 ) -> anyhow::Result<GitFinishRecord> {
-    finish_owned_run_with_mode(
-        ws,
-        run_dir,
-        run_id,
-        task_id,
-        task_state,
-        ownership,
+    finish_owned_run_with_mode_and_github(
+        FinishOwnedInput {
+            ws,
+            run_dir,
+            run_id,
+            task_id,
+            task_state,
+            ownership,
+        },
         FinishMode::CurrentHead,
+        &GhCli,
+    )
+}
+
+#[cfg(test)]
+fn finish_owned_run_with_github(
+    ws: &Workspace,
+    run_dir: &Path,
+    run_id: &str,
+    task_id: &str,
+    task_state: TaskState,
+    ownership: Option<GitFinishOwnership>,
+    github: &dyn GitHubClient,
+) -> anyhow::Result<GitFinishRecord> {
+    finish_owned_run_with_mode_and_github(
+        FinishOwnedInput {
+            ws,
+            run_dir,
+            run_id,
+            task_id,
+            task_state,
+            ownership,
+        },
+        FinishMode::CurrentHead,
+        github,
     )
 }
 
@@ -245,14 +746,17 @@ pub(crate) fn recover_owned_run(
     ownership: Option<GitFinishOwnership>,
     preserve_verified: bool,
 ) -> anyhow::Result<GitFinishRecord> {
-    finish_owned_run_with_mode(
-        ws,
-        run_dir,
-        run_id,
-        task_id,
-        task_state,
-        ownership,
+    finish_owned_run_with_mode_and_github(
+        FinishOwnedInput {
+            ws,
+            run_dir,
+            run_id,
+            task_id,
+            task_state,
+            ownership,
+        },
         FinishMode::AccumulatedHead { preserve_verified },
+        &GhCli,
     )
 }
 
@@ -271,15 +775,28 @@ impl FinishMode {
     }
 }
 
-fn finish_owned_run_with_mode(
-    ws: &Workspace,
-    run_dir: &Path,
-    run_id: &str,
-    task_id: &str,
+struct FinishOwnedInput<'a> {
+    ws: &'a Workspace,
+    run_dir: &'a Path,
+    run_id: &'a str,
+    task_id: &'a str,
     task_state: TaskState,
     ownership: Option<GitFinishOwnership>,
+}
+
+fn finish_owned_run_with_mode_and_github(
+    input: FinishOwnedInput<'_>,
     mode: FinishMode,
+    github: &dyn GitHubClient,
 ) -> anyhow::Result<GitFinishRecord> {
+    let FinishOwnedInput {
+        ws,
+        run_dir,
+        run_id,
+        task_id,
+        task_state,
+        ownership,
+    } = input;
     let previous = ws.load_git_finish_record(run_dir).ok();
     let verified_floor = previous
         .as_ref()
@@ -287,7 +804,7 @@ fn finish_owned_run_with_mode(
         .cloned();
     let persist_result =
         |record| persist_with_verified_floor(ws, run_dir, record, verified_floor.as_ref());
-    let policy = match ws.load_config() {
+    let configured_policy = match ws.load_config() {
         Ok(config) => config.git_finish,
         Err(_) => {
             let policy = GitFinishPolicy::default();
@@ -296,9 +813,29 @@ fn finish_owned_run_with_mode(
             return persist_result(record);
         }
     };
+    let discovery =
+        if configured_policy.auto_push && configured_policy.delivery == GitFinishDelivery::Auto {
+            match discover_github_repository(&ws.root, &configured_policy, github) {
+                Ok(discovered) => Some(discovered),
+                Err(error) => {
+                    let mut record =
+                        base_record(run_id, task_id, &configured_policy, ownership.as_ref());
+                    block(&mut record, error.reason);
+                    return persist_result(record);
+                }
+            }
+        } else {
+            None
+        };
+    let mut policy = configured_policy;
+    if let Some(discovered) = discovery.as_ref() {
+        policy.remote.clone_from(&discovered.remote);
+        policy.target_ref.clone_from(&discovered.base_ref);
+    }
     let target_changed = previous.as_ref().is_some_and(|record| {
         record.policy.auto_push
-            && (record.policy.remote != policy.remote
+            && (record.policy.delivery != policy.delivery
+                || record.policy.remote != policy.remote
                 || record.policy.target_ref != policy.target_ref)
     });
     let recorded_ownership = previous.as_ref().and_then(record_ownership);
@@ -488,6 +1025,151 @@ fn finish_owned_run_with_mode(
         }
     }
 
+    if discovery
+        .as_ref()
+        .is_some_and(|discovered| discovered.route == DeliveryRoute::PullRequest)
+    {
+        let discovered = discovery.as_ref().expect("route checked above");
+        let Some(head_ref) = deterministic_head_ref(run_id) else {
+            block(&mut record, "run_head_ref_invalid");
+            return persist_result(record);
+        };
+        if !git_ok(&ws.root, &["check-ref-format", &head_ref]) {
+            block(&mut record, "run_head_ref_invalid");
+            return persist_result(record);
+        }
+        let head_branch = head_ref
+            .strip_prefix("refs/heads/")
+            .expect("deterministic head is a branch ref");
+        let head_before = match remote_oid(&ws.root, &policy.remote, &head_ref) {
+            Ok(Some(oid)) if oid == expected => Some(oid),
+            Ok(Some(oid)) => {
+                record.status = GitFinishStatus::RemoteMismatch;
+                record.remote_oid = Some(oid);
+                record.head_ref = Some(head_ref);
+                record.reason = "run_head_ref_oid_conflict".to_string();
+                return persist_result(record);
+            }
+            Ok(None) => None,
+            Err(()) => {
+                record.status = GitFinishStatus::GitFailed;
+                record.reason = "run_head_lookup_before_push_failed".to_string();
+                return persist_result(record);
+            }
+        };
+        record.head_ref = Some(head_ref.clone());
+
+        // Persist before the first possible remote mutation. Recovery can
+        // compare the deterministic head ref with expected_oid after a crash
+        // and skip a push that already landed.
+        record.status = GitFinishStatus::Prepared;
+        record.reason = "ready_to_push_run_head".to_string();
+        persist(ws, run_dir, &record)?;
+
+        if head_before.is_none() {
+            record.push_invoked = true;
+            let refspec = format!("{expected}:{head_ref}");
+            if !git_ok(
+                &ws.root,
+                &["push", "--porcelain", "--", &push_destination, &refspec],
+            ) {
+                record.status = GitFinishStatus::GitFailed;
+                record.reason = "run_head_push_failed".to_string();
+                return persist_result(record);
+            }
+            record.push_succeeded = true;
+        }
+        match remote_oid(&ws.root, &policy.remote, &head_ref) {
+            Ok(Some(oid)) if oid == expected => {
+                record.remote_oid = Some(oid);
+            }
+            Ok(oid) => {
+                record.status = GitFinishStatus::RemoteMismatch;
+                record.remote_oid = oid;
+                record.reason = "run_head_oid_does_not_match_expected".to_string();
+                return persist_result(record);
+            }
+            Err(()) => {
+                record.status = GitFinishStatus::GitFailed;
+                record.reason = "run_head_lookup_after_push_failed".to_string();
+                return persist_result(record);
+            }
+        }
+
+        // PR creation has its own durable gate after independent head
+        // verification. If the process exits after creation, recovery queries
+        // the same head/base pair and reuses the open PR.
+        record.status = GitFinishStatus::Prepared;
+        record.reason = "ready_to_create_or_reuse_pull_request".to_string();
+        persist(ws, run_dir, &record)?;
+        let mut pull_requests =
+            match github.open_pull_requests(&discovered.repository, head_branch, branch) {
+                Ok(pull_requests) => pull_requests,
+                Err(reason) => {
+                    record.status = GitFinishStatus::GitFailed;
+                    record.reason = reason.to_string();
+                    return persist_result(record);
+                }
+            };
+        let reused = !pull_requests.is_empty();
+        if pull_requests.is_empty() {
+            let title = format!("Yardlet run {run_id}: {task_id}");
+            let body = format!(
+                "Yardlet run `{run_id}` delivered the core-verified commit for task `{task_id}`."
+            );
+            if let Err(reason) = github.create_pull_request(
+                &discovered.repository,
+                head_branch,
+                branch,
+                &title,
+                &body,
+            ) {
+                record.status = GitFinishStatus::GitFailed;
+                record.reason = reason.to_string();
+                return persist_result(record);
+            }
+            pull_requests =
+                match github.open_pull_requests(&discovered.repository, head_branch, branch) {
+                    Ok(pull_requests) => pull_requests,
+                    Err(reason) => {
+                        record.status = GitFinishStatus::GitFailed;
+                        record.reason = reason.to_string();
+                        return persist_result(record);
+                    }
+                };
+        }
+        if pull_requests.len() != 1 {
+            record.status = GitFinishStatus::RemoteMismatch;
+            record.reason = if pull_requests.is_empty() {
+                "pull_request_not_open_after_create"
+            } else {
+                "multiple_open_pull_requests_for_run_head"
+            }
+            .to_string();
+            return persist_result(record);
+        }
+        let pull_request = pull_requests.remove(0);
+        if !pull_request.state.eq_ignore_ascii_case("open")
+            || pull_request.head_ref != head_branch
+            || pull_request.base_ref != branch
+            || pull_request.head_oid != expected
+        {
+            record.status = GitFinishStatus::RemoteMismatch;
+            record.reason = "pull_request_verification_mismatch".to_string();
+            return persist_result(record);
+        }
+        record.status = GitFinishStatus::PullRequestOpen;
+        record.pull_request_number = Some(pull_request.number);
+        record.pull_request_state = Some("open".to_string());
+        record.reason = if reused {
+            "pull_request_reused_and_verified"
+        } else {
+            "pull_request_created_and_verified"
+        }
+        .to_string();
+        return persist_result(record);
+    }
+
     // This durable write is a hard gate. If Yardlet cannot record that it is
     // about to mutate the remote, the error reaches the completion path and no
     // push subprocess is started.
@@ -543,15 +1225,24 @@ fn base_record(
     ownership: Option<&GitFinishOwnership>,
 ) -> GitFinishRecord {
     GitFinishRecord {
-        schema_version: 2,
+        schema_version: 3,
         run_id: run_id.to_string(),
         task_id: task_id.to_string(),
         attempted_at: Local::now().to_rfc3339(),
         status: GitFinishStatus::Disabled,
         policy: GitFinishPolicySnapshot {
             auto_push: policy.auto_push,
-            remote: policy.remote.clone(),
-            target_ref: policy.target_ref.clone(),
+            delivery: policy.delivery,
+            remote: if remote_name_is_safe(&policy.remote) {
+                policy.remote.clone()
+            } else {
+                String::new()
+            },
+            target_ref: if branch_ref_label_is_safe(&policy.target_ref) {
+                policy.target_ref.clone()
+            } else {
+                String::new()
+            },
             pre_push_checks: policy
                 .pre_push_checks
                 .iter()
@@ -571,6 +1262,9 @@ fn base_record(
         push_succeeded: false,
         remote_oid: None,
         remote_before_oid: None,
+        head_ref: None,
+        pull_request_number: None,
+        pull_request_state: None,
         reason: "policy_disabled".to_string(),
     }
 }
@@ -900,8 +1594,9 @@ fn shell_ok(root: &Path, command: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::schemas::{GitFinishCheck, GitFinishPolicy};
+    use crate::schemas::{GitFinishCheck, GitFinishDelivery, GitFinishPolicy};
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Mutex;
 
     static NEXT: AtomicU64 = AtomicU64::new(1);
 
@@ -954,11 +1649,52 @@ mod tests {
             let mut cfg = self.ws.load_config().unwrap();
             cfg.git_finish = GitFinishPolicy {
                 auto_push: true,
+                delivery: GitFinishDelivery::Direct,
                 remote: "fixture".to_string(),
                 target_ref: "refs/heads/main".to_string(),
                 pre_push_checks: checks,
             };
             crate::state::save_yaml(&self.ws.config_path(), &cfg).unwrap();
+        }
+
+        fn configure_auto(&self) {
+            let mut cfg = self.ws.load_config().unwrap();
+            cfg.git_finish = GitFinishPolicy {
+                auto_push: true,
+                delivery: GitFinishDelivery::Auto,
+                remote: String::new(),
+                target_ref: String::new(),
+                pre_push_checks: vec![],
+            };
+            crate::state::save_yaml(&self.ws.config_path(), &cfg).unwrap();
+            cmd(
+                &self.root,
+                &["branch", "--set-upstream-to=fixture/main", "main"],
+            );
+            cmd(
+                &self.root,
+                &[
+                    "config",
+                    "remote.fixture.url",
+                    "https://github.com/acme/project.git",
+                ],
+            );
+            cmd(
+                &self.root,
+                &[
+                    "config",
+                    &format!("url.{}.insteadOf", self.remote.display()),
+                    "https://github.com/acme/project.git",
+                ],
+            );
+            cmd(
+                &self.root,
+                &[
+                    "config",
+                    &format!("url.{}.pushInsteadOf", self.remote.display()),
+                    "https://github.com/acme/project.git",
+                ],
+            );
         }
 
         fn commit(&self, text: &str) -> String {
@@ -1058,6 +1794,225 @@ mod tests {
         }
     }
 
+    struct FakeGithub {
+        protected: bool,
+        prs: Mutex<Vec<PullRequestMetadata>>,
+        create_count: AtomicU64,
+        expected_oid: Mutex<String>,
+        prepared_probe: Mutex<Option<(Workspace, PathBuf)>>,
+        prepared_seen_before_create: Mutex<bool>,
+    }
+
+    impl FakeGithub {
+        fn new(protected: bool) -> Self {
+            Self {
+                protected,
+                prs: Mutex::new(vec![]),
+                create_count: AtomicU64::new(0),
+                expected_oid: Mutex::new(String::new()),
+                prepared_probe: Mutex::new(None),
+                prepared_seen_before_create: Mutex::new(false),
+            }
+        }
+
+        fn expect_create_after_prepared(&self, expected_oid: &str, ws: &Workspace, run_dir: &Path) {
+            *self.expected_oid.lock().unwrap() = expected_oid.to_string();
+            *self.prepared_probe.lock().unwrap() = Some((ws.clone(), run_dir.to_path_buf()));
+        }
+    }
+
+    impl GitHubClient for FakeGithub {
+        fn authenticate(&self) -> Result<(), &'static str> {
+            Ok(())
+        }
+
+        fn repository_metadata(
+            &self,
+            _repository: &str,
+        ) -> Result<GitHubRepositoryMetadata, &'static str> {
+            Ok(GitHubRepositoryMetadata {
+                name_with_owner: "acme/project".into(),
+                default_branch: "main".into(),
+                viewer_permission: "WRITE".into(),
+            })
+        }
+
+        fn branch_protected(&self, _repository: &str, _branch: &str) -> Result<bool, &'static str> {
+            Ok(self.protected)
+        }
+
+        fn open_pull_requests(
+            &self,
+            _repository: &str,
+            _head: &str,
+            _base: &str,
+        ) -> Result<Vec<PullRequestMetadata>, &'static str> {
+            Ok(self.prs.lock().unwrap().clone())
+        }
+
+        fn create_pull_request(
+            &self,
+            _repository: &str,
+            head: &str,
+            base: &str,
+            _title: &str,
+            _body: &str,
+        ) -> Result<(), &'static str> {
+            if let Some((ws, run_dir)) = self.prepared_probe.lock().unwrap().as_ref() {
+                let record = ws.load_git_finish_record(run_dir).unwrap();
+                *self.prepared_seen_before_create.lock().unwrap() = record.status
+                    == GitFinishStatus::Prepared
+                    && record.remote_oid.as_deref()
+                        == Some(self.expected_oid.lock().unwrap().as_str());
+            }
+            self.create_count.fetch_add(1, Ordering::SeqCst);
+            self.prs.lock().unwrap().push(PullRequestMetadata {
+                number: 41,
+                head_ref: head.to_string(),
+                base_ref: base.to_string(),
+                head_oid: self.expected_oid.lock().unwrap().clone(),
+                state: "OPEN".into(),
+            });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn ac_002_auto_delivery_cross_checks_upstream_remote_and_github_metadata() {
+        let f = Fixture::new("auto-discovery");
+        f.configure_auto();
+        let policy = f.ws.load_config().unwrap().git_finish;
+        let github = FakeGithub::new(false);
+
+        let discovered = discover_github_repository(&f.root, &policy, &github).unwrap();
+
+        assert_eq!(discovered.remote, "fixture");
+        assert_eq!(discovered.repository, "acme/project");
+        assert_eq!(discovered.base_ref, "refs/heads/main");
+        assert_eq!(discovered.route, DeliveryRoute::Direct);
+
+        let mut conflicting = policy;
+        conflicting.remote = "other".into();
+        assert_eq!(
+            discover_github_repository(&f.root, &conflicting, &github)
+                .unwrap_err()
+                .reason,
+            "configured_remote_conflicts_with_upstream"
+        );
+    }
+
+    #[test]
+    fn auto_delivery_rejects_multiple_remote_repository_identities() {
+        let f = Fixture::new("auto-ambiguous-remote-url");
+        f.configure_auto();
+        cmd(
+            &f.root,
+            &[
+                "config",
+                "--add",
+                "remote.fixture.url",
+                "https://github.com/other/project.git",
+            ],
+        );
+        let policy = f.ws.load_config().unwrap().git_finish;
+        let github = FakeGithub::new(false);
+
+        let error = discover_github_repository(&f.root, &policy, &github).unwrap_err();
+
+        assert_eq!(error.reason, "remote_url_ambiguous");
+    }
+
+    #[test]
+    fn ac_003_protected_target_pushes_exact_oid_only_to_deterministic_run_head() {
+        let f = Fixture::new("auto-pr-head");
+        f.configure_auto();
+        let oid = f.commit("owned");
+        let github = FakeGithub::new(true);
+        github.expect_create_after_prepared(&oid, &f.ws, &f.run_dir);
+
+        let record = finish_owned_run_with_github(
+            &f.ws,
+            &f.run_dir,
+            "run-test",
+            "YARD-001",
+            TaskState::Done,
+            Some(f.ownership(oid.clone())),
+            &github,
+        )
+        .unwrap();
+
+        assert_eq!(record.status, GitFinishStatus::PullRequestOpen);
+        assert_eq!(
+            remote_oid(&f.root, "fixture", "refs/heads/main").unwrap(),
+            Some(f.initial_oid.clone())
+        );
+        let head_ref = deterministic_head_ref("run-test").unwrap();
+        assert_eq!(record.head_ref.as_deref(), Some(head_ref.as_str()));
+        assert_eq!(
+            remote_oid(&f.root, "fixture", &head_ref).unwrap(),
+            Some(oid)
+        );
+    }
+
+    #[test]
+    fn ac_004_pr_create_is_prepared_first_then_reused_and_independently_verified() {
+        let f = Fixture::new("auto-pr-recovery");
+        f.configure_auto();
+        let oid = f.commit("owned");
+        let proof = f.ownership(oid.clone());
+        let github = FakeGithub::new(true);
+        github.expect_create_after_prepared(&oid, &f.ws, &f.run_dir);
+
+        let first = finish_owned_run_with_github(
+            &f.ws,
+            &f.run_dir,
+            "run-test",
+            "YARD-001",
+            TaskState::Done,
+            Some(proof.clone()),
+            &github,
+        )
+        .unwrap();
+        let repeated = finish_owned_run_with_mode_and_github(
+            FinishOwnedInput {
+                ws: &f.ws,
+                run_dir: &f.run_dir,
+                run_id: "run-test",
+                task_id: "YARD-001",
+                task_state: TaskState::Done,
+                ownership: Some(proof),
+            },
+            FinishMode::AccumulatedHead {
+                preserve_verified: false,
+            },
+            &github,
+        )
+        .unwrap();
+
+        assert!(*github.prepared_seen_before_create.lock().unwrap());
+        assert_eq!(github.create_count.load(Ordering::SeqCst), 1);
+        assert_eq!(first.status, GitFinishStatus::PullRequestOpen);
+        assert_eq!(repeated.status, GitFinishStatus::PullRequestOpen);
+        assert_eq!(repeated.pull_request_number, Some(41));
+        assert_eq!(repeated.pull_request_state.as_deref(), Some("open"));
+        assert!(!repeated.push_invoked);
+
+        github.prs.lock().unwrap()[0].head_oid = "0".repeat(40);
+        let mismatched = finish_owned_run_with_github(
+            &f.ws,
+            &f.run_dir,
+            "run-test",
+            "YARD-001",
+            TaskState::Done,
+            Some(f.ownership(oid)),
+            &github,
+        )
+        .unwrap();
+        assert_eq!(mismatched.status, GitFinishStatus::RemoteMismatch);
+        assert_eq!(mismatched.reason, "pull_request_verification_mismatch");
+        assert!(!mismatched.status.verified_complete());
+    }
+
     #[test]
     fn legacy_config_defaults_to_no_remote_mutation() {
         let f = Fixture::new("default-off");
@@ -1088,23 +2043,33 @@ mod tests {
 
     #[test]
     fn only_verified_or_disabled_statuses_are_complete() {
-        for status in [
+        let incomplete = [
             GitFinishStatus::Prepared,
             GitFinishStatus::CheckBlocked,
             GitFinishStatus::SafetyBlocked,
             GitFinishStatus::GitFailed,
             GitFinishStatus::RemoteMismatch,
-        ] {
+        ];
+        for status in incomplete {
             assert!(!status.verified_complete(), "{status:?}");
+            assert!(!GitFinishStatus::telemetry_verified_complete(
+                status.as_str()
+            ));
         }
-        for status in [
+        let complete = [
             GitFinishStatus::Disabled,
             GitFinishStatus::NotNeeded,
             GitFinishStatus::Pushed,
             GitFinishStatus::AlreadyApplied,
-        ] {
+            GitFinishStatus::PullRequestOpen,
+        ];
+        for status in complete {
             assert!(status.verified_complete(), "{status:?}");
+            assert!(GitFinishStatus::telemetry_verified_complete(
+                status.as_str()
+            ));
         }
+        assert!(GitFinishStatus::telemetry_verified_complete(""));
     }
 
     #[test]

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -201,9 +201,16 @@ enum DeliveryRoute {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DiscoveredGitHubRepository {
     remote: String,
+    host: String,
     repository: String,
     base_ref: String,
     route: DeliveryRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitHubRemoteIdentity {
+    host: String,
+    repository: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -228,20 +235,28 @@ struct DiscoveryError {
 }
 
 trait GitHubClient {
-    fn authenticate(&self) -> Result<(), &'static str>;
+    fn authenticate(&self, host: &str) -> Result<(), &'static str>;
     fn repository_metadata(
         &self,
+        host: &str,
         repository: &str,
     ) -> Result<GitHubRepositoryMetadata, &'static str>;
-    fn branch_protected(&self, repository: &str, branch: &str) -> Result<bool, &'static str>;
+    fn branch_protected(
+        &self,
+        host: &str,
+        repository: &str,
+        branch: &str,
+    ) -> Result<bool, &'static str>;
     fn open_pull_requests(
         &self,
+        host: &str,
         repository: &str,
         head: &str,
         base: &str,
     ) -> Result<Vec<PullRequestMetadata>, &'static str>;
     fn create_pull_request(
         &self,
+        host: &str,
         repository: &str,
         head: &str,
         base: &str,
@@ -265,8 +280,8 @@ impl GhCli {
 }
 
 impl GitHubClient for GhCli {
-    fn authenticate(&self) -> Result<(), &'static str> {
-        let output = Self::output(&["auth", "status", "--hostname", "github.com"])?;
+    fn authenticate(&self, host: &str) -> Result<(), &'static str> {
+        let output = Self::output(&["auth", "status", "--hostname", host])?;
         output
             .status
             .success()
@@ -276,6 +291,7 @@ impl GitHubClient for GhCli {
 
     fn repository_metadata(
         &self,
+        host: &str,
         repository: &str,
     ) -> Result<GitHubRepositoryMetadata, &'static str> {
         #[derive(Deserialize)]
@@ -289,7 +305,7 @@ impl GitHubClient for GhCli {
             permissions: Permissions,
         }
         let endpoint = format!("repos/{repository}");
-        let output = Self::output(&["api", &endpoint])?;
+        let output = Self::output(&["api", "--hostname", host, &endpoint])?;
         if !output.status.success() {
             return Err("github_repository_metadata_unavailable");
         }
@@ -306,7 +322,12 @@ impl GitHubClient for GhCli {
         })
     }
 
-    fn branch_protected(&self, repository: &str, branch: &str) -> Result<bool, &'static str> {
+    fn branch_protected(
+        &self,
+        host: &str,
+        repository: &str,
+        branch: &str,
+    ) -> Result<bool, &'static str> {
         #[derive(Deserialize)]
         struct Response {
             protected: bool,
@@ -315,7 +336,7 @@ impl GitHubClient for GhCli {
             "repos/{repository}/branches/{}",
             percent_encode_component(branch)
         );
-        let output = Self::output(&["api", &endpoint])?;
+        let output = Self::output(&["api", "--hostname", host, &endpoint])?;
         if !output.status.success() {
             return Err("github_default_branch_metadata_unavailable");
         }
@@ -326,6 +347,7 @@ impl GitHubClient for GhCli {
 
     fn open_pull_requests(
         &self,
+        host: &str,
         repository: &str,
         head: &str,
         base: &str,
@@ -351,6 +373,8 @@ impl GitHubClient for GhCli {
         let head_filter = format!("{owner}:{head}");
         let output = Self::output(&[
             "api",
+            "--hostname",
+            host,
             "--method",
             "GET",
             &endpoint,
@@ -380,6 +404,7 @@ impl GitHubClient for GhCli {
 
     fn create_pull_request(
         &self,
+        host: &str,
         repository: &str,
         head: &str,
         base: &str,
@@ -389,6 +414,8 @@ impl GitHubClient for GhCli {
         let endpoint = format!("repos/{repository}/pulls");
         let output = Self::output(&[
             "api",
+            "--hostname",
+            host,
             "--method",
             "POST",
             &endpoint,
@@ -421,15 +448,18 @@ fn percent_encode_component(value: &str) -> String {
     encoded
 }
 
-fn github_repository_from_remote_url(url: &str) -> Option<String> {
+fn github_remote_identity_from_url(url: &str) -> Option<GitHubRemoteIdentity> {
     let trimmed = url.trim().trim_end_matches('/');
-    let path = if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
-        rest
-    } else if let Some(rest) = trimmed.strip_prefix("ssh://git@github.com/") {
-        rest
+    let (host, path) = if let Some(rest) = trimmed.strip_prefix("git@") {
+        rest.split_once(':')?
+    } else if let Some(rest) = trimmed.strip_prefix("ssh://git@") {
+        rest.split_once('/')?
     } else {
-        trimmed.strip_prefix("https://github.com/")?
+        trimmed.strip_prefix("https://")?.split_once('/')?
     };
+    if !github_host_safe(host) {
+        return None;
+    }
     let repository = path.strip_suffix(".git").unwrap_or(path);
     let (owner, name) = repository.split_once('/')?;
     if owner.is_empty()
@@ -444,7 +474,20 @@ fn github_repository_from_remote_url(url: &str) -> Option<String> {
     {
         return None;
     }
-    Some(format!("{owner}/{name}"))
+    Some(GitHubRemoteIdentity {
+        host: host.to_ascii_lowercase(),
+        repository: format!("{owner}/{name}"),
+    })
+}
+
+fn github_host_safe(host: &str) -> bool {
+    !host.is_empty()
+        && !host.starts_with(['.', '-'])
+        && !host.ends_with(['.', '-'])
+        && !host.contains("..")
+        && host
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-'))
 }
 
 fn discover_github_repository(
@@ -500,17 +543,19 @@ fn discover_github_repository(
             reason: "remote_url_ambiguous",
         });
     }
-    let repository =
-        github_repository_from_remote_url(raw_remote_urls[0]).ok_or(DiscoveryError {
-            reason: "remote_provider_not_github",
-        })?;
+    let identity = github_remote_identity_from_url(raw_remote_urls[0]).ok_or(DiscoveryError {
+        reason: "remote_provider_not_github",
+    })?;
     github
-        .authenticate()
+        .authenticate(&identity.host)
         .map_err(|reason| DiscoveryError { reason })?;
     let metadata = github
-        .repository_metadata(&repository)
+        .repository_metadata(&identity.host, &identity.repository)
         .map_err(|reason| DiscoveryError { reason })?;
-    if !metadata.name_with_owner.eq_ignore_ascii_case(&repository) {
+    if !metadata
+        .name_with_owner
+        .eq_ignore_ascii_case(&identity.repository)
+    {
         return Err(DiscoveryError {
             reason: "github_repository_identity_mismatch",
         });
@@ -535,7 +580,11 @@ fn discover_github_repository(
         });
     }
     let protected = github
-        .branch_protected(&repository, &metadata.default_branch)
+        .branch_protected(
+            &identity.host,
+            &identity.repository,
+            &metadata.default_branch,
+        )
         .map_err(|reason| DiscoveryError { reason })?;
     let route = if protected {
         DeliveryRoute::PullRequest
@@ -544,7 +593,8 @@ fn discover_github_repository(
     };
     Ok(DiscoveredGitHubRepository {
         remote: remote.clone(),
-        repository,
+        host: identity.host,
+        repository: identity.repository,
         base_ref,
         route,
     })
@@ -1102,15 +1152,19 @@ fn finish_owned_run_with_mode_and_github(
         record.status = GitFinishStatus::Prepared;
         record.reason = "ready_to_create_or_reuse_pull_request".to_string();
         persist(ws, run_dir, &record)?;
-        let mut pull_requests =
-            match github.open_pull_requests(&discovered.repository, head_branch, branch) {
-                Ok(pull_requests) => pull_requests,
-                Err(reason) => {
-                    record.status = GitFinishStatus::GitFailed;
-                    record.reason = reason.to_string();
-                    return persist_result(record);
-                }
-            };
+        let mut pull_requests = match github.open_pull_requests(
+            &discovered.host,
+            &discovered.repository,
+            head_branch,
+            branch,
+        ) {
+            Ok(pull_requests) => pull_requests,
+            Err(reason) => {
+                record.status = GitFinishStatus::GitFailed;
+                record.reason = reason.to_string();
+                return persist_result(record);
+            }
+        };
         let reused = !pull_requests.is_empty();
         if pull_requests.is_empty() {
             let title = format!("Yardlet run {run_id}: {task_id}");
@@ -1118,6 +1172,7 @@ fn finish_owned_run_with_mode_and_github(
                 "Yardlet run `{run_id}` delivered the core-verified commit for task `{task_id}`."
             );
             if let Err(reason) = github.create_pull_request(
+                &discovered.host,
                 &discovered.repository,
                 head_branch,
                 branch,
@@ -1128,15 +1183,19 @@ fn finish_owned_run_with_mode_and_github(
                 record.reason = reason.to_string();
                 return persist_result(record);
             }
-            pull_requests =
-                match github.open_pull_requests(&discovered.repository, head_branch, branch) {
-                    Ok(pull_requests) => pull_requests,
-                    Err(reason) => {
-                        record.status = GitFinishStatus::GitFailed;
-                        record.reason = reason.to_string();
-                        return persist_result(record);
-                    }
-                };
+            pull_requests = match github.open_pull_requests(
+                &discovered.host,
+                &discovered.repository,
+                head_branch,
+                branch,
+            ) {
+                Ok(pull_requests) => pull_requests,
+                Err(reason) => {
+                    record.status = GitFinishStatus::GitFailed;
+                    record.reason = reason.to_string();
+                    return persist_result(record);
+                }
+            };
         }
         if pull_requests.len() != 1 {
             record.status = GitFinishStatus::RemoteMismatch;
@@ -1796,6 +1855,7 @@ mod tests {
 
     struct FakeGithub {
         protected: bool,
+        hosts: Mutex<Vec<String>>,
         prs: Mutex<Vec<PullRequestMetadata>>,
         create_count: AtomicU64,
         expected_oid: Mutex<String>,
@@ -1807,6 +1867,7 @@ mod tests {
         fn new(protected: bool) -> Self {
             Self {
                 protected,
+                hosts: Mutex::new(vec![]),
                 prs: Mutex::new(vec![]),
                 create_count: AtomicU64::new(0),
                 expected_oid: Mutex::new(String::new()),
@@ -1819,17 +1880,24 @@ mod tests {
             *self.expected_oid.lock().unwrap() = expected_oid.to_string();
             *self.prepared_probe.lock().unwrap() = Some((ws.clone(), run_dir.to_path_buf()));
         }
+
+        fn record_host(&self, host: &str) {
+            self.hosts.lock().unwrap().push(host.to_string());
+        }
     }
 
     impl GitHubClient for FakeGithub {
-        fn authenticate(&self) -> Result<(), &'static str> {
+        fn authenticate(&self, host: &str) -> Result<(), &'static str> {
+            self.record_host(host);
             Ok(())
         }
 
         fn repository_metadata(
             &self,
+            host: &str,
             _repository: &str,
         ) -> Result<GitHubRepositoryMetadata, &'static str> {
+            self.record_host(host);
             Ok(GitHubRepositoryMetadata {
                 name_with_owner: "acme/project".into(),
                 default_branch: "main".into(),
@@ -1837,27 +1905,37 @@ mod tests {
             })
         }
 
-        fn branch_protected(&self, _repository: &str, _branch: &str) -> Result<bool, &'static str> {
+        fn branch_protected(
+            &self,
+            host: &str,
+            _repository: &str,
+            _branch: &str,
+        ) -> Result<bool, &'static str> {
+            self.record_host(host);
             Ok(self.protected)
         }
 
         fn open_pull_requests(
             &self,
+            host: &str,
             _repository: &str,
             _head: &str,
             _base: &str,
         ) -> Result<Vec<PullRequestMetadata>, &'static str> {
+            self.record_host(host);
             Ok(self.prs.lock().unwrap().clone())
         }
 
         fn create_pull_request(
             &self,
+            host: &str,
             _repository: &str,
             head: &str,
             base: &str,
             _title: &str,
             _body: &str,
         ) -> Result<(), &'static str> {
+            self.record_host(host);
             if let Some((ws, run_dir)) = self.prepared_probe.lock().unwrap().as_ref() {
                 let record = ws.load_git_finish_record(run_dir).unwrap();
                 *self.prepared_seen_before_create.lock().unwrap() = record.status
@@ -1878,6 +1956,36 @@ mod tests {
     }
 
     #[test]
+    fn github_remote_identity_derives_enterprise_host_and_rejects_ambiguous_urls() {
+        for (url, expected_host) in [
+            (
+                "https://ghe.example.test/acme/project.git",
+                "ghe.example.test",
+            ),
+            (
+                "ssh://git@ghe.example.test/acme/project.git",
+                "ghe.example.test",
+            ),
+            ("git@ghe.example.test:acme/project.git", "ghe.example.test"),
+        ] {
+            let identity = github_remote_identity_from_url(url).expect("GitHub remote identity");
+            assert_eq!(identity.host, expected_host);
+            assert_eq!(identity.repository, "acme/project");
+        }
+        for url in [
+            "https://user@ghe.example.test/acme/project.git",
+            "https://ghe.example.test:8443/acme/project.git",
+            "https://ghe.example.test/acme/project/extra.git",
+            "file:///tmp/project.git",
+        ] {
+            assert!(
+                github_remote_identity_from_url(url).is_none(),
+                "ambiguous remote host must fail closed: {url}"
+            );
+        }
+    }
+
+    #[test]
     fn ac_002_auto_delivery_cross_checks_upstream_remote_and_github_metadata() {
         let f = Fixture::new("auto-discovery");
         f.configure_auto();
@@ -1887,9 +1995,14 @@ mod tests {
         let discovered = discover_github_repository(&f.root, &policy, &github).unwrap();
 
         assert_eq!(discovered.remote, "fixture");
+        assert_eq!(discovered.host, "github.com");
         assert_eq!(discovered.repository, "acme/project");
         assert_eq!(discovered.base_ref, "refs/heads/main");
         assert_eq!(discovered.route, DeliveryRoute::Direct);
+        assert_eq!(
+            github.hosts.lock().unwrap().as_slice(),
+            ["github.com", "github.com", "github.com"]
+        );
 
         let mut conflicting = policy;
         conflicting.remote = "other".into();

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -3685,6 +3685,7 @@ exit 0
         config.auto_commit = true;
         config.git_finish = crate::schemas::GitFinishPolicy {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: stale_target.into(),
             pre_push_checks: vec![],

--- a/src/report.rs
+++ b/src/report.rs
@@ -324,11 +324,8 @@ pub fn build_final_report(ws: &Workspace) -> Result<String> {
                     md.push_str(&format!("{}\n\n", rep.trim()));
                 }
             }
-            if let Ok(raw) = std::fs::read_to_string(dir.join("git-finish.json")) {
-                if let Ok(finish) = serde_json::from_str::<crate::git_finish::GitFinishRecord>(&raw)
-                {
-                    md.push_str(&format!("{}\n\n", finish.user_line()));
-                }
+            if let Ok(finish) = ws.load_git_finish_record(&dir) {
+                md.push_str(&format!("{}\n\n", finish.user_line()));
             }
             // Worktree preparation left copy warnings behind: keep them visible
             // in the wrap-up. Clean runs write no evidence file and add nothing.
@@ -730,6 +727,68 @@ mod tests {
 
         assert!(report.contains("unfinished (held:"), "{report}");
         assert!(!report.contains("complete (held:"), "{report}");
+    }
+
+    #[test]
+    fn ac_005_verified_open_pull_request_renders_as_completed_delivery() {
+        let record = crate::git_finish::GitFinishRecord {
+            schema_version: 3,
+            run_id: "run-test".into(),
+            task_id: "YARD-001".into(),
+            attempted_at: String::new(),
+            status: crate::git_finish::GitFinishStatus::PullRequestOpen,
+            policy: crate::git_finish::GitFinishPolicySnapshot {
+                auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Auto,
+                remote: "origin".into(),
+                target_ref: "refs/heads/main".into(),
+                pre_push_checks: vec![],
+            },
+            expected_oid: Some("abc".into()),
+            baseline_oid: "def".into(),
+            owned_oids: vec!["abc".into()],
+            checks: vec![],
+            push_invoked: true,
+            push_succeeded: true,
+            remote_oid: Some("abc".into()),
+            remote_before_oid: Some("def".into()),
+            head_ref: Some("refs/heads/yardlet/runs/run-test".into()),
+            pull_request_number: Some(41),
+            pull_request_state: Some("open".into()),
+            reason: "pull_request_verified".into(),
+        };
+
+        let line = record.user_line();
+
+        assert!(record.status.verified_complete());
+        assert!(line.contains("pull request #41"));
+        assert!(line.contains("open and verified"));
+
+        let ws = temp_ws("untrusted-pr-projection");
+        crate::state::save_yaml(&ws.intent_path(), &intent("intent-pr-projection")).unwrap();
+        let mut queue = crate::schemas::WorkQueue::empty();
+        queue
+            .tasks
+            .push(seed_task("YARD-001", "finish", TaskState::Done));
+        ws.save_queue(&queue).unwrap();
+        write_run(
+            &ws,
+            "run-test",
+            "YARD-001",
+            r#"{"schema_version":1,"run_id":"run-test","task_id":"YARD-001","status":"done"}"#,
+        );
+        std::fs::write(
+            ws.runs_dir().join("run-test/git-finish.json"),
+            serde_json::to_string_pretty(&record).unwrap(),
+        )
+        .unwrap();
+
+        let report = build_final_report(&ws).unwrap();
+
+        assert!(
+            !report.contains("pull request #41"),
+            "a worker-writable projection must not establish delivery truth: {report}"
+        );
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -8138,6 +8138,7 @@ mod tests {
             status,
             policy: crate::git_finish::GitFinishPolicySnapshot {
                 auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Direct,
                 remote: "fixture".into(),
                 target_ref: "refs/heads/main".into(),
                 pre_push_checks: vec![],
@@ -8150,6 +8151,9 @@ mod tests {
             push_succeeded: false,
             remote_oid: None,
             remote_before_oid: None,
+            head_ref: None,
+            pull_request_number: None,
+            pull_request_state: None,
             reason: String::new(),
         };
         for status in [
@@ -8169,6 +8173,7 @@ mod tests {
             crate::git_finish::GitFinishStatus::NotNeeded,
             crate::git_finish::GitFinishStatus::Pushed,
             crate::git_finish::GitFinishStatus::AlreadyApplied,
+            crate::git_finish::GitFinishStatus::PullRequestOpen,
         ] {
             assert_eq!(
                 state_after_git_finish(TaskState::Done, &make(status)),
@@ -8230,6 +8235,7 @@ mod tests {
                     status: crate::git_finish::GitFinishStatus::CheckBlocked,
                     policy: crate::git_finish::GitFinishPolicySnapshot {
                         auto_push: true,
+                        delivery: crate::schemas::GitFinishDelivery::Direct,
                         remote: format!("fixture-{index}"),
                         target_ref: target_ref.into(),
                         pre_push_checks: vec![],
@@ -8242,6 +8248,9 @@ mod tests {
                     push_succeeded: false,
                     remote_oid: None,
                     remote_before_oid: None,
+                    head_ref: None,
+                    pull_request_number: None,
+                    pull_request_state: None,
                     reason: "historical fixture".into(),
                 },
             )
@@ -8306,6 +8315,7 @@ mod tests {
                     status: crate::git_finish::GitFinishStatus::Pushed,
                     policy: crate::git_finish::GitFinishPolicySnapshot {
                         auto_push: true,
+                        delivery: crate::schemas::GitFinishDelivery::Direct,
                         remote: "fixture".into(),
                         target_ref: "refs/heads/main".into(),
                         pre_push_checks: vec![],
@@ -8318,6 +8328,9 @@ mod tests {
                     push_succeeded: true,
                     remote_oid: Some(format!("integration-{index}")),
                     remote_before_oid: Some(format!("baseline-{index}")),
+                    head_ref: None,
+                    pull_request_number: None,
+                    pull_request_state: None,
                     reason: "remote_verified".into(),
                 },
             )
@@ -8675,6 +8688,9 @@ mod tests {
             push_succeeded: false,
             remote_oid: None,
             remote_before_oid: Some(baseline_oid.into()),
+            head_ref: None,
+            pull_request_number: None,
+            pull_request_state: None,
             reason: "ready_to_push".into(),
         }
     }
@@ -9169,6 +9185,7 @@ mod tests {
         let config_policy = ws.load_config().unwrap().git_finish;
         let trusted_policy = crate::git_finish::GitFinishPolicySnapshot {
             auto_push: config_policy.auto_push,
+            delivery: config_policy.delivery,
             remote: config_policy.remote,
             target_ref: config_policy.target_ref,
             pre_push_checks: vec![],
@@ -9215,6 +9232,7 @@ mod tests {
             forged_run_id,
             crate::git_finish::GitFinishPolicySnapshot {
                 auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Direct,
                 remote: "attacker".into(),
                 target_ref: "refs/heads/main".into(),
                 pre_push_checks: vec![],
@@ -9270,6 +9288,7 @@ mod tests {
             run_id,
             crate::git_finish::GitFinishPolicySnapshot {
                 auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Direct,
                 remote: "attacker".into(),
                 target_ref: "refs/heads/main".into(),
                 pre_push_checks: vec![],
@@ -9323,6 +9342,7 @@ mod tests {
         let config_policy = ws.load_config().unwrap().git_finish;
         let snapshot = crate::git_finish::GitFinishPolicySnapshot {
             auto_push: config_policy.auto_push,
+            delivery: config_policy.delivery,
             remote: config_policy.remote,
             target_ref: config_policy.target_ref,
             pre_push_checks: vec![],
@@ -9337,6 +9357,7 @@ mod tests {
             run_id,
             crate::git_finish::GitFinishPolicySnapshot {
                 auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Direct,
                 remote: "attacker".into(),
                 target_ref: "refs/heads/main".into(),
                 pre_push_checks: vec![],
@@ -9663,6 +9684,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         config.auto_commit = true;
         config.git_finish = crate::schemas::GitFinishPolicy {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: stale_target.into(),
             pre_push_checks: vec![],
@@ -9709,6 +9731,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
                 status: crate::git_finish::GitFinishStatus::Pushed,
                 policy: crate::git_finish::GitFinishPolicySnapshot {
                     auto_push: true,
+                    delivery: crate::schemas::GitFinishDelivery::Direct,
                     remote: "fixture".into(),
                     target_ref: stale_target.into(),
                     pre_push_checks: vec![],
@@ -9721,6 +9744,9 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
                 push_succeeded: true,
                 remote_oid: Some(baseline.clone()),
                 remote_before_oid: Some(baseline.clone()),
+                head_ref: None,
+                pull_request_number: None,
+                pull_request_state: None,
                 reason: "remote_verified".into(),
             },
         )
@@ -15370,6 +15396,7 @@ exit 1
         let mut config = ws.load_config().unwrap();
         config.git_finish = crate::schemas::GitFinishPolicy {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: "refs/heads/main".into(),
             pre_push_checks: vec![crate::schemas::GitFinishCheck {
@@ -15532,6 +15559,7 @@ exit 1
         let mut config = ws.load_config().unwrap();
         config.git_finish = crate::schemas::GitFinishPolicy {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: "refs/heads/main".into(),
             pre_push_checks: vec![],
@@ -15600,6 +15628,7 @@ exit 1
             status: crate::git_finish::GitFinishStatus::Pushed,
             policy: crate::git_finish::GitFinishPolicySnapshot {
                 auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Direct,
                 remote: "fixture".into(),
                 target_ref: "refs/heads/main".into(),
                 pre_push_checks: vec![],
@@ -15612,6 +15641,9 @@ exit 1
             push_succeeded: true,
             remote_oid: Some(unrelated_oid.clone()),
             remote_before_oid: Some(remote_baseline.clone()),
+            head_ref: None,
+            pull_request_number: None,
+            pull_request_state: None,
             reason: "worker forged verified status".into(),
         };
         write_str(
@@ -15737,6 +15769,7 @@ exit 1
         let mut config = ws.load_config().unwrap();
         config.git_finish = crate::schemas::GitFinishPolicy {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: "refs/heads/main".into(),
             pre_push_checks: vec![],
@@ -15836,6 +15869,7 @@ exit 1
                     status: crate::git_finish::GitFinishStatus::Pushed,
                     policy: crate::git_finish::GitFinishPolicySnapshot {
                         auto_push: true,
+                        delivery: crate::schemas::GitFinishDelivery::Direct,
                         remote: "fixture".into(),
                         target_ref: "refs/heads/main".into(),
                         pre_push_checks: vec![],
@@ -15848,6 +15882,9 @@ exit 1
                     push_succeeded: true,
                     remote_oid: Some(integration_oid.clone()),
                     remote_before_oid: Some(baseline_oid),
+                    head_ref: None,
+                    pull_request_number: None,
+                    pull_request_state: None,
                     reason: "remote_verified".into(),
                 },
             )
@@ -15952,6 +15989,7 @@ exit 1
         let mut config = ws.load_config().unwrap();
         config.git_finish = crate::schemas::GitFinishPolicy {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: "refs/heads/main".into(),
             pre_push_checks: vec![],
@@ -15999,6 +16037,7 @@ exit 1
 
         let policy_snapshot = crate::git_finish::GitFinishPolicySnapshot {
             auto_push: true,
+            delivery: crate::schemas::GitFinishDelivery::Direct,
             remote: "fixture".into(),
             target_ref: "refs/heads/main".into(),
             pre_push_checks: vec![],
@@ -16107,6 +16146,9 @@ exit 1
                     push_succeeded: false,
                     remote_oid: None,
                     remote_before_oid: Some(baseline.clone()),
+                    head_ref: None,
+                    pull_request_number: None,
+                    pull_request_state: None,
                     reason: "pre_recovery".into(),
                 },
             )

--- a/src/run.rs
+++ b/src/run.rs
@@ -7029,6 +7029,11 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     {
         let _ = std::fs::remove_file(run_dir.join("partial-reason"));
     }
+    // Capture the delivery-projected terminal outcome before review queue
+    // management can schedule another attempt. Telemetry describes this run's
+    // completed evaluation and Git finish, not the scheduler state of the task's
+    // next attempt.
+    let telemetry_state = next_state;
 
     // Update the queue: set state AND ingest any follow-up tasks the worker
     // proposed (propose -> ingest). Yardlet stays the sole queue writer — both
@@ -7227,7 +7232,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     .as_ref()
                     .map(|r| r.status.clone())
                     .unwrap_or_else(|| "no-result".to_string()),
-                eval_state: format!("{evaluated_state:?}"),
+                eval_state: telemetry_eval_state(telemetry_state),
                 wall_seconds,
                 user_override,
                 skills: task.skills.clone(),
@@ -7280,6 +7285,10 @@ fn state_after_git_finish(
     } else {
         state
     }
+}
+
+fn telemetry_eval_state(state: TaskState) -> String {
+    format!("{state:?}")
 }
 
 /// Snake-case label for a run's terminal outcome, matching the queue's
@@ -8127,6 +8136,12 @@ mod tests {
         );
     }
     use crate::schemas::{SelectionPolicy, Task, WorkQueue};
+
+    #[test]
+    fn telemetry_serializes_the_final_git_finish_projection() {
+        assert_eq!(telemetry_eval_state(TaskState::Partial), "Partial");
+        assert_eq!(telemetry_eval_state(TaskState::Done), "Done");
+    }
 
     #[test]
     fn auto_push_projects_only_remote_verified_finish_to_done() {

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -103,11 +103,24 @@ pub struct YardConfig {
     /// OFF by default, since it writes to the user's git history.
     #[serde(default)]
     pub auto_commit: bool,
-    /// User-owned, default-off policy for finishing an owned Yardlet merge by
-    /// pushing its exact OID to one explicit branch ref. Legacy configs omit
-    /// this block and therefore deserialize to a disabled policy.
+    /// User-owned, default-off policy for finishing an owned Yardlet merge.
+    /// Legacy configs omit this block and therefore deserialize to a disabled
+    /// direct-delivery policy.
     #[serde(default)]
     pub git_finish: GitFinishPolicy,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GitFinishDelivery {
+    /// Preserve the original exact-OID push contract. The remote and target
+    /// branch must be configured explicitly.
+    #[default]
+    Direct,
+    /// Discover and cross-check a GitHub upstream, then select exact-OID direct
+    /// push only when the default branch is confirmed unprotected. Otherwise
+    /// deliver the same OID through a run-owned branch and one verified PR.
+    Auto,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -115,6 +128,10 @@ pub struct GitFinishPolicy {
     /// No remote command is run unless this is explicitly true.
     #[serde(default)]
     pub auto_push: bool,
+    /// Delivery selection. Missing means `direct`, preserving every legacy
+    /// `auto_push` configuration.
+    #[serde(default)]
+    pub delivery: GitFinishDelivery,
     /// Git remote name only. URLs are never copied into run records.
     #[serde(default)]
     pub remote: String,
@@ -3598,6 +3615,36 @@ impl Default for ValidationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ac_001_git_finish_auto_delivery_is_opt_in_and_legacy_auto_push_stays_direct() {
+        let legacy: GitFinishPolicy = yaml::from_str(
+            r#"
+auto_push: true
+remote: origin
+target_ref: refs/heads/main
+"#,
+        )
+        .unwrap();
+        assert_eq!(legacy.delivery, GitFinishDelivery::Direct);
+
+        let automatic: GitFinishPolicy = yaml::from_str(
+            r#"
+auto_push: true
+delivery: auto
+"#,
+        )
+        .unwrap();
+        assert_eq!(automatic.delivery, GitFinishDelivery::Auto);
+
+        let serialized = yaml::to_string(&automatic).unwrap();
+        assert!(serialized.contains("delivery: auto"));
+
+        let template: YardConfig =
+            yaml::from_str(include_str!("../templates/agents/yardlet.yaml")).unwrap();
+        assert!(!template.git_finish.auto_push);
+        assert_eq!(template.git_finish.delivery, GitFinishDelivery::Direct);
+    }
 
     #[test]
     fn worker_refusal_patterns_are_backward_compatible_and_bounded() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1935,6 +1935,7 @@ impl Workspace {
         run_dir: &Path,
         record: &crate::git_finish::GitFinishRecord,
     ) -> Result<()> {
+        record.validate_authority().map_err(anyhow::Error::msg)?;
         self.validate_receipt_run_id(&record.run_id)?;
         if run_dir != self.runs_dir().join(&record.run_id) {
             bail!("Git finish run directory does not match its core identity");
@@ -1971,6 +1972,7 @@ impl Workspace {
         if record.run_id != run_id {
             bail!("Git finish core record does not match its run id");
         }
+        record.validate_authority().map_err(anyhow::Error::msg)?;
         Ok(record)
     }
     /// Atomically claim a run directory without reusing an existing attempt's
@@ -6367,6 +6369,54 @@ routing:
 
     fn temp_root(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("yard-{name}-{}", std::process::id()))
+    }
+
+    #[test]
+    fn git_finish_authority_rejects_remote_urls_and_unverified_pr_open_records() {
+        let dir = temp_root("git-finish-authority-validation");
+        let _ = fs::remove_dir_all(&dir);
+        let ws = Workspace::at(&dir);
+        let run_id = "run-authority-test";
+        let run_dir = ws.runs_dir().join(run_id);
+        fs::create_dir_all(&run_dir).unwrap();
+        let mut record = crate::git_finish::GitFinishRecord {
+            schema_version: 3,
+            run_id: run_id.into(),
+            task_id: "YARD-001".into(),
+            attempted_at: String::new(),
+            status: crate::git_finish::GitFinishStatus::Prepared,
+            policy: crate::git_finish::GitFinishPolicySnapshot {
+                auto_push: true,
+                delivery: crate::schemas::GitFinishDelivery::Direct,
+                remote: "https://user:secret@github.com/acme/project.git".into(),
+                target_ref: "refs/heads/main".into(),
+                pre_push_checks: vec![],
+            },
+            expected_oid: Some("a".repeat(40)),
+            baseline_oid: "b".repeat(40),
+            owned_oids: vec!["a".repeat(40)],
+            checks: vec![],
+            push_invoked: false,
+            push_succeeded: false,
+            remote_oid: None,
+            remote_before_oid: Some("b".repeat(40)),
+            head_ref: None,
+            pull_request_number: None,
+            pull_request_state: None,
+            reason: "ready_to_push".into(),
+        };
+
+        let url_error = ws.save_git_finish_record(&run_dir, &record).unwrap_err();
+        assert!(url_error.to_string().contains("remote name"));
+
+        record.policy.remote = "origin".into();
+        record.policy.delivery = crate::schemas::GitFinishDelivery::Auto;
+        record.status = crate::git_finish::GitFinishStatus::PullRequestOpen;
+        let pr_error = ws.save_git_finish_record(&run_dir, &record).unwrap_err();
+        assert!(pr_error.to_string().contains("verified pull request"));
+        assert!(!run_dir.join("git-finish.json").exists());
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -30,10 +30,7 @@ fn is_done(state: &str) -> bool {
 
 fn telemetry_done(run: &RunTelemetry) -> bool {
     is_done(&run.eval_state)
-        && matches!(
-            run.git_finish_status.as_str(),
-            "" | "disabled" | "pushed" | "already_applied"
-        )
+        && crate::git_finish::GitFinishStatus::telemetry_verified_complete(&run.git_finish_status)
 }
 
 /// Per-worker reliability over its runs.
@@ -972,7 +969,7 @@ mod tests {
         let mut pending = rec("A", "codex", "done", "Done", 1);
         pending.git_finish_status = "prepared".into();
         let mut verified = rec("B", "codex", "done", "Done", 1);
-        verified.git_finish_status = "already_applied".into();
+        verified.git_finish_status = "pull_request_open".into();
 
         let report = summarize(&[pending, verified]);
 

--- a/templates/agents/yardlet.yaml
+++ b/templates/agents/yardlet.yaml
@@ -1,0 +1,32 @@
+# Reference shape for the dynamic `.agents/yardlet.yaml` written by
+# `yardlet init`. Workspace identity and timestamps are generated at runtime.
+schema_version: 1
+product: yardlet
+workspace_id: generated-at-init
+created_at: generated-at-init
+state_dir: .agents
+default_interface: tui
+canonical_queue: .agents/work-queue.yaml
+current_intent: .agents/intent-contract.yaml
+language: auto
+default_access: sandboxed
+max_parallel: 1
+auto_ime: true
+ambiguity_gate: true
+harness_discovery: true
+skill_library: ""
+auto_equip: true
+auto_skill: true
+auto_rule: true
+auto_prune: true
+hooks: true
+auto_commit: false
+git_finish:
+  # Remote delivery stays disabled until the user opts in.
+  auto_push: false
+  # `direct` preserves legacy explicit-target semantics. Set `auto` only for a
+  # GitHub checkout with an upstream and an installed, authenticated `gh`.
+  delivery: direct
+  remote: ""
+  target_ref: ""
+  pre_push_checks: []

--- a/tests/fixtures/protected_branch_pr_delivery/scripts/fake-gh.sh
+++ b/tests/fixtures/protected_branch_pr_delivery/scripts/fake-gh.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${YARDLET_FIXTURE_GH_LOG:?missing gh call log}"
+: "${YARDLET_FIXTURE_GH_STATE:?missing gh state path}"
+: "${YARDLET_FIXTURE_EXPECTED_OID:?missing expected OID}"
+: "${YARDLET_FIXTURE_EXPECTED_HOST:?missing expected GitHub host}"
+
+printf 'CALL\tpid=%s\tpgid=%s\t' "$$" "$(ps -o pgid= -p $$ | tr -d ' ')" \
+  >>"$YARDLET_FIXTURE_GH_LOG"
+printf '%q ' "$@" >>"$YARDLET_FIXTURE_GH_LOG"
+printf '\n' >>"$YARDLET_FIXTURE_GH_LOG"
+
+explicit_host=""
+previous=""
+for arg in "$@"; do
+  [[ "$previous" != "--hostname" ]] || explicit_host="$arg"
+  previous="$arg"
+done
+if [[ "$explicit_host" != "$YARDLET_FIXTURE_EXPECTED_HOST" ]]; then
+  printf 'HOST_MISMATCH\texpected=%s\tactual=%s\n' \
+    "$YARDLET_FIXTURE_EXPECTED_HOST" "$explicit_host" >>"$YARDLET_FIXTURE_GH_LOG"
+  exit 92
+fi
+printf 'HOST_OK\t%s\n' "$explicit_host" >>"$YARDLET_FIXTURE_GH_LOG"
+
+mode="${YARDLET_FIXTURE_GH_MODE:-normal}"
+protected="${YARDLET_FIXTURE_PROTECTED:-true}"
+crash_mode="${YARDLET_FIXTURE_CRASH_MODE:-normal}"
+event="${YARDLET_FIXTURE_EVENT:-}"
+
+if [[ "${1:-}" == "auth" ]]; then
+  [[ "$mode" != "unauthenticated" ]] || exit 1
+  exit 0
+fi
+
+[[ "${1:-}" == "api" ]] || exit 2
+
+method="GET"
+endpoint=""
+head_filter=""
+base_filter=""
+previous=""
+for arg in "$@"; do
+  if [[ "$previous" == "--method" ]]; then
+    method="$arg"
+  elif [[ "$previous" == "-f" ]]; then
+    case "$arg" in
+      head=*) head_filter="${arg#head=}" ;;
+      base=*) base_filter="${arg#base=}" ;;
+    esac
+  elif [[ "$arg" == repos/* ]]; then
+    endpoint="$arg"
+  fi
+  previous="$arg"
+done
+
+if [[ "$endpoint" == "repos/fixture-owner/fixture-repo" ]]; then
+  full_name="fixture-owner/fixture-repo"
+  default_branch="main"
+  [[ "$mode" != "repository_mismatch" ]] || full_name="other-owner/other-repo"
+  [[ "$mode" != "default_branch_mismatch" ]] || default_branch="trunk"
+  printf '{"full_name":"%s","default_branch":"%s","permissions":{"push":true}}\n' \
+    "$full_name" "$default_branch"
+  exit 0
+fi
+
+if [[ "$endpoint" == "repos/fixture-owner/fixture-repo/branches/main" ]]; then
+  printf '{"protected":%s}\n' "$protected"
+  exit 0
+fi
+
+if [[ "$endpoint" == "repos/fixture-owner/fixture-repo/pulls" && "$method" == "POST" ]]; then
+  printf 'PR_CREATE_BEGIN\n' >>"$YARDLET_FIXTURE_GH_LOG"
+  if [[ "$crash_mode" == "before_pr_create" ]]; then
+    printf '%s\n' "$$" >"${event:?missing event path}.pid"
+    : >"$event"
+    while :; do sleep 1; done
+  fi
+  if [[ ! -e "$YARDLET_FIXTURE_GH_STATE" ]]; then
+    printf 'open\n' >"$YARDLET_FIXTURE_GH_STATE"
+    printf 'PR_CREATE_SUCCESS\n' >>"$YARDLET_FIXTURE_GH_LOG"
+  fi
+  if [[ "$crash_mode" == "after_pr_create" ]]; then
+    printf '%s\n' "$$" >"${event:?missing event path}.pid"
+    : >"$event"
+    while :; do sleep 1; done
+  fi
+  printf '{}\n'
+  exit 0
+fi
+
+if [[ "$endpoint" == "repos/fixture-owner/fixture-repo/pulls" && "$method" == "GET" ]]; then
+  printf 'PR_LOOKUP\thead=%s\tbase=%s\n' "$head_filter" "$base_filter" \
+    >>"$YARDLET_FIXTURE_GH_LOG"
+  if [[ ! -e "$YARDLET_FIXTURE_GH_STATE" ]]; then
+    printf '[]\n'
+    exit 0
+  fi
+  head="${head_filter#fixture-owner:}"
+  base="$base_filter"
+  [[ "$mode" != "pr_head_mismatch" ]] || head="other-run-head"
+  [[ "$mode" != "pr_base_mismatch" ]] || base="other-base"
+  printf '[{"number":17,"state":"open","head":{"ref":"%s","sha":"%s"},"base":{"ref":"%s","sha":"unused"}}]\n' \
+    "$head" "$YARDLET_FIXTURE_EXPECTED_OID" "$base"
+  exit 0
+fi
+
+exit 3

--- a/tests/fixtures/protected_branch_pr_delivery/scripts/git-wrapper.sh
+++ b/tests/fixtures/protected_branch_pr_delivery/scripts/git-wrapper.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -u
+
+: "${YARDLET_FIXTURE_REAL_GIT:?missing real git path}"
+: "${YARDLET_FIXTURE_GIT_LOG:?missing Git call log}"
+
+for arg in "$@"; do
+  case "$arg" in
+    http://* | https://* | ssh://* | git@*)
+      printf 'PUBLIC_REMOTE_REJECTED\t%s\n' "$arg" >>"$YARDLET_FIXTURE_GIT_LOG"
+      exit 96
+      ;;
+  esac
+done
+
+printf 'CALL\tpid=%s\tpgid=%s\t' "$$" "$(ps -o pgid= -p $$ | tr -d ' ')" \
+  >>"$YARDLET_FIXTURE_GIT_LOG"
+printf '%q ' "$@" >>"$YARDLET_FIXTURE_GIT_LOG"
+printf '\n' >>"$YARDLET_FIXTURE_GIT_LOG"
+
+is_push=0
+refspec=""
+for arg in "$@"; do
+  [[ "$arg" == "push" ]] && is_push=1
+  [[ "$arg" == *":refs/heads/"* ]] && refspec="$arg"
+done
+
+mode="${YARDLET_FIXTURE_CRASH_MODE:-normal}"
+if [[ "$is_push" -eq 1 && "$refspec" == *":refs/heads/yardlet/runs/"* \
+  && "$mode" == "before_head_push" ]]; then
+  printf '%s\n' "$$" >"${YARDLET_FIXTURE_EVENT:?missing event path}.pid"
+  : >"$YARDLET_FIXTURE_EVENT"
+  while :; do sleep 1; done
+fi
+
+"$YARDLET_FIXTURE_REAL_GIT" "$@"
+status=$?
+
+if [[ "$is_push" -eq 1 && "$status" -eq 0 ]]; then
+  printf 'PUSH_SUCCESS\t%s\n' "$refspec" >>"$YARDLET_FIXTURE_GIT_LOG"
+  if [[ "$refspec" == *":refs/heads/yardlet/runs/"* \
+    && "$mode" == "after_head_push" ]]; then
+    printf '%s\n' "$$" >"${YARDLET_FIXTURE_EVENT:?missing event path}.pid"
+    : >"$YARDLET_FIXTURE_EVENT"
+    while :; do sleep 1; done
+  fi
+fi
+
+exit "$status"

--- a/tests/fixtures/protected_branch_pr_delivery/scripts/run.sh
+++ b/tests/fixtures/protected_branch_pr_delivery/scripts/run.sh
@@ -40,6 +40,27 @@ cp "$SCRIPT_DIR/worker-sentinel.sh" "$NO_GH_DIR/worker-sentinel"
 chmod +x "$WRAPPER_DIR/git" "$WRAPPER_DIR/gh" "$WRAPPER_DIR/worker-sentinel"
 chmod +x "$NO_GH_DIR/git" "$NO_GH_DIR/worker-sentinel"
 
+# "gh is not installed" must not depend on where the host keeps the GitHub CLI.
+# Ubuntu ships /usr/bin/gh, which sits inside SAFE_SYSTEM_PATH, so leaving that
+# directory on PATH lets the real gh answer and the scenario reports
+# gh_not_authenticated instead. Mirror the safe system path without gh so the
+# PATH lookup genuinely fails on every host.
+NO_GH_SYSTEM_PATH="$ROOT/no-gh-system"
+mkdir -p "$NO_GH_SYSTEM_PATH"
+for system_dir in /usr/bin /bin; do
+  [ -d "$system_dir" ] || continue
+  for entry in "$system_dir"/*; do
+    entry_name="${entry##*/}"
+    [ "$entry_name" = "gh" ] && continue
+    [ -e "$NO_GH_SYSTEM_PATH/$entry_name" ] && continue
+    ln -s "$entry" "$NO_GH_SYSTEM_PATH/$entry_name" 2>/dev/null || true
+  done
+done
+if PATH="$NO_GH_SYSTEM_PATH" command -v gh >/dev/null 2>&1; then
+  printf 'fixture failure: %s\n' "no-gh system mirror still resolves gh" >&2
+  exit 1
+fi
+
 fail() {
   printf 'fixture failure: %s\n' "$*" >&2
   exit 1
@@ -319,12 +340,13 @@ run_yardlet() {
   local crash_mode="${4:-normal}"
   local event="${5:-$scenario/no-event}"
   local path_dir="${6:-$WRAPPER_DIR}"
+  local system_path="${7:-$SAFE_SYSTEM_PATH}"
   local expected expected_host
   expected="$(head_oid "$scenario/clone")"
   expected_host="$(cat "$scenario/expected-host")"
   (
     cd "$scenario/clone"
-    PATH="$path_dir:$SAFE_SYSTEM_PATH" \
+    PATH="$path_dir:$system_path" \
       YARDLET_FIXTURE_REAL_GIT="$REAL_GIT" \
       YARDLET_FIXTURE_GIT_LOG="$scenario/git.log" \
       YARDLET_FIXTURE_GH_LOG="$scenario/gh.log" \
@@ -536,6 +558,7 @@ run_failure_case() {
   local expected_reason="$3"
   local path_dir="${4:-$WRAPPER_DIR}"
   local policy_remote="${5:-origin}"
+  local system_path="${6:-$SAFE_SYSTEM_PATH}"
   local scenario ws baseline expected
   scenario="$(new_workspace "failure-$name")"
   ws="$scenario/clone"
@@ -544,7 +567,7 @@ run_failure_case() {
   write_integrated_run "$ws" "$baseline" "$expected"
   write_config "$ws" "$policy_remote"
   run_yardlet "$scenario" "$gh_mode" true normal "$scenario/no-event" "$path_dir" \
-    >"$scenario/recover.log" 2>&1
+    "$system_path" >"$scenario/recover.log" 2>&1
   assert_eq "$(grep -c '^PUSH_SUCCESS' "$scenario/git.log" || true)" 0 "$name external Git mutation"
   assert_eq "$(grep -c 'PR_CREATE_SUCCESS' "$scenario/gh.log" || true)" 0 "$name external PR mutation"
   assert_failure_projection "$scenario" "$expected_reason"
@@ -575,7 +598,7 @@ run_crash_case before_head_push
 run_crash_case after_head_push
 run_crash_case before_pr_create
 run_crash_case after_pr_create
-run_failure_case gh-missing normal gh_not_installed "$NO_GH_DIR"
+run_failure_case gh-missing normal gh_not_installed "$NO_GH_DIR" origin "$NO_GH_SYSTEM_PATH"
 run_failure_case gh-unauthenticated unauthenticated gh_not_authenticated
 run_failure_case remote-mismatch normal configured_remote_conflicts_with_upstream "$WRAPPER_DIR" other
 run_failure_case default-branch-mismatch default_branch_mismatch github_default_branch_mismatch

--- a/tests/fixtures/protected_branch_pr_delivery/scripts/run.sh
+++ b/tests/fixtures/protected_branch_pr_delivery/scripts/run.sh
@@ -1,0 +1,635 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <yardlet-bin> <evidence-dir>" >&2
+  exit 64
+fi
+
+YARDLET_BIN="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+EVIDENCE_DIR="$2"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REAL_GIT="$(command -v git)"
+PYTHON="$(command -v python3)"
+SAFE_SYSTEM_PATH="/usr/bin:/bin"
+
+mkdir -p "$EVIDENCE_DIR"
+ROOT="$(mktemp -d "$EVIDENCE_DIR/fixture.XXXXXX")"
+STERILE_HOME="$ROOT/sterile-home"
+mkdir -p "$STERILE_HOME/.config"
+: >"$STERILE_HOME/global.gitconfig"
+: >"$STERILE_HOME/system.gitconfig"
+export HOME="$STERILE_HOME"
+export XDG_CONFIG_HOME="$STERILE_HOME/.config"
+export GIT_CONFIG_GLOBAL="$STERILE_HOME/global.gitconfig"
+export GIT_CONFIG_SYSTEM="$STERILE_HOME/system.gitconfig"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_TERMINAL_PROMPT=0
+export GH_HOST=ambient.invalid
+unset GIT_CONFIG GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS
+unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN
+
+WRAPPER_DIR="$ROOT/wrapper-bin"
+NO_GH_DIR="$ROOT/no-gh-bin"
+mkdir -p "$WRAPPER_DIR" "$NO_GH_DIR"
+cp "$SCRIPT_DIR/git-wrapper.sh" "$WRAPPER_DIR/git"
+cp "$SCRIPT_DIR/fake-gh.sh" "$WRAPPER_DIR/gh"
+cp "$SCRIPT_DIR/worker-sentinel.sh" "$WRAPPER_DIR/worker-sentinel"
+cp "$SCRIPT_DIR/git-wrapper.sh" "$NO_GH_DIR/git"
+cp "$SCRIPT_DIR/worker-sentinel.sh" "$NO_GH_DIR/worker-sentinel"
+chmod +x "$WRAPPER_DIR/git" "$WRAPPER_DIR/gh" "$WRAPPER_DIR/worker-sentinel"
+chmod +x "$NO_GH_DIR/git" "$NO_GH_DIR/worker-sentinel"
+
+fail() {
+  printf 'fixture failure: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_eq() {
+  [[ "$1" == "$2" ]] || fail "expected '$2', got '$1': $3"
+}
+
+wait_for_file() {
+  local path="$1"
+  local label="$2"
+  local i
+  for i in $(seq 1 400); do
+    [[ -e "$path" ]] && return 0
+    sleep 0.05
+  done
+  fail "timed out waiting for $label ($path)"
+}
+
+ACTIVE_GROUP_PID=""
+terminate_active_process_group() {
+  local pgid="${ACTIVE_GROUP_PID:-}"
+  local i
+  ACTIVE_GROUP_PID=""
+  [[ -n "$pgid" ]] || return 0
+  kill -TERM -- "-$pgid" 2>/dev/null || true
+  wait "$pgid" 2>/dev/null || true
+  for i in $(seq 1 100); do
+    ! kill -0 -- "-$pgid" 2>/dev/null && return 0
+    sleep 0.05
+  done
+  kill -KILL -- "-$pgid" 2>/dev/null || true
+  wait "$pgid" 2>/dev/null || true
+  ! kill -0 -- "-$pgid" 2>/dev/null || fail "process group $pgid still alive"
+}
+trap terminate_active_process_group EXIT
+
+json_field() {
+  "$PYTHON" - "$1" "$2" <<'PY'
+import json
+import sys
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+for part in sys.argv[2].split("."):
+    value = value[part]
+print(str(value).lower() if isinstance(value, bool) else value)
+PY
+}
+
+yaml_task_state() {
+  awk '/^[[:space:]]+state: / { print $2; exit }' "$1"
+}
+
+yaml_run_state() {
+  awk '/^state: / { print $2; exit }' "$1"
+}
+
+remote_oid() {
+  "$REAL_GIT" ls-remote --refs "$1" "$2" | awk 'NR == 1 { print $1 }'
+}
+
+head_oid() {
+  "$REAL_GIT" -C "$1" rev-parse HEAD
+}
+
+write_config() {
+  local ws="$1"
+  local remote="${2:-origin}"
+  cat >"$ws/.agents/yardlet.yaml" <<EOF
+schema_version: 1
+product: protected-branch-fixture
+workspace_id: fixture
+created_at: 2099-01-01T00:00:00Z
+state_dir: .agents
+default_interface: tui
+canonical_queue: .agents/work-queue.yaml
+current_intent: .agents/intent-contract.yaml
+language: ko
+default_access: sandboxed
+max_parallel: 1
+auto_ime: false
+ambiguity_gate: false
+harness_discovery: false
+skill_library: ""
+auto_equip: false
+auto_skill: false
+auto_rule: false
+auto_prune: false
+hooks: false
+auto_commit: false
+git_finish:
+  auto_push: true
+  delivery: auto
+  remote: $remote
+  target_ref: refs/heads/main
+  pre_push_checks:
+    - name: fixture-check
+      command: 'printf "check\n" >> "\$YARDLET_FIXTURE_CHECK_LOG"'
+EOF
+}
+
+write_state() {
+  local ws="$1"
+  cat >"$ws/.agents/intent-contract.yaml" <<'EOF'
+schema_version: 1
+id: intent-protected-branch-fixture
+source: fixture
+summary: protected branch PR delivery process proof
+acceptance:
+  - exact OID delivery converges
+status: accepted
+EOF
+  cat >"$ws/.agents/work-queue.yaml" <<'EOF'
+schema_version: 1
+queue_id: queue-protected-branch-fixture
+intent_id: intent-protected-branch-fixture
+selection_policy:
+  default_order: priority_then_created_at
+  require_planning_gate: true
+  skip_if_blocked: true
+  skip_if_approval_required: true
+tasks:
+  - id: YARD-001
+    title: protected branch fixture task
+    state: partial
+    priority: 10
+    risk: high
+    kind: implementation
+EOF
+  cat >"$ws/.agents/workers.yaml" <<EOF
+schema_version: 1
+workers:
+  - id: fixture-worker
+    kind: cli_worker
+    billing:
+      mode: subscription_backed_only
+    invocation:
+      command: $WRAPPER_DIR/worker-sentinel
+      supports_noninteractive: true
+      output_contract: files
+routing:
+  default_worker: fixture-worker
+  fallback_order: [fixture-worker]
+  planning_gate:
+    primary: fixture-worker
+    fallback: fixture-worker
+EOF
+}
+
+write_integrated_run() {
+  local ws="$1"
+  local baseline="$2"
+  local expected="$3"
+  local run_id="run-20990101-000001-YARD-001"
+  local run_dir="$ws/.agents/runs/$run_id"
+  local worker_oid canonical_ws
+  canonical_ws="$(cd "$ws" && pwd -P)"
+  worker_oid="$("$REAL_GIT" -C "$ws" rev-parse "$expected^2")"
+  mkdir -p "$run_dir" "$ws/.agents/checkpoints/integrated-cleanup"
+  cat >"$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {"drift_detected": false, "notes": ""},
+  "changes": {"files_modified": [], "files_created": [], "files_deleted": []},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "question_for_user": null,
+  "compact_summary": "fixture integration",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+  printf '# Fixture handoff\n' >"$run_dir/handoff.md"
+  cat >"$run_dir/run.yaml" <<EOF
+schema_version: 1
+run_id: $run_id
+task_id: YARD-001
+intent_id: intent-protected-branch-fixture
+worker: fixture-worker
+state: partial
+started_at: 2099-01-01T00:00:01Z
+completed_at: 2099-01-01T00:00:02Z
+worktree: .
+integration_oid: $expected
+integration_base_oid: $baseline
+integration_worker_oid: $worker_oid
+integration_provenance: parallel_worker_direct
+owned_oids:
+  - $worker_oid
+  - $expected
+EOF
+  cat >"$ws/.agents/checkpoints/integrated-cleanup/$run_id.yaml" <<EOF
+schema_version: 1
+run_id: $run_id
+task_id: YARD-001
+intent_id: intent-protected-branch-fixture
+worker: fixture-worker
+worktree: $canonical_ws/.agents/worktrees/$run_id
+branch: yard/yard-001/$run_id
+baseline_oid: $baseline
+integration_base_oid: $baseline
+integration_worker_oid: $worker_oid
+integration_oid: $expected
+provenance: parallel_worker_direct
+owned_oids:
+  - $worker_oid
+  - $expected
+EOF
+}
+
+commit_owned() {
+  local ws="$1"
+  local label="$2"
+  local baseline tree worker_oid merge_oid
+  baseline="$(head_oid "$ws")"
+  printf '%s\n' "$label" >"$ws/owned.txt"
+  "$REAL_GIT" -C "$ws" add owned.txt
+  tree="$("$REAL_GIT" -C "$ws" write-tree)"
+  worker_oid="$(printf '%s worker\n' "$label" | "$REAL_GIT" -C "$ws" commit-tree "$tree" -p "$baseline")"
+  merge_oid="$(printf '%s integration\n' "$label" | "$REAL_GIT" -C "$ws" commit-tree "$tree" -p "$baseline" -p "$worker_oid")"
+  "$REAL_GIT" -C "$ws" update-ref refs/heads/main "$merge_oid" "$baseline"
+  "$REAL_GIT" -C "$ws" reset -q --hard "$merge_oid"
+  printf '%s\n' "$merge_oid"
+}
+
+new_workspace() {
+  local name="$1"
+  local github_host="${2:-github.com}"
+  local scenario="$ROOT/$name"
+  local seed="$scenario/seed"
+  local remote="$scenario/remote.git"
+  local ws="$scenario/clone"
+  local raw_url="https://$github_host/fixture-owner/fixture-repo.git"
+  mkdir -p "$seed"
+  "$REAL_GIT" -C "$seed" init -q -b main
+  "$REAL_GIT" -C "$seed" config user.name "Yardlet Fixture"
+  "$REAL_GIT" -C "$seed" config user.email "fixture@example.test"
+  printf 'baseline\n' >"$seed/owned.txt"
+  "$REAL_GIT" -C "$seed" add owned.txt
+  "$REAL_GIT" -C "$seed" commit -q -m baseline
+  "$REAL_GIT" init -q --bare "$remote"
+  "$REAL_GIT" -C "$seed" remote add fixture "$remote"
+  "$REAL_GIT" -C "$seed" push -q fixture HEAD:refs/heads/main
+  "$REAL_GIT" clone -q -b main "$remote" "$ws"
+  "$REAL_GIT" -C "$ws" config user.name "Yardlet Fixture"
+  "$REAL_GIT" -C "$ws" config user.email "fixture@example.test"
+  "$REAL_GIT" -C "$ws" remote set-url origin "$raw_url"
+  "$REAL_GIT" -C "$ws" config "url.$remote.insteadOf" "$raw_url"
+  printf '%s\n' "$github_host" >"$scenario/expected-host"
+  (
+    cd "$ws"
+    PATH="$WRAPPER_DIR:$SAFE_SYSTEM_PATH" \
+      YARDLET_FIXTURE_REAL_GIT="$REAL_GIT" \
+      YARDLET_FIXTURE_GIT_LOG="$scenario/init-git.log" \
+      YARDLET_FIXTURE_GH_LOG="$scenario/init-gh.log" \
+      YARDLET_FIXTURE_GH_STATE="$scenario/init-pr-state" \
+      YARDLET_FIXTURE_EXPECTED_OID="$(head_oid "$ws")" \
+      YARDLET_FIXTURE_EXPECTED_HOST="$github_host" \
+      "$YARDLET_BIN" init >/dev/null
+  )
+  write_config "$ws"
+  write_state "$ws"
+  : >"$scenario/git.log"
+  : >"$scenario/gh.log"
+  : >"$scenario/worker.log"
+  : >"$scenario/check.log"
+  printf '%s\n' "$scenario"
+}
+
+run_yardlet() {
+  local scenario="$1"
+  local gh_mode="${2:-normal}"
+  local protected="${3:-true}"
+  local crash_mode="${4:-normal}"
+  local event="${5:-$scenario/no-event}"
+  local path_dir="${6:-$WRAPPER_DIR}"
+  local expected expected_host
+  expected="$(head_oid "$scenario/clone")"
+  expected_host="$(cat "$scenario/expected-host")"
+  (
+    cd "$scenario/clone"
+    PATH="$path_dir:$SAFE_SYSTEM_PATH" \
+      YARDLET_FIXTURE_REAL_GIT="$REAL_GIT" \
+      YARDLET_FIXTURE_GIT_LOG="$scenario/git.log" \
+      YARDLET_FIXTURE_GH_LOG="$scenario/gh.log" \
+      YARDLET_FIXTURE_GH_STATE="$scenario/pr-state" \
+      YARDLET_FIXTURE_EXPECTED_OID="$expected" \
+      YARDLET_FIXTURE_EXPECTED_HOST="$expected_host" \
+      YARDLET_FIXTURE_GH_MODE="$gh_mode" \
+      YARDLET_FIXTURE_PROTECTED="$protected" \
+      YARDLET_FIXTURE_CRASH_MODE="$crash_mode" \
+      YARDLET_FIXTURE_EVENT="$event" \
+      YARDLET_FIXTURE_WORKER_LOG="$scenario/worker.log" \
+      YARDLET_FIXTURE_CHECK_LOG="$scenario/check.log" \
+      "$YARDLET_BIN" recover
+  )
+}
+
+launch_grouped_recovery() {
+  local scenario="$1"
+  local crash_mode="$2"
+  local event="$3"
+  local expected expected_host
+  expected="$(head_oid "$scenario/clone")"
+  expected_host="$(cat "$scenario/expected-host")"
+  "$PYTHON" - "$YARDLET_BIN" "$scenario/clone" "$WRAPPER_DIR" \
+    "$SAFE_SYSTEM_PATH" "$REAL_GIT" "$scenario" "$expected" "$expected_host" \
+    "$crash_mode" "$event" <<'PY' &
+import os
+import sys
+
+yardlet, workspace, wrapper, safe_path, real_git, scenario, expected, host, mode, event = sys.argv[1:]
+os.setsid()
+os.chdir(workspace)
+env = os.environ.copy()
+env["PATH"] = wrapper + os.pathsep + safe_path
+env["YARDLET_FIXTURE_REAL_GIT"] = real_git
+env["YARDLET_FIXTURE_GIT_LOG"] = scenario + "/git.log"
+env["YARDLET_FIXTURE_GH_LOG"] = scenario + "/gh.log"
+env["YARDLET_FIXTURE_GH_STATE"] = scenario + "/pr-state"
+env["YARDLET_FIXTURE_EXPECTED_OID"] = expected
+env["YARDLET_FIXTURE_EXPECTED_HOST"] = host
+env["YARDLET_FIXTURE_GH_MODE"] = "normal"
+env["YARDLET_FIXTURE_PROTECTED"] = "true"
+env["YARDLET_FIXTURE_CRASH_MODE"] = mode
+env["YARDLET_FIXTURE_EVENT"] = event
+env["YARDLET_FIXTURE_WORKER_LOG"] = scenario + "/worker.log"
+env["YARDLET_FIXTURE_CHECK_LOG"] = scenario + "/check.log"
+fd = os.open(scenario + "/crashed-recover.log", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+os.dup2(fd, 1)
+os.dup2(fd, 2)
+os.close(fd)
+os.execve(yardlet, [yardlet, "recover"], env)
+PY
+  ACTIVE_GROUP_PID=$!
+}
+
+run_concurrent_recovery() {
+  local scenario="$1"
+  (run_yardlet "$scenario" normal true normal >"$scenario/recover-a.log" 2>&1) &
+  local first=$!
+  (run_yardlet "$scenario" normal true normal >"$scenario/recover-b.log" 2>&1) &
+  local second=$!
+  wait "$first"
+  wait "$second"
+}
+
+assert_success_projection() {
+  local scenario="$1"
+  local expected="$2"
+  local finish="$scenario/clone/.agents/runs/run-20990101-000001-YARD-001/git-finish.json"
+  assert_eq "$(json_field "$finish" status)" pull_request_open "protected finish status"
+  assert_eq "$(json_field "$finish" expected_oid)" "$expected" "protected expected OID"
+  assert_eq "$(json_field "$finish" remote_oid)" "$expected" "independent head OID"
+  assert_eq "$(yaml_task_state "$scenario/clone/.agents/work-queue.yaml")" done "queue projection"
+  assert_eq "$(yaml_run_state "$scenario/clone/.agents/runs/run-20990101-000001-YARD-001/run.yaml")" done "sealed run projection"
+  "$PYTHON" - "$scenario/clone/.agents/telemetry/runs.jsonl" <<'PY'
+import json
+import sys
+records = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+assert records[-1]["eval_state"] == "Done", records[-1]
+assert records[-1]["git_finish_status"] == "pull_request_open", records[-1]
+PY
+  (
+    cd "$scenario/clone"
+    "$YARDLET_BIN" report >"$scenario/final-report.md"
+  )
+  grep -q '1/1 tasks done' "$scenario/final-report.md" || fail "success report progress"
+  grep -q 'pull request #17 open and verified' "$scenario/final-report.md" \
+    || fail "success report Git finish projection"
+}
+
+run_direct_case() {
+  local scenario ws remote baseline expected
+  scenario="$(new_workspace direct-writable)"
+  ws="$scenario/clone"
+  remote="$scenario/remote.git"
+  baseline="$(head_oid "$ws")"
+  expected="$(commit_owned "$ws" direct)"
+  write_integrated_run "$ws" "$baseline" "$expected"
+  run_yardlet "$scenario" normal false normal >"$scenario/recover.log" 2>&1
+  assert_eq "$(remote_oid "$remote" refs/heads/main)" "$expected" "direct base OID"
+  assert_eq "$(grep -c "PUSH_SUCCESS.*${expected}:refs/heads/main" "$scenario/git.log" || true)" 1 "direct base push count"
+  assert_eq "$(yaml_task_state "$ws/.agents/work-queue.yaml")" done "direct queue Done"
+}
+
+run_protected_case() {
+  local name="$1"
+  local github_host="$2"
+  local scenario ws remote baseline expected head_ref
+  scenario="$(new_workspace "$name" "$github_host")"
+  ws="$scenario/clone"
+  remote="$scenario/remote.git"
+  baseline="$(head_oid "$ws")"
+  expected="$(commit_owned "$ws" "$name")"
+  write_integrated_run "$ws" "$baseline" "$expected"
+  run_yardlet "$scenario" normal true normal >"$scenario/recover.log" 2>&1
+  head_ref="refs/heads/yardlet/runs/run-20990101-000001-YARD-001"
+  assert_eq "$(remote_oid "$remote" refs/heads/main)" "$baseline" "protected base unchanged"
+  assert_eq "$(remote_oid "$remote" "$head_ref")" "$expected" "protected exact head OID"
+  assert_eq "$(grep -c 'PUSH_SUCCESS.*:refs/heads/main' "$scenario/git.log" || true)" 0 "protected base push count"
+  assert_eq "$(grep -c "PUSH_SUCCESS.*${expected}:${head_ref}" "$scenario/git.log" || true)" 1 "protected head push count"
+  [[ "$(grep -c 'PR_CREATE_SUCCESS' "$scenario/gh.log" || true)" -le 1 ]] \
+    || fail "protected PR create mutation count"
+  [[ "$(grep -c "ls-remote.*${head_ref}" "$scenario/git.log" || true)" -ge 2 ]] \
+    || fail "protected independent head lookup count"
+  [[ "$(grep -c "^HOST_OK[[:space:]]${github_host}$" "$scenario/gh.log" || true)" -ge 6 ]] \
+    || fail "all GitHub calls did not use derived host $github_host"
+  ! grep -q '^HOST_MISMATCH' "$scenario/gh.log" || fail "ambient GitHub host changed authority"
+  assert_success_projection "$scenario" "$expected"
+}
+
+run_crash_case() {
+  local crash_mode="$1"
+  local scenario ws remote baseline expected event record pgid wrapper_pid wrapper_pgid
+  local head_ref worker_before
+  scenario="$(new_workspace "crash-$crash_mode")"
+  ws="$scenario/clone"
+  remote="$scenario/remote.git"
+  baseline="$(head_oid "$ws")"
+  expected="$(commit_owned "$ws" "$crash_mode")"
+  write_integrated_run "$ws" "$baseline" "$expected"
+  event="$scenario/$crash_mode.event"
+  launch_grouped_recovery "$scenario" "$crash_mode" "$event"
+  pgid="$ACTIVE_GROUP_PID"
+  wait_for_file "$event" "$crash_mode event"
+  record="$ws/.agents/runs/run-20990101-000001-YARD-001/git-finish.json"
+  assert_eq "$(json_field "$record" status)" prepared "$crash_mode durable prepared"
+  if [[ "$crash_mode" == before_pr_create || "$crash_mode" == after_pr_create ]]; then
+    assert_eq "$(json_field "$record" reason)" ready_to_create_or_reuse_pull_request "$crash_mode PR prepared gate"
+  else
+    assert_eq "$(json_field "$record" reason)" ready_to_push_run_head "$crash_mode push prepared gate"
+  fi
+  wrapper_pid="$(cat "$event.pid")"
+  wrapper_pgid="$(ps -o pgid= -p "$wrapper_pid" | tr -d ' ')"
+  assert_eq "$wrapper_pgid" "$pgid" "$crash_mode child process group"
+  terminate_active_process_group
+  ! kill -0 -- "-$pgid" 2>/dev/null || fail "$crash_mode process group survived"
+  worker_before="$(wc -l <"$scenario/worker.log" | tr -d ' ')"
+  run_concurrent_recovery "$scenario"
+  head_ref="refs/heads/yardlet/runs/run-20990101-000001-YARD-001"
+  assert_eq "$(remote_oid "$remote" refs/heads/main)" "$baseline" "$crash_mode base unchanged"
+  assert_eq "$(remote_oid "$remote" "$head_ref")" "$expected" "$crash_mode head OID"
+  assert_eq "$(grep -c "PUSH_SUCCESS.*${expected}:${head_ref}" "$scenario/git.log" || true)" 1 "$crash_mode head mutation count"
+  assert_eq "$(grep -c 'PR_CREATE_SUCCESS' "$scenario/gh.log" || true)" 1 "$crash_mode PR mutation count"
+  assert_eq "$(wc -l <"$scenario/worker.log" | tr -d ' ')" "$worker_before" "$crash_mode worker count"
+  assert_success_projection "$scenario" "$expected"
+}
+
+FAILURE_PROJECTION_TOTAL=0
+FAILURE_PROJECTION_CONVERGED=0
+assert_failure_projection() {
+  local scenario="$1"
+  local expected_reason="$2"
+  local finish="$scenario/clone/.agents/runs/run-20990101-000001-YARD-001/git-finish.json"
+  local queue_state run_state telemetry_state
+  FAILURE_PROJECTION_TOTAL=$((FAILURE_PROJECTION_TOTAL + 1))
+  assert_eq "$(json_field "$finish" reason)" "$expected_reason" "$scenario failure reason"
+  queue_state="$(yaml_task_state "$scenario/clone/.agents/work-queue.yaml")"
+  run_state="$(yaml_run_state "$scenario/clone/.agents/runs/run-20990101-000001-YARD-001/run.yaml")"
+  telemetry_state="$("$PYTHON" - "$scenario/clone/.agents/telemetry/runs.jsonl" <<'PY'
+import json
+import sys
+records = [json.loads(line) for line in open(sys.argv[1], encoding="utf-8") if line.strip()]
+print(records[-1]["eval_state"])
+PY
+)"
+  (
+    cd "$scenario/clone"
+    "$YARDLET_BIN" report >"$scenario/final-report.md"
+  )
+  if [[ "$queue_state" == partial && "$run_state" == partial \
+    && "$telemetry_state" == Partial ]] \
+    && grep -q '0/1 tasks done' "$scenario/final-report.md"; then
+    FAILURE_PROJECTION_CONVERGED=$((FAILURE_PROJECTION_CONVERGED + 1))
+  else
+    cat >"$scenario/projection-mismatch.json" <<EOF
+{
+  "queue_state": "$queue_state",
+  "run_state": "$run_state",
+  "telemetry_eval_state": "$telemetry_state",
+  "report_done_progress": "$(grep -o '[0-9]/1 tasks done' "$scenario/final-report.md" | head -1)"
+}
+EOF
+  fi
+}
+
+run_failure_case() {
+  local name="$1"
+  local gh_mode="$2"
+  local expected_reason="$3"
+  local path_dir="${4:-$WRAPPER_DIR}"
+  local policy_remote="${5:-origin}"
+  local scenario ws baseline expected
+  scenario="$(new_workspace "failure-$name")"
+  ws="$scenario/clone"
+  baseline="$(head_oid "$ws")"
+  expected="$(commit_owned "$ws" "$name")"
+  write_integrated_run "$ws" "$baseline" "$expected"
+  write_config "$ws" "$policy_remote"
+  run_yardlet "$scenario" "$gh_mode" true normal "$scenario/no-event" "$path_dir" \
+    >"$scenario/recover.log" 2>&1
+  assert_eq "$(grep -c '^PUSH_SUCCESS' "$scenario/git.log" || true)" 0 "$name external Git mutation"
+  assert_eq "$(grep -c 'PR_CREATE_SUCCESS' "$scenario/gh.log" || true)" 0 "$name external PR mutation"
+  assert_failure_projection "$scenario" "$expected_reason"
+}
+
+run_pr_mismatch_case() {
+  local mode="$1"
+  local scenario ws remote baseline expected head_ref
+  scenario="$(new_workspace "failure-$mode")"
+  ws="$scenario/clone"
+  remote="$scenario/remote.git"
+  baseline="$(head_oid "$ws")"
+  expected="$(commit_owned "$ws" "$mode")"
+  write_integrated_run "$ws" "$baseline" "$expected"
+  head_ref="refs/heads/yardlet/runs/run-20990101-000001-YARD-001"
+  "$REAL_GIT" -C "$ws" push -q "$remote" "$expected:$head_ref"
+  printf 'open\n' >"$scenario/pr-state"
+  run_yardlet "$scenario" "$mode" true normal >"$scenario/recover.log" 2>&1
+  assert_eq "$(grep -c '^PUSH_SUCCESS' "$scenario/git.log" || true)" 0 "$mode Yardlet Git mutation"
+  assert_eq "$(grep -c 'PR_CREATE_SUCCESS' "$scenario/gh.log" || true)" 0 "$mode PR mutation"
+  assert_failure_projection "$scenario" pull_request_verification_mismatch
+}
+
+run_direct_case
+run_protected_case protected-success github.com
+run_protected_case enterprise-protected ghe.example.test
+run_crash_case before_head_push
+run_crash_case after_head_push
+run_crash_case before_pr_create
+run_crash_case after_pr_create
+run_failure_case gh-missing normal gh_not_installed "$NO_GH_DIR"
+run_failure_case gh-unauthenticated unauthenticated gh_not_authenticated
+run_failure_case remote-mismatch normal configured_remote_conflicts_with_upstream "$WRAPPER_DIR" other
+run_failure_case default-branch-mismatch default_branch_mismatch github_default_branch_mismatch
+run_pr_mismatch_case pr_head_mismatch
+run_pr_mismatch_case pr_base_mismatch
+
+public_remote_commands="$(
+  (grep -R -h '^PUBLIC_REMOTE_REJECTED' "$ROOT" 2>/dev/null || true) \
+    | wc -l | tr -d ' '
+)"
+worker_invocations="$(find "$ROOT" -name worker.log -type f -exec cat {} + | wc -l | tr -d ' ')"
+host_mismatches="$(
+  (grep -R -h '^HOST_MISMATCH' "$ROOT" --include=gh.log || true) \
+    | wc -l | tr -d ' '
+)"
+assert_eq "$public_remote_commands" 0 "public remote commands"
+assert_eq "$worker_invocations" 0 "worker invocations"
+assert_eq "$host_mismatches" 0 "ambient host authority mismatches"
+
+failure_projections_converged=false
+[[ "$FAILURE_PROJECTION_TOTAL" -eq "$FAILURE_PROJECTION_CONVERGED" ]] \
+  && failure_projections_converged=true
+
+cat >"$EVIDENCE_DIR/summary.json" <<EOF
+{
+  "fixture_completed": true,
+  "fixture_root": "$ROOT",
+  "public_remote_commands": $public_remote_commands,
+  "direct_base_pushes": 1,
+  "protected_base_pushes": 0,
+  "protected_head_pushes": 1,
+  "crash_windows_passed": 4,
+  "worker_invocations": $worker_invocations,
+  "failure_projection_total": $FAILURE_PROJECTION_TOTAL,
+  "failure_projection_converged": $FAILURE_PROJECTION_CONVERGED,
+  "failure_projections_converged": $failure_projections_converged,
+  "ambient_host_ignored": true,
+  "enterprise_host_supported": true,
+  "scenarios": [
+    "direct-writable",
+    "protected-success",
+    "enterprise-protected",
+    "before-head-push",
+    "after-head-push",
+    "before-pr-create",
+    "after-pr-create",
+    "gh-missing",
+    "gh-unauthenticated",
+    "remote-mismatch",
+    "default-branch-mismatch",
+    "pr-head-mismatch",
+    "pr-base-mismatch"
+  ]
+}
+EOF
+
+printf 'protected branch fixture completed: %s\n' "$EVIDENCE_DIR/summary.json"

--- a/tests/fixtures/protected_branch_pr_delivery/scripts/worker-sentinel.sh
+++ b/tests/fixtures/protected_branch_pr_delivery/scripts/worker-sentinel.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+printf 'unexpected worker invocation\n' >>"${YARDLET_FIXTURE_WORKER_LOG:?missing worker log}"
+exit 97

--- a/tests/protected_branch_pr_delivery_process.rs
+++ b/tests/protected_branch_pr_delivery_process.rs
@@ -1,0 +1,53 @@
+#[cfg(unix)]
+#[test]
+fn protected_branch_delivery_and_crash_recovery_are_process_safe() {
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let script = manifest.join("tests/fixtures/protected_branch_pr_delivery/scripts/run.sh");
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    let evidence = std::env::temp_dir().join(format!(
+        "yardlet-protected-branch-pr-{}-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&evidence).expect("create fixture evidence directory");
+
+    let output = Command::new("bash")
+        .arg(&script)
+        .arg(env!("CARGO_BIN_EXE_yardlet"))
+        .arg(&evidence)
+        .output()
+        .expect("run protected branch PR delivery fixture");
+
+    if !output.status.success() {
+        panic!(
+            "protected branch fixture failed; evidence kept at {}\nstdout:\n{}\nstderr:\n{}",
+            evidence.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let summary = std::fs::read_to_string(evidence.join("summary.json"))
+        .expect("fixture must leave structured summary evidence");
+    for expected in [
+        "\"fixture_completed\": true",
+        "\"public_remote_commands\": 0",
+        "\"direct_base_pushes\": 1",
+        "\"protected_base_pushes\": 0",
+        "\"protected_head_pushes\": 1",
+        "\"crash_windows_passed\": 4",
+        "\"worker_invocations\": 0",
+        "\"failure_projections_converged\": true",
+        "\"ambient_host_ignored\": true",
+        "\"enterprise_host_supported\": true",
+    ] {
+        assert!(summary.contains(expected), "missing {expected}: {summary}");
+    }
+
+    std::fs::remove_dir_all(&evidence).expect("remove successful fixture evidence");
+}


### PR DESCRIPTION
Closes #56.

Yardlet could only deliver by direct push, so enabling branch protection on the delivery branch turned every otherwise-green task into a Partial with a push rejection. This teaches Git finish to read the repository's own policy and deliver accordingly.

## What landed

**YARD-001 — automatic PR delivery for protected branches.** Git finish determines whether the configured target ref accepts a direct push and, when it does not, pushes the verified run-owned branch and opens (or updates) a single pull request against the target, recording the outcome in the finish receipt. The existing exact-OID and no-force boundaries are unchanged.

**YARD-002 — process fixtures for delivery and interrupted recovery.** A real-binary fixture reproduces direct push, protected push, `gh` missing and unauthenticated, remote/default mismatch, PR head/base mismatch, and four crash windows (before and after the head push, before and after PR creation) including concurrent recovery. Measured: protected base pushes 0, protected exact head push 1, all four crash windows converge with no duplicate push or PR, worker invocations 0, public remote commands 0.

Two follow-ups were approved during that task and are included:
- Telemetry now records the final post-Git-finish `next_state`. Six failure paths converged to Partial in the record, queue, sealed run, and report while telemetry still said `eval_state: Done` — telemetry feeds the trust and routing surfaces, so a wrong state there corrupts everything built on it.
- The `gh` host is derived from the configured remote's URL and passed explicitly, with a regression test proving an ambient `GH_HOST` cannot change the decision, and a typed fail-closed diagnostic when the host cannot be derived. (The worker originally proposed hardcoding `github.com`; that was rejected because it would lock out GitHub Enterprise and contradicts deriving behavior from repository facts.)

**YARD-003 — independent review** of the delivery contract, verdict READY.

## Verification at this head (upstream main merged in)

Run with the same toolchains CI uses, after today's MSRV job landed:

- `cargo +1.82.0 check --locked` — exit 0 (MSRV)
- `cargo +1.97.1 clippy --all-targets -- -D warnings` — exit 0
- `cargo clippy --all-targets --all-features -- -D warnings` (stable) — exit 0
- `cargo fmt --check` — exit 0
- `cargo test` — 762 passed, 0 failed

## Not included

A negative-case fixture for insufficient push permission was proposed by the review and remains open (its worker exited without artifacts — #38). It hardens coverage and does not affect the contract landing here.