### PR TITLE
Own the CodeQL setup so test code is excluded from analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: yardlet
+
+# Analyze production code only. Yardlet's tests build their own scratch
+# directories from `std::env::temp_dir()` and delete them on the way out,
+# which the Rust path-injection query reads as a filesystem sink fed by an
+# environment value. That threat model does not apply to a test creating and
+# removing its own directory, so scanning test code produced only false
+# positives while masking the signal from real code paths.
+paths-ignore:
+  - tests

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+# Advanced setup, replacing CodeQL default setup. The only reason to own this
+# workflow is the configuration file: default setup cannot apply path filters,
+# so it scanned test code and reported test-only temp directories as
+# path-injection sinks. See .github/codeql/codeql-config.yml.
+#
+# Languages match what default setup analyzed, so switching does not narrow
+# coverage.
+
+on:
+  push:
+    branches: [main, "v*"]
+  pull_request:
+  schedule:
+    # Keep a weekly baseline scan so advisories that land after a merge are
+    # still surfaced on the default branch.
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript, python, rust]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: github/codeql-action/init@3b0bd1d116c0bde30213346b22d4f634d96a2fb0 # v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - uses: github/codeql-action/analyze@3b0bd1d116c0bde30213346b22d4f634d96a2fb0 # v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Follow-up to the false positives that blocked #72.

## Why

CodeQL runs through **default setup**, which cannot apply path filters. It therefore analyzes test code, where the standard pattern — build a scratch directory from `std::env::temp_dir()`, use it, delete it — reads as a path-injection sink fed by an environment value. The threat model does not apply to a test creating and removing its own directory.

The result was seven high-severity false positives on #72 (dismissed with reasons) on top of twenty already open on main, all the same rule. Left alone, every PR that adds a test trips a required check. A gate that fires on ordinary work stops being read and starts being worked around, which is worse for security than a narrower gate that stays meaningful.

## What this does

Replaces default setup with an advanced setup whose only substantive addition is the config file: `paths-ignore: [tests]`. The language matrix (`actions`, `javascript-typescript`, `python`, `rust`) matches what default setup analyzed, so coverage over production code does not narrow, and a weekly scheduled scan keeps a default-branch baseline. Actions are SHA-pinned to match the existing CI convention.

Note this does not silence the pattern inside `src/*.rs` `#[cfg(test)]` modules, since path filters work per file. Those are few; they can be dismissed individually as they appear, or the shared temp-dir helper can be moved under `tests/` later.

## Repository settings required when this merges

Two changes only you can make:

1. **Disable CodeQL default setup** (Settings -> Code security -> Code scanning). If both remain enabled, analyses run twice and the duplicate results are confusing.
2. **Update the protected-branch required checks** to this workflow's `Analyze (...)` jobs, replacing the default-setup check entries. Without this the branch protection will wait on check names that no longer report.

Worth doing in that order, right after merge, so main is never left waiting on a check that cannot run.