### PR TITLE
fix(runtime): detect and recover workers that defer artifacts to a killed background task

### DIFF
--- a/src/guard.rs
+++ b/src/guard.rs
@@ -704,6 +704,7 @@ invocation:
             },
             limits: crate::schemas::Limits::default(),
             provider_response_refusal_patterns: vec![],
+            background_deferral_patterns: vec![],
         };
 
         assert!(scout_sandbox_contract(&profile(&[], &[])).is_err());

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1076,6 +1076,16 @@ pub fn compile(inputs: &PacketInputs) -> String {
          - `{rd}/validation.log` (if you ran validation)\n\n",
         rd = inputs.run_dir_rel
     ));
+    // Issue #38: workers repeatedly backgrounded a long `cargo test` and ended
+    // the turn intending to finish "when the notification arrives". The session
+    // is torn down at end of turn, so that notification never comes and the
+    // finished work is lost. State the session lifetime explicitly.
+    p.push_str(
+        "Your session ends when your turn ends. Run long validation commands synchronously in \
+         the foreground and wait for them to exit \u{2014} a backgrounded task is killed at \
+         teardown and its completion notification is never delivered. Write the files above \
+         BEFORE ending your turn; work you did not record does not exist.\n\n",
+    );
     // Non-code tasks (research/review/safety) deliver findings as prose; require
     // a human-readable report so there's an artifact a person can actually read.
     let kind = inputs.task.kind.trim();
@@ -1582,6 +1592,20 @@ pub(crate) fn provider_refusal_recovery_instruction() -> &'static str {
      run/task ids. If the task cannot be completed, use status needs_user with a concise \
      question_for_user. Do not repeat, reinterpret, or work around any prior provider message; \
      report only the structured task status."
+}
+
+/// Recovery guidance for a worker that ended its turn while a background task
+/// was still running (issue #38). It names the mechanism rather than the
+/// symptom, because the worker's own review work was usually complete.
+pub(crate) fn background_deferral_recovery_instruction() -> &'static str {
+    "Output-contract recovery: your previous attempt ended its turn while a background task was \
+     still running, so it never wrote its result files. This session is non-interactive — when \
+     your turn ends the session is torn down, any background task is killed, and its completion \
+     notification is never delivered. Run every validation command synchronously in the \
+     foreground and wait for it to exit, then write result.json (and handoff.md, and \
+     validation.log if you ran validation) BEFORE you end your turn. If a command is too slow to \
+     finish in the foreground, narrow it and record what you did not run in validation.failures \
+     rather than deferring the write."
 }
 
 const RESULT_SCHEMA_HINT: &str = r#"```json

--- a/src/run.rs
+++ b/src/run.rs
@@ -1152,23 +1152,23 @@ fn output_log_span(run_dir: &std::path::Path, byte_start: u64) -> WorkerOutputLo
     }
 }
 
