### PR TITLE
fix(runtime): type the partial-reason marker instead of assuming a merge conflict

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ pub enum Command {
     Defer(DeferArgs),
     /// Bring a Deferred task back to Queued.
     Revive(ReviveArgs),
-    /// Finalize a merge-conflict Partial to Done after you integrated it by hand.
+    /// Finalize a blocked Partial to Done after you integrated it by hand.
     Resolve(ResolveArgs),
     /// Set the default worker permission: sandboxed | full.
     Access(AccessArgs),
@@ -1917,7 +1917,7 @@ fn cmd_resolve(cwd: &std::path::Path, args: ResolveArgs) -> Result<()> {
     } else if args.no_outputs {
         "state-only partial resolved by hand; no repository outputs".to_string()
     } else {
-        "merge conflict resolved by hand; task integrated".to_string()
+        "partial resolved by hand; task integrated".to_string()
     };
     let outcome = if args.no_outputs {
         crate::state::resolve_partial_no_outputs(&ws, &id, &detail).map_err(|error| {
@@ -1961,7 +1961,7 @@ fn cmd_resolve(cwd: &std::path::Path, args: ResolveArgs) -> Result<()> {
         );
     }
     if outcome.cleared_partial_reason {
-        println!("  Cleared the merge-conflict marker.");
+        println!("  Cleared the partial-reason marker.");
     }
     if let Some(wt) = &outcome.removed_worktree {
         println!("  Removed the merged worktree at {}.", wt.display());

--- a/src/run.rs
+++ b/src/run.rs
@@ -3498,10 +3498,15 @@ pub fn run_auto<F: FnMut(&str)>(
         // A merge-conflict Partial needs a human; a self-reported Partial is
         // auto-continued from its checkpoint (retry path below, attempts-capped).
         if let Some(t) = queue.tasks.iter().find(|t| t.state == TaskState::Partial) {
-            if partial_is_conflict(ws, &t.id) {
+            if let Some(reason) = latest_partial_reason(ws, &t.id) {
                 emit(i18n::run_progress(
                     event_lang,
-                    i18n::RunProgress::MergeConflict(&t.id),
+                    i18n::RunProgress::PartialNeedsYou {
+                        id: &t.id,
+                        kind: reason.kind,
+                        marker: &reason.marker,
+                        detail: reason.detail.as_deref(),
+                    },
                 ));
                 break;
             }
@@ -7043,9 +7048,26 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                         m.wt_path.display()
                     ));
                 }
+                // An integration ERROR is not a conflict: nothing is left
+                // half-merged for a human to resolve, and telling them to
+                // resolve one sends them looking for markers that do not exist
+                // (issue #69). Record the error itself so the handoff can say
+                // what actually failed.
                 Err(e) => {
                     next_state = TaskState::Partial;
-                    let _ = state::write_str(&run_dir.join("partial-reason"), "merge_conflict");
+                    let _ = state::write_str(&run_dir.join("partial-reason"), "integration_error");
+                    let note = format!(
+                        "\n## Integration error\n\nYardlet could not integrate `{}`: {}\n\
+                         This is not a merge conflict: there is nothing to resolve by hand. \
+                         The worktree is kept at `{}`.\n",
+                        m.branch,
+                        e.to_string().trim(),
+                        m.wt_path.display()
+                    );
+                    let hp = run_dir.join("handoff.md");
+                    let mut existing = std::fs::read_to_string(&hp).unwrap_or_default();
+                    existing.push_str(&note);
+                    let _ = state::write_str(&hp, &existing);
                     lines.push(format!("{}: integration error: {e}", task.id));
                 }
             }
@@ -7774,12 +7796,80 @@ pub(crate) fn continuation_context(ws: &Workspace, task_id: &str) -> Option<Stri
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
-/// Did this task's latest run go Partial because of a merge conflict (needs a
-/// human) rather than a worker self-report (safe to auto-continue)?
-pub(crate) fn partial_is_conflict(ws: &Workspace, task_id: &str) -> bool {
-    latest_run_for(ws, task_id)
-        .map(|(_, dir)| dir.join("partial-reason").exists())
-        .unwrap_or(false)
+/// Why a run left its task Partial, as recorded in the run's `partial-reason`
+/// marker. The marker's presence means a human is needed before the drain can
+/// continue; its CONTENT says what they actually have to do, and those
+/// remediations differ (issue #40). Unrecognized markers keep their raw text
+/// rather than being folded into a familiar-looking cause.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PartialReason {
+    pub kind: PartialReasonKind,
+    /// Raw marker text, for causes with no dedicated wording.
+    pub marker: String,
+    /// Cause-specific evidence, e.g. the pre-push checks that failed.
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PartialReasonKind {
+    /// The merge itself conflicted; the worktree is kept for manual integration.
+    MergeConflict,
+    /// Integration failed for some other reason. Distinct from a conflict:
+    /// there is nothing to resolve by hand (issue #69).
+    IntegrationError,
+    /// The work merged cleanly; only delivery is unverified.
+    GitFinishUnverified,
+    WorktreeCleanupChanged,
+    AutoCommitDisabled,
+    Other,
+}
+
+impl PartialReason {
+    fn from_marker(marker: &str, run_dir: &std::path::Path) -> Self {
+        let marker = marker.trim().to_string();
+        let kind = match marker.as_str() {
+            "merge_conflict" => PartialReasonKind::MergeConflict,
+            "integration_error" => PartialReasonKind::IntegrationError,
+            "git_finish_unverified" => PartialReasonKind::GitFinishUnverified,
+            "worktree_cleanup_changed" => PartialReasonKind::WorktreeCleanupChanged,
+            "auto_commit_disabled" => PartialReasonKind::AutoCommitDisabled,
+            _ => PartialReasonKind::Other,
+        };
+        let detail = (kind == PartialReasonKind::GitFinishUnverified)
+            .then(|| git_finish_block_detail(run_dir))
+            .flatten();
+        Self {
+            kind,
+            marker,
+            detail,
+        }
+    }
+}
+
+/// Name the failing pre-push checks behind a `git_finish_unverified` Partial so
+/// the operator is not told to go hunting for the cause.
+fn git_finish_block_detail(run_dir: &std::path::Path) -> Option<String> {
+    let record: crate::git_finish::GitFinishRecord =
+        serde_json::from_str(&std::fs::read_to_string(run_dir.join("git-finish.json")).ok()?)
+            .ok()?;
+    let failed: Vec<&str> = record
+        .checks
+        .iter()
+        .filter(|check| !check.passed)
+        .map(|check| check.name.as_str())
+        .collect();
+    if !failed.is_empty() {
+        return Some(failed.join(", "));
+    }
+    Some(record.status.as_str().to_string())
+}
+
+/// The typed reason this task's latest run left it Partial, if it recorded one.
+/// A Partial with no marker is a worker self-report and is safe to auto-retry.
+pub(crate) fn latest_partial_reason(ws: &Workspace, task_id: &str) -> Option<PartialReason> {
+    let (_, dir) = latest_run_for(ws, task_id)?;
+    let marker = std::fs::read_to_string(dir.join("partial-reason")).ok()?;
+    Some(PartialReason::from_marker(&marker, &dir))
 }
 
 /// The intent a run belonged to, read from its `run.yaml` (empty if unknown).
@@ -7933,6 +8023,74 @@ mod tests {
             payload: serde_json::Value::Null,
             raw_ref: None,
         }
+    }
+
+    /// Issue #40: the marker's CONTENT decides the remediation. Reading only
+    /// its existence reported every blocked Partial as a merge conflict.
+    #[test]
+    fn partial_reason_is_typed_from_the_marker_content() {
+        let dir = std::env::temp_dir().join(format!("yard-partial-reason-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        for (marker, expected) in [
+            ("merge_conflict", PartialReasonKind::MergeConflict),
+            ("integration_error", PartialReasonKind::IntegrationError),
+            (
+                "git_finish_unverified",
+                PartialReasonKind::GitFinishUnverified,
+            ),
+            (
+                "worktree_cleanup_changed",
+                PartialReasonKind::WorktreeCleanupChanged,
+            ),
+            (
+                "auto_commit_disabled",
+                PartialReasonKind::AutoCommitDisabled,
+            ),
+            ("something_new", PartialReasonKind::Other),
+        ] {
+            // Trailing newline: writers use both forms.
+            let reason = PartialReason::from_marker(&format!("{marker}\n"), &dir);
+            assert_eq!(reason.kind, expected, "{marker}");
+            assert_eq!(reason.marker, marker);
+        }
+
+        // git_finish_unverified names the failing pre-push checks when the
+        // run recorded them.
+        std::fs::write(
+            dir.join("git-finish.json"),
+            serde_json::json!({
+                "schema_version": 1,
+                "run_id": "run-test",
+                "task_id": "YARD-001",
+                "attempted_at": "",
+                "status": "check_blocked",
+                "policy": {
+                    "auto_push": false,
+                    "remote": "origin",
+                    "target_ref": "refs/heads/main",
+                    "pre_push_checks": ["cargo fmt", "cargo clippy"]
+                },
+                "checks": [
+                    {"name": "cargo fmt", "passed": true},
+                    {"name": "cargo clippy", "passed": false}
+                ],
+                "push_invoked": false,
+                "push_succeeded": false,
+                "reason": "pre_push_check_failed"
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let reason = PartialReason::from_marker("git_finish_unverified", &dir);
+        assert_eq!(reason.detail.as_deref(), Some("cargo clippy"));
+
+        // A conflict marker never picks up Git finish detail.
+        let reason = PartialReason::from_marker("merge_conflict", &dir);
+        assert_eq!(reason.detail, None);
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 
     fn eval_with_failed_checks(names: &[&str]) -> evaluator::Evaluation {

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -93,11 +93,21 @@ pub fn runnable_class_label(l: &L, class: RunnableClass) -> &'static str {
 /// Typed progress emitted by the run engine. Identifiers and diagnostic
 /// details are interpolated verbatim; only Yardlet-authored chrome changes.
 pub enum RunProgress<'a> {
-    Ambiguity { turn: u32, cap: u32 },
+    Ambiguity {
+        turn: u32,
+        cap: u32,
+    },
     Paused,
     WaitingForWorker(&'a str),
     WorkerLongRunning(&'a str),
-    MergeConflict(&'a str),
+    /// A Partial the drain cannot continue past. The remediation differs by
+    /// cause, so the cause is carried through rather than assumed (issue #40).
+    PartialNeedsYou {
+        id: &'a str,
+        kind: crate::run::PartialReasonKind,
+        marker: &'a str,
+        detail: Option<&'a str>,
+    },
     ParallelOff(&'a str),
     ParallelSequential(&'a str),
     NeedsUserMany(&'a str),
@@ -111,6 +121,58 @@ pub enum RunProgress<'a> {
     NeedsUser(&'a str),
     PartialContinue(&'a str),
     FailedRetry(&'a str),
+}
+
+/// Per-cause stop wording. Only a genuine merge conflict asks for conflict
+/// resolution; the others name what actually has to be fixed.
+fn partial_needs_you(
+    lang: Lang,
+    id: &str,
+    kind: crate::run::PartialReasonKind,
+    marker: &str,
+    detail: Option<&str>,
+) -> String {
+    use crate::run::PartialReasonKind as K;
+    let detail_en = detail.map(|d| format!(" ({d})")).unwrap_or_default();
+    let detail_ko = detail.map(|d| format!(" ({d})")).unwrap_or_default();
+    match (lang, kind) {
+        (Lang::En, K::MergeConflict) => format!(
+            "stopped: {id} has a merge conflict; resolve it (see handoff), then run auto again"
+        ),
+        (Lang::Ko, K::MergeConflict) => format!(
+            "정지: {id}에 병합 충돌이 있음; 핸드오프를 보고 해결한 뒤 자동 실행을 다시 시작하세요"
+        ),
+        (Lang::En, K::IntegrationError) => format!(
+            "stopped: {id} could not be integrated; there is no conflict to resolve. See the run's handoff for the error, then run auto again"
+        ),
+        (Lang::Ko, K::IntegrationError) => format!(
+            "정지: {id} 통합이 실패함; 해결할 충돌은 없습니다. run 핸드오프에서 오류를 확인한 뒤 자동 실행을 다시 시작하세요"
+        ),
+        (Lang::En, K::GitFinishUnverified) => format!(
+            "stopped: {id} merged cleanly but its Git finish is unverified{detail_en}; fix that, then run auto again"
+        ),
+        (Lang::Ko, K::GitFinishUnverified) => format!(
+            "정지: {id}는 병합은 깨끗했지만 Git finish가 검증되지 않음{detail_ko}; 해결한 뒤 자동 실행을 다시 시작하세요"
+        ),
+        (Lang::En, K::WorktreeCleanupChanged) => format!(
+            "stopped: {id} merged, but its worktree changed during cleanup and was kept; inspect it, then run auto again"
+        ),
+        (Lang::Ko, K::WorktreeCleanupChanged) => format!(
+            "정지: {id}는 병합됐지만 정리 중 worktree가 변경되어 보존됨; 확인한 뒤 자동 실행을 다시 시작하세요"
+        ),
+        (Lang::En, K::AutoCommitDisabled) => format!(
+            "stopped: {id} left uncommitted work and auto-commit is off; commit it, then run auto again"
+        ),
+        (Lang::Ko, K::AutoCommitDisabled) => format!(
+            "정지: {id}가 커밋되지 않은 작업을 남겼고 자동 커밋이 꺼져 있음; 커밋한 뒤 자동 실행을 다시 시작하세요"
+        ),
+        (Lang::En, K::Other) => {
+            format!("stopped: {id} is partial ({marker}); resolve it, then run auto again")
+        }
+        (Lang::Ko, K::Other) => {
+            format!("정지: {id}가 부분 완료 상태({marker}); 해결한 뒤 자동 실행을 다시 시작하세요")
+        }
+    }
 }
 
 pub fn run_progress(lang: Lang, event: RunProgress<'_>) -> String {
@@ -139,12 +201,15 @@ pub fn run_progress(lang: Lang, event: RunProgress<'_>) -> String {
         (Lang::Ko, RunProgress::WorkerLongRunning(id)) => format!(
             "정지: {id}가 30분 넘게 실행 중; 워커를 정지하거나 계속 기다린 뒤 자동 실행을 다시 시작하세요"
         ),
-        (Lang::En, RunProgress::MergeConflict(id)) => format!(
-            "stopped: {id} has a merge conflict; resolve it (see handoff), then run auto again"
-        ),
-        (Lang::Ko, RunProgress::MergeConflict(id)) => format!(
-            "정지: {id}에 병합 충돌이 있음; 핸드오프를 보고 해결한 뒤 자동 실행을 다시 시작하세요"
-        ),
+        (
+            lang,
+            RunProgress::PartialNeedsYou {
+                id,
+                kind,
+                marker,
+                detail,
+            },
+        ) => partial_needs_you(lang, id, kind, marker, detail),
         (Lang::En, RunProgress::ParallelOff(reason)) => {
             format!("parallel off ({reason}); running sequentially")
         }
@@ -892,6 +957,60 @@ pub const KO: L = L {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Issue #40: every Partial with a marker used to stop the drain with the
+    /// merge-conflict message, sending the operator after a conflict that does
+    /// not exist. Only a real conflict may ask for conflict resolution.
+    #[test]
+    fn partial_stop_message_names_the_actual_cause() {
+        use crate::run::PartialReasonKind as K;
+        let render = |lang, kind, marker, detail| {
+            run_progress(
+                lang,
+                RunProgress::PartialNeedsYou {
+                    id: "YARD-001",
+                    kind,
+                    marker,
+                    detail,
+                },
+            )
+        };
+
+        for lang in [Lang::En, Lang::Ko] {
+            let conflict = render(lang, K::MergeConflict, "merge_conflict", None);
+            assert!(
+                conflict.contains("conflict") || conflict.contains("충돌"),
+                "{conflict}"
+            );
+
+            for (kind, marker) in [
+                (K::IntegrationError, "integration_error"),
+                (K::GitFinishUnverified, "git_finish_unverified"),
+                (K::WorktreeCleanupChanged, "worktree_cleanup_changed"),
+                (K::AutoCommitDisabled, "auto_commit_disabled"),
+            ] {
+                let rendered = render(lang, kind, marker, None);
+                assert!(rendered.contains("YARD-001"), "{rendered}");
+                assert!(
+                    !rendered.contains("merge conflict") && !rendered.contains("병합 충돌"),
+                    "{marker} must not be reported as a merge conflict: {rendered}"
+                );
+            }
+        }
+
+        // An unknown marker is surfaced verbatim rather than guessed at.
+        let other = render(Lang::En, K::Other, "some_new_reason", None);
+        assert!(other.contains("some_new_reason"), "{other}");
+
+        // A blocked Git finish names the checks that failed.
+        let blocked = render(
+            Lang::En,
+            K::GitFinishUnverified,
+            "git_finish_unverified",
+            Some("cargo clippy"),
+        );
+        assert!(blocked.contains("cargo clippy"), "{blocked}");
+    }
 
     #[test]
     fn explicit_config_wins() {


### PR DESCRIPTION
Closes #40. Fixes the second defect in #69 (the first, cross-process finalize serialization, is a separate change).

**Stacked on #74** so the diff shows only this commit. Retarget to `main` once #74 merges.

## The wrong record, on both sides

**Reader.** The drain asked one question:

```rust
pub(crate) fn partial_is_conflict(ws: &Workspace, task_id: &str) -> bool {
    latest_run_for(ws, task_id)
        .map(|(_, dir)| dir.join("partial-reason").exists())   // content never read
        .unwrap_or(false)
}
```

Any marker at all meant "merge conflict". The runs cited in #40 were marked `git_finish_unverified`: the merge was clean and only the push was blocked, by a failing pre-push check or a stale `target_ref`. The operator was told to resolve a conflict that did not exist, for work that had already merged.

**Writer.** The `Err(e)` arm of integration wrote `merge_conflict`, the same marker as a real `Integration::Conflict`. So an arbitrary integration failure became a conflict-to-resolve, which is how #70's `git rev-parse failed: fatal: Needed a single rev` surfaced as a merge conflict on a task that was already Done and correctly merged.

## What changed

`PartialReason` parses the marker into a typed kind: `merge_conflict`, `integration_error`, `git_finish_unverified`, `worktree_cleanup_changed`, `auto_commit_disabled`, or an unrecognized marker kept verbatim.

The drain's stop message is now per cause:

- merge conflict: unchanged, still asks for resolution
- integration error: states there is nothing to resolve by hand
- Git finish unverified: says the work merged cleanly and **names the pre-push checks that failed**, read from `git-finish.json`
- worktree cleanup changed / auto-commit disabled: their own remediations
- unknown marker: surfaced verbatim rather than guessed at

Both languages. The integration `Err` arm records `integration_error` and appends the actual error to the handoff. `yardlet resolve` loses its merge-conflict-only wording, since it finalizes any hand-integrated Partial.

## Behavior deliberately unchanged

Every marker still halts the drain for a human, exactly as before. This changes what the human is told, not when they are asked. Widening or narrowing which Partials can auto-continue is a separate question and is not decided here.

## Verification

- `cargo test`: 768 passed, 0 failed, 20 targets, exit 0
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`: clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets -- -D warnings`: clean

New tests: marker-to-kind typing for all six kinds including trailing-newline tolerance, failing-check extraction from `git-finish.json`, no detail leaking onto a conflict marker, and a message test asserting no non-conflict cause is ever reported as a merge conflict in either language.