-struct ProviderRefusalAttemptClassification {
+struct OutputContractAttemptClassification {
     incident: Option<OutputContractIncident>,
     skip_notice: Option<String>,
 }
 
 #[derive(Default, Deserialize, Serialize)]
-struct ProviderRefusalClassificationSkips {
+struct OutputContractClassificationSkips {
     schema_version: u32,
     notices: Vec<String>,
 }
 
-fn classify_provider_refusal_attempt(
+fn classify_output_contract_attempt(
     profile: &WorkerProfile,
     run_dir: &std::path::Path,
     attempt_id: &str,
     byte_start: u64,
-) -> ProviderRefusalAttemptClassification {
+) -> OutputContractAttemptClassification {
     let span = output_log_span(run_dir, byte_start);
     match workers::classify_output_contract_cause(
         profile,
@@ -1176,44 +1176,42 @@ fn classify_provider_refusal_attempt(
         &run_dir.join("worker-output.log"),
         &span,
     ) {
-        Ok(Some(OutputContractCause::ProviderResponseRefused)) => {
-            ProviderRefusalAttemptClassification {
-                incident: Some(OutputContractIncident {
-                    cause: OutputContractCause::ProviderResponseRefused,
-                    worker_id: profile.id.clone(),
-                    first_attempt_id: attempt_id.to_string(),
-                    first_log_span: span,
-                    recovery_consumed: false,
-                    terminal_attempt_id: None,
-                }),
-                skip_notice: None,
-            }
-        }
-        Ok(None) => ProviderRefusalAttemptClassification {
+        Ok(Some(cause)) => OutputContractAttemptClassification {
+            incident: Some(OutputContractIncident {
+                cause,
+                worker_id: profile.id.clone(),
+                first_attempt_id: attempt_id.to_string(),
+                first_log_span: span,
+                recovery_consumed: false,
+                terminal_attempt_id: None,
+            }),
+            skip_notice: None,
+        },
+        Ok(None) => OutputContractAttemptClassification {
             incident: None,
             skip_notice: None,
         },
-        Err(error) => ProviderRefusalAttemptClassification {
+        Err(error) => OutputContractAttemptClassification {
             incident: None,
             skip_notice: Some(format!(
-                "provider refusal classification skipped for {attempt_id}: {error}"
+                "output-contract classification skipped for {attempt_id}: {error}"
             )),
         },
     }
 }
 
-fn retain_provider_refusal_classification(
+fn retain_output_contract_classification(
     run_dir: &std::path::Path,
-    classification: ProviderRefusalAttemptClassification,
+    classification: OutputContractAttemptClassification,
     lines: &mut Vec<String>,
 ) -> Result<Option<OutputContractIncident>> {
     if let Some(notice) = classification.skip_notice {
         lines.push(notice.clone());
         let path = run_dir.join(PROVIDER_REFUSAL_CLASSIFICATION_SKIPS_FILE);
         let mut record = if path.is_file() {
-            state::load_yaml::<ProviderRefusalClassificationSkips>(&path)?
+            state::load_yaml::<OutputContractClassificationSkips>(&path)?
         } else {
-            ProviderRefusalClassificationSkips {
+            OutputContractClassificationSkips {
                 schema_version: 1,
                 notices: Vec::new(),
             }
@@ -2818,9 +2816,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         &current_capture,
         &outcome,
     )?;
-    let mut output_contract_incident = retain_provider_refusal_classification(
+    let mut output_contract_incident = retain_output_contract_classification(
         &run_dir,
-        classify_provider_refusal_attempt(
+        classify_output_contract_attempt(
             &eff_profile,
             &run_dir,
             &current_attempt.attempt_id,
@@ -2910,9 +2908,9 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             &current_capture,
             &outcome,
         )?;
-        output_contract_incident = retain_provider_refusal_classification(
+        output_contract_incident = retain_output_contract_classification(
             &run_dir,
-            classify_provider_refusal_attempt(
+            classify_output_contract_attempt(
                 &eff_profile,
                 &run_dir,
                 &current_attempt.attempt_id,
@@ -2958,9 +2956,18 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         // NeedsUser instead of starting another worker.
         incident.recovery_consumed = true;
         persist_output_contract_incident(&run_dir, &incident)?;
+        let (cause_label, recovery_instruction) = match incident.cause {
+            OutputContractCause::ProviderResponseRefused => (
+                "provider_response_refused",
+                packet::provider_refusal_recovery_instruction(),
+            ),
+            OutputContractCause::WorkerDeferredToBackgroundTask => (
+                "worker_deferred_to_background_task",
+                packet::background_deferral_recovery_instruction(),
+            ),
+        };
         lines.push(format!(
-            "typed output-contract cause: provider_response_refused; retrying {} once",
-            active_worker_id
+            "typed output-contract cause: {cause_label}; retrying {active_worker_id} once"
         ));
         let recovery_packet = packet::compile(&PacketInputs {
             worker_id: &active_worker_id,
@@ -2969,7 +2976,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             repo: &summary,
             run_dir_rel: &run_dir_rel,
             conversation: &conversation,
-            continuation: Some(packet::provider_refusal_recovery_instruction()),
+            continuation: Some(recovery_instruction),
             chained_from: None,
             language: &language,
             images: &images,
@@ -6111,11 +6118,60 @@ fn feedback_question(task: &crate::schemas::Task, feedback: &FeedbackRecord) -> 
     }
 }
 
-fn review_without_remediation_question(task: &crate::schemas::Task) -> String {
-    format!(
-        "`{}` 리뷰가 통과하지 못했고 실행 가능한 수정 작업이 없습니다. 수정 작업을 큐에 추가한 뒤 리뷰를 재실행하거나 현재 판정을 수동으로 확정해 주세요. 어느 조치로 이어갈까요?",
-        task.id
-    )
+/// Why a review run ended without a usable pass. These are different events for
+/// the operator: a failing verdict is review evidence to act on, while missing
+/// artifacts mean no verdict exists at all and the only next step is a re-run
+/// (issue #39).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReviewFailureCause {
+    /// The review ran and judged at least one criterion as failing.
+    VerdictFailed,
+    /// The worker exited without writing (or writing a valid) result.json.
+    ArtifactsMissing,
+}
+
+fn review_failure_cause(eval: &evaluator::Evaluation) -> ReviewFailureCause {
+    let artifacts_missing = eval.checks.iter().any(|check| {
+        check.fatal
+            && !check.passed
+            && matches!(
+                check.name.as_str(),
+                "result_file_present" | "result_schema_valid"
+            )
+    });
+    if artifacts_missing {
+        ReviewFailureCause::ArtifactsMissing
+    } else {
+        ReviewFailureCause::VerdictFailed
+    }
+}
+
+fn review_without_remediation_question(
+    task: &crate::schemas::Task,
+    cause: ReviewFailureCause,
+    incident: Option<&OutputContractIncident>,
+) -> String {
+    match cause {
+        ReviewFailureCause::VerdictFailed => format!(
+            "`{}` 리뷰가 통과하지 못했고 실행 가능한 수정 작업이 없습니다. 수정 작업을 큐에 추가한 뒤 리뷰를 재실행하거나 현재 판정을 수동으로 확정해 주세요. 어느 조치로 이어갈까요?",
+            task.id
+        ),
+        ReviewFailureCause::ArtifactsMissing => {
+            let detail = match incident.map(|incident| incident.cause) {
+                Some(OutputContractCause::WorkerDeferredToBackgroundTask) => {
+                    " 워커가 백그라운드 작업을 남긴 채 턴을 끝낸 것이 원인입니다."
+                }
+                Some(OutputContractCause::ProviderResponseRefused) => {
+                    " provider가 응답을 거부한 것이 원인입니다."
+                }
+                None => "",
+            };
+            format!(
+                "`{}` 리뷰 워커가 결과 파일 없이 종료되어 판정 자체가 없습니다. 리뷰가 실패했다는 뜻이 아니므로 수정 작업을 추가하거나 판정을 확정하지 마시고, 리뷰를 다시 실행해 주세요.{detail} 어느 조치로 이어갈까요?",
+                task.id
+            )
+        }
+    }
 }
 
 fn review_evaluation_failed(is_review: bool, evaluated_state: TaskState) -> bool {
@@ -6551,8 +6607,8 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         .ok()
         .and_then(|t| serde_json::from_str(&t).ok());
     let output_contract_incident = load_output_contract_incident(run_dir);
-    let provider_refusal_classification_skips =
-        state::load_yaml::<ProviderRefusalClassificationSkips>(
+    let output_contract_classification_skips =
+        state::load_yaml::<OutputContractClassificationSkips>(
             &run_dir.join(PROVIDER_REFUSAL_CLASSIFICATION_SKIPS_FILE),
         )
         .map(|record| record.notices)
@@ -6608,15 +6664,23 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     }
     if terminal_output_contract_incident {
         next_state = TaskState::NeedsUser;
-        question_to_persist = Some((
-            "provider_response_refused가 감지되었고 동일 worker의 1회 output-contract 복구도 result.json 없이 종료되었습니다. worker/provider 응답을 확인한 뒤 이 작업을 어떻게 진행할지 알려주세요."
-                .to_string(),
-            EventActorKind::System,
+        let cause = output_contract_incident
+            .as_ref()
+            .map(|incident| incident.cause);
+        let (cause_label, question) = match cause {
+            Some(OutputContractCause::WorkerDeferredToBackgroundTask) => (
+                "worker_deferred_to_background_task",
+                "worker가 백그라운드 작업을 남긴 채 턴을 끝내 result.json 없이 종료되었고, 전경 실행을 지시한 1회 복구도 같은 방식으로 끝났습니다. 리뷰/작업 내용이 실패했다는 뜻은 아닙니다. 이 작업을 어떻게 진행할지 알려주세요.",
+            ),
+            _ => (
+                "provider_response_refused",
+                "provider_response_refused가 감지되었고 동일 worker의 1회 output-contract 복구도 result.json 없이 종료되었습니다. worker/provider 응답을 확인한 뒤 이 작업을 어떻게 진행할지 알려주세요.",
+            ),
+        };
+        question_to_persist = Some((question.to_string(), EventActorKind::System));
+        lines.push(format!(
+            "output-contract recovery exhausted: {cause_label}; paused for user"
         ));
-        lines.push(
-            "output-contract recovery exhausted: provider_response_refused; paused for user"
-                .to_string(),
-        );
     }
     if let Some(reason) = input_overlay_parity_failure.as_ref() {
         state::write_str(&run_dir.join("partial-reason"), reason)?;
@@ -6673,9 +6737,9 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     if let Some(incident) = &output_contract_incident {
         append_output_contract_incident_note(run_dir, incident)?;
     }
-    append_provider_refusal_classification_skip_notes(
+    append_output_contract_classification_skip_notes(
         run_dir,
-        &provider_refusal_classification_skips,
+        &output_contract_classification_skips,
     )?;
     let artifact_context = channel_run_context(ws, &intent_id, &task.id);
     let worker_root = merge
@@ -7127,7 +7191,11 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         let remediation = schedulable_remediation_ids(queue, &ingested);
         if remediation.is_empty() {
             if persisted_question.is_none() {
-                let question = review_without_remediation_question(task);
+                let question = review_without_remediation_question(
+                    task,
+                    review_failure_cause(&eval),
+                    output_contract_incident.as_ref(),
+                );
                 let channel_context = channel_run_context(ws, &intent_id, &task.id);
                 persist_needs_user_question(
                     ws,
@@ -7596,7 +7664,7 @@ fn append_output_contract_incident_note(
     Ok(())
 }
 
-fn append_provider_refusal_classification_skip_notes(
+fn append_output_contract_classification_skip_notes(
     run_dir: &std::path::Path,
     notices: &[String],
 ) -> Result<()> {
@@ -7865,6 +7933,93 @@ mod tests {
             payload: serde_json::Value::Null,
             raw_ref: None,
         }
+    }
+
+    fn eval_with_failed_checks(names: &[&str]) -> evaluator::Evaluation {
+        evaluator::Evaluation {
+            run_id: "run-test".into(),
+            task_id: "YARD-002".into(),
+            status: "failed".into(),
+            checks: names
+                .iter()
+                .map(|name| evaluator::Check {
+                    name: (*name).into(),
+                    passed: false,
+                    fatal: true,
+                    note: String::new(),
+                })
+                .collect(),
+            next_task_state: TaskState::Failed,
+        }
+    }
+
+    fn review_task() -> crate::schemas::Task {
+        crate::yaml::from_str("id: YARD-002\ntitle: review\nkind: review\n").unwrap()
+    }
+
+    /// Issue #39: a review worker that exits without result.json produced NO
+    /// verdict. Telling the operator the review "did not pass" makes them queue
+    /// fix tasks for a review that never judged anything.
+    #[test]
+    fn review_without_artifacts_is_not_reported_as_a_failed_verdict() {
+        let missing = eval_with_failed_checks(&["result_file_present"]);
+        assert_eq!(
+            review_failure_cause(&missing),
+            ReviewFailureCause::ArtifactsMissing
+        );
+        let question = review_without_remediation_question(
+            &review_task(),
+            review_failure_cause(&missing),
+            None,
+        );
+        assert!(question.contains("판정 자체가 없습니다"), "{question}");
+        assert!(
+            !question.contains("리뷰가 통과하지 못했고"),
+            "must not claim a failing verdict: {question}"
+        );
+
+        let invalid = eval_with_failed_checks(&["result_schema_valid"]);
+        assert_eq!(
+            review_failure_cause(&invalid),
+            ReviewFailureCause::ArtifactsMissing
+        );
+
+        // A real failing verdict keeps the remediation wording.
+        let judged = eval_with_failed_checks(&["review_criteria_pass"]);
+        assert_eq!(
+            review_failure_cause(&judged),
+            ReviewFailureCause::VerdictFailed
+        );
+        let question = review_without_remediation_question(
+            &review_task(),
+            review_failure_cause(&judged),
+            None,
+        );
+        assert!(question.contains("리뷰가 통과하지 못했고"), "{question}");
+    }
+
+    /// Issue #38: when the missing artifacts are explained by a typed incident,
+    /// the operator prompt names that cause instead of leaving them guessing.
+    #[test]
+    fn review_artifacts_missing_question_names_a_typed_incident_cause() {
+        let incident = OutputContractIncident {
+            cause: OutputContractCause::WorkerDeferredToBackgroundTask,
+            worker_id: "claude-code".into(),
+            first_attempt_id: "attempt-1".into(),
+            first_log_span: WorkerOutputLogSpan {
+                path: "worker-output.log".into(),
+                byte_start: 0,
+                byte_end: 1,
+            },
+            recovery_consumed: true,
+            terminal_attempt_id: Some("attempt-2".into()),
+        };
+        let question = review_without_remediation_question(
+            &review_task(),
+            ReviewFailureCause::ArtifactsMissing,
+            Some(&incident),
+        );
+        assert!(question.contains("백그라운드 작업"), "{question}");
     }
 
     #[test]

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1959,32 +1959,48 @@ pub const MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES: usize = 256;
 impl WorkersFile {
     pub fn validate(&self) -> Result<(), String> {
         for worker in &self.workers {
-            let patterns = &worker.provider_response_refusal_patterns;
-            if patterns.len() > MAX_PROVIDER_RESPONSE_REFUSAL_PATTERNS {
-                return Err(format!(
-                    "worker '{}' configures {} provider refusal patterns; maximum is {}",
-                    worker.id,
-                    patterns.len(),
-                    MAX_PROVIDER_RESPONSE_REFUSAL_PATTERNS
-                ));
-            }
-            for pattern in patterns {
-                if pattern.trim().is_empty() {
-                    return Err(format!(
-                        "worker '{}' has an empty provider refusal pattern",
-                        worker.id
-                    ));
-                }
-                if pattern.len() > MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES {
-                    return Err(format!(
-                        "worker '{}' provider refusal pattern exceeds {} bytes",
-                        worker.id, MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES
-                    ));
-                }
-            }
+            validate_output_contract_patterns(
+                &worker.id,
+                "provider refusal",
+                &worker.provider_response_refusal_patterns,
+            )?;
+            validate_output_contract_patterns(
+                &worker.id,
+                "background deferral",
+                &worker.background_deferral_patterns,
+            )?;
         }
         Ok(())
     }
+}
+
+/// Both output-contract pattern lists are scanned over the same bounded log
+/// span, so they share one budget and one set of well-formedness rules.
+fn validate_output_contract_patterns(
+    worker_id: &str,
+    label: &str,
+    patterns: &[String],
+) -> Result<(), String> {
+    if patterns.len() > MAX_PROVIDER_RESPONSE_REFUSAL_PATTERNS {
+        return Err(format!(
+            "worker '{}' configures {} {label} patterns; maximum is {}",
+            worker_id,
+            patterns.len(),
+            MAX_PROVIDER_RESPONSE_REFUSAL_PATTERNS
+        ));
+    }
+    for pattern in patterns {
+        if pattern.trim().is_empty() {
+            return Err(format!("worker '{worker_id}' has an empty {label} pattern"));
+        }
+        if pattern.len() > MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES {
+            return Err(format!(
+                "worker '{worker_id}' {label} pattern exceeds {} bytes",
+                MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2079,12 +2095,44 @@ pub struct WorkerProfile {
     /// current attempt wrote no result.json.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub provider_response_refusal_patterns: Vec<String>,
+    /// Bounded, case-insensitive literal signatures this worker emits when its
+    /// non-interactive session is torn down with a background task still
+    /// running. Consulted only when the current attempt wrote no result.json:
+    /// the worker deferred its artifacts to a completion notification that a
+    /// non-interactive session can never deliver. Defaulted rather than left
+    /// empty so existing workspaces are covered without editing workers.yaml;
+    /// set an explicit (possibly empty) list to override.
+    #[serde(
+        default = "default_background_deferral_patterns",
+        skip_serializing_if = "is_default_background_deferral_patterns"
+    )]
+    pub background_deferral_patterns: Vec<String>,
+}
+
+/// Structural markers, not prose: these are the exact stream events a
+/// non-interactive Claude Code session emits while tearing down a still-running
+/// background task. Other worker families simply never emit them, so an
+/// unconditional default cannot produce a cross-worker false positive.
+pub fn default_background_deferral_patterns() -> Vec<String> {
+    vec![
+        "\"subtype\":\"task_updated\"".to_string(),
+        "\"subtype\":\"task_notification\"".to_string(),
+    ]
+}
+
+/// Keep the defaulted list out of written workers.yaml so only a deliberate
+/// user override is ever persisted.
+fn is_default_background_deferral_patterns(patterns: &[String]) -> bool {
+    patterns == default_background_deferral_patterns()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OutputContractCause {
     ProviderResponseRefused,
+    /// The worker ended its turn while a background task was still running, so
+    /// it never wrote its result artifacts (issue #38).
+    WorkerDeferredToBackgroundTask,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -22,7 +22,9 @@ use crate::schemas::{
     RoutingProvenance, WorkerOutputLogSpan, WorkerProfile,
 };
 
-pub const MAX_PROVIDER_RESPONSE_REFUSAL_SCAN_BYTES: u64 = 256 * 1024;
+/// Tail of a resultless attempt's log span that output-contract classification
+/// reads. Bounds the work; the causes it looks for are terminal events.
+pub const MAX_OUTPUT_CONTRACT_SCAN_BYTES: u64 = 256 * 1024;
 
 pub(crate) const WORKER_PROCESS_PROVENANCE_FILE: &str = "worker-process.yaml";
 
@@ -100,9 +102,17 @@ pub struct AttemptCapture {
     pub stderr_log: PathBuf,
 }
 
-/// Classify only the exact public-log bytes appended by one resultless attempt.
+/// Classify only the public-log bytes appended by one resultless attempt.
 /// Patterns are bounded, case-insensitive literals rather than regexes so a
 /// user-owned profile cannot introduce unbounded matching work.
+///
+/// A real attempt log runs to hundreds of kilobytes or more, so a span larger
+/// than the scan budget is the normal case, not an error: both classified
+/// causes are terminal events (a provider's refusal reply, a session teardown
+/// killing background tasks) and therefore land at the END of the span. The
+/// scan reads the last `MAX_OUTPUT_CONTRACT_SCAN_BYTES` of the span. Spans that
+/// are structurally invalid (inverted, or past the end of the file) are still
+/// errors.
 pub fn classify_output_contract_cause(
     profile: &WorkerProfile,
     result_path: &Path,
@@ -111,18 +121,14 @@ pub fn classify_output_contract_cause(
 ) -> Result<Option<OutputContractCause>> {
     use std::io::{Read, Seek, SeekFrom};
 
-    if result_path.is_file() || profile.provider_response_refusal_patterns.is_empty() {
+    if result_path.is_file()
+        || (profile.provider_response_refusal_patterns.is_empty()
+            && profile.background_deferral_patterns.is_empty())
+    {
         return Ok(None);
     }
     if span.byte_end < span.byte_start {
         anyhow::bail!("worker output log span ends before it starts");
-    }
-    let span_len = span.byte_end - span.byte_start;
-    if span_len > MAX_PROVIDER_RESPONSE_REFUSAL_SCAN_BYTES {
-        anyhow::bail!(
-            "worker output log span exceeds {} bytes",
-            MAX_PROVIDER_RESPONSE_REFUSAL_SCAN_BYTES
-        );
     }
     let mut file = std::fs::File::open(output_log)
         .with_context(|| format!("opening bounded worker output {}", output_log.display()))?;
@@ -135,15 +141,26 @@ pub fn classify_output_contract_cause(
             file_len
         );
     }
-    file.seek(SeekFrom::Start(span.byte_start))?;
-    let mut bytes = vec![0; span_len as usize];
+    let scan_start = span
+        .byte_end
+        .saturating_sub(MAX_OUTPUT_CONTRACT_SCAN_BYTES)
+        .max(span.byte_start);
+    file.seek(SeekFrom::Start(scan_start))?;
+    let mut bytes = vec![0; (span.byte_end - scan_start) as usize];
     file.read_exact(&mut bytes)?;
     let haystack = String::from_utf8_lossy(&bytes).to_lowercase();
-    Ok(profile
-        .provider_response_refusal_patterns
-        .iter()
-        .any(|pattern| haystack.contains(&pattern.to_lowercase()))
-        .then_some(OutputContractCause::ProviderResponseRefused))
+    let matches = |patterns: &[String]| {
+        patterns
+            .iter()
+            .any(|pattern| haystack.contains(&pattern.to_lowercase()))
+    };
+    // A refusal explains why no work happened at all; a background deferral only
+    // explains missing artifacts. Classify the stronger cause first.
+    if matches(&profile.provider_response_refusal_patterns) {
+        return Ok(Some(OutputContractCause::ProviderResponseRefused));
+    }
+    Ok(matches(&profile.background_deferral_patterns)
+        .then_some(OutputContractCause::WorkerDeferredToBackgroundTask))
 }
 
 fn normalized_event(
@@ -1637,15 +1654,17 @@ mod tests {
         )
         .unwrap();
         for span in [
+            // Inverted span.
             WorkerOutputLogSpan {
                 path: "worker-output.log".into(),
                 byte_start: 10,
                 byte_end: 9,
             },
+            // Span running past the end of the file.
             WorkerOutputLogSpan {
                 path: "worker-output.log".into(),
                 byte_start: 0,
-                byte_end: MAX_PROVIDER_RESPONSE_REFUSAL_SCAN_BYTES + 1,
+                byte_end: MAX_OUTPUT_CONTRACT_SCAN_BYTES + 1,
             },
         ] {
             assert!(classify_output_contract_cause(
@@ -1656,6 +1675,91 @@ mod tests {
             )
             .is_err());
         }
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Regression: a real attempt log is far larger than the scan budget. The
+    /// span must be scanned from its tail rather than rejected, or no live run
+    /// is ever classified.
+    #[test]
+    fn classification_scans_the_tail_of_an_oversized_span() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-output-contract-oversized-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("worker-output.log");
+        let filler = "x".repeat(MAX_OUTPUT_CONTRACT_SCAN_BYTES as usize + 4096);
+        std::fs::write(&log, format!("{filler}\nprovider declined\n")).unwrap();
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: fixture\nprovider_response_refusal_patterns: ['provider declined']\ninvocation: {command: fixture}\n",
+        )
+        .unwrap();
+        let span = WorkerOutputLogSpan {
+            path: "worker-output.log".into(),
+            byte_start: 0,
+            byte_end: std::fs::metadata(&log).unwrap().len(),
+        };
+        assert_eq!(
+            classify_output_contract_cause(&profile, &root.join("result.json"), &log, &span)
+                .unwrap(),
+            Some(OutputContractCause::ProviderResponseRefused)
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    /// Issue #38: the worker ended its turn with a background task still
+    /// running, so the non-interactive session tore down before result.json was
+    /// written. The teardown markers are structural stream events.
+    #[test]
+    fn classifies_background_task_deferral_from_teardown_markers() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-output-contract-deferral-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let log = root.join("worker-output.log");
+        // Verbatim shape of the teardown events observed in the runs cited by #38.
+        std::fs::write(
+            &log,
+            "{\"type\":\"system\",\"subtype\":\"task_updated\",\"task_id\":\"bdtea3zev\",\
+             \"patch\":{\"status\":\"killed\",\"end_time\":1784816678419}}\n\
+             {\"type\":\"system\",\"subtype\":\"task_notification\",\"task_id\":\"bdtea3zev\",\
+             \"status\":\"stopped\",\"output_file\":\"\",\"summary\":\"Run full cargo test\"}\n",
+        )
+        .unwrap();
+        let profile: WorkerProfile =
+            crate::yaml::from_str("id: claude-code\ninvocation: {command: claude}\n").unwrap();
+        assert_eq!(
+            profile.background_deferral_patterns,
+            crate::schemas::default_background_deferral_patterns(),
+            "an existing workers.yaml without the key must still be covered"
+        );
+        let span = WorkerOutputLogSpan {
+            path: "worker-output.log".into(),
+            byte_start: 0,
+            byte_end: std::fs::metadata(&log).unwrap().len(),
+        };
+        assert_eq!(
+            classify_output_contract_cause(&profile, &root.join("result.json"), &log, &span)
+                .unwrap(),
+            Some(OutputContractCause::WorkerDeferredToBackgroundTask)
+        );
+
+        // A worker family that never emits those events is unaffected.
+        std::fs::write(&log, "codex finished without writing a result\n").unwrap();
+        let span = WorkerOutputLogSpan {
+            path: "worker-output.log".into(),
+            byte_start: 0,
+            byte_end: std::fs::metadata(&log).unwrap().len(),
+        };
+        assert_eq!(
+            classify_output_contract_cause(&profile, &root.join("result.json"), &log, &span)
+                .unwrap(),
+            None
+        );
         std::fs::remove_dir_all(root).unwrap();
     }
 

--- a/tests/provider_response_refusal_process.rs
+++ b/tests/provider_response_refusal_process.rs
@@ -231,7 +231,7 @@ mod unix {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let notice = stdout
             .lines()
-            .find(|line| line.starts_with("provider refusal classification skipped for "))
+            .find(|line| line.starts_with("output-contract classification skipped for "))
             .unwrap_or_else(|| {
                 panic!(
                     "run summary keeps the classification skip notice\nstdout:\n{stdout}\nstderr:\n{}",


### PR DESCRIPTION
Closes #38, closes #39.

## Why

`yardlet trust` over 340 runs: claude-code produced **no result.json in 25 of 141 runs (18%)** against codex's 6 of 199 (3%). That is roughly 6 of its 35h29m of worker wall spent on runs that finished their work and recorded none of it. Every occurrence in #38 had complete, correct review substance.

The cause is a lifetime mismatch. The worker launches a long `cargo test` as a background task, ends its turn saying it will finalize when the completion notification arrives, and the non-interactive session is torn down at end of turn. The notification never fires. Three cited runs end with exactly this:

```
{"type":"system","subtype":"task_updated","patch":{"status":"killed",...}}
{"type":"system","subtype":"task_notification","status":"stopped","output_file":"",...}
```

## What changed

**Prevention.** Every packet now states the session lifetime in the required-output section: the session ends when the turn ends, a backgrounded task is killed at teardown, its notification is never delivered, and the result files must be written before the turn ends.

**Detection.** `OutputContractCause::WorkerDeferredToBackgroundTask`, classified from those teardown markers. They are structural stream events rather than prose, so matching does not depend on how the worker phrases its last message. Patterns default in code (not in the workers.yaml template) so existing workspaces are covered without editing their profiles; an explicit list still overrides. Worker families that never emit these events cannot false-positive, and classification only runs when result.json is already absent.

**Recovery.** The typed cause selects the recovery instruction for the existing one-shot retry, injecting the foreground-only guidance that fixed every observed occurrence on the first retry. Previously the retry only existed for provider refusals, and its log line and exhaustion message hardcoded `provider_response_refused` regardless of cause.

**Message accuracy (#39).** A review that produced no verdict is no longer reported as a review that failed one. `ReviewFailureCause` splits artifacts-missing from verdict-failed: the former names the typed incident behind it when one exists and asks for a re-run, rather than telling the operator to queue fix tasks or confirm a verdict that was never reached.

## Separate defect found while fixing this

Classification bailed with an error on any log span over 256KB. The three resultless runs cited in #38 have 470KB, 487KB, and 5.5MB logs, so **typed classification never ran on a live attempt and provider-refusal detection was dead in practice** — it only ever wrote a skip notice.

Both classified causes are terminal events at the end of a span, so the scan now reads the last 256KB of the span instead of rejecting it. Structurally invalid spans (inverted, or running past end of file) remain errors, and the existing process fixture still exercises that path.

## Verification

- `cargo test`: 766 passed, 0 failed, 20 targets, exit 0
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- CI parity: `cargo +1.82.0 check --locked --all-targets` and `cargo +1.97.1 clippy --all-targets -- -D warnings` both clean

New tests: teardown-marker classification including the cross-worker negative case, defaulted patterns reaching a profile that predates the key, tail scanning of an oversized span, and the two review-message causes.

Not covered here: no live run has exercised the automatic retry yet, since reproducing it means getting a worker to background a long command again. The unit path is tested; the end-to-end recovery is not.