### PR TITLE
fix(runtime): show workers the delivery gate, and say when a learned skill is not durable

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2481,6 +2481,7 @@ fn cmd_packet(cwd: &std::path::Path, args: PacketArgs) -> Result<()> {
         role_notes: &role_notes,
         harness: &harness,
         approved,
+        pre_push_checks: &config.git_finish.pre_push_checks,
     });
     if args.dry_run {
         eprintln!("(dry-run: packet not persisted)\n");

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -9,8 +9,8 @@ use serde::Deserialize;
 
 use crate::inspect::RepoSummary;
 use crate::schemas::{
-    ConversationTurn, IntentContract, ResearchPolicy, ResearchSource, ScoutDisposition,
-    ScoutResult, Task, TurnRole,
+    ConversationTurn, GitFinishCheck, IntentContract, ResearchPolicy, ResearchSource,
+    ScoutDisposition, ScoutResult, Task, TurnRole,
 };
 
 pub struct ScoutPacketInputs<'a> {
@@ -194,6 +194,11 @@ pub struct PacketInputs<'a> {
     /// tells the worker to proceed and finish without re-gating or re-asking,
     /// so a single human decision carries the task to completion.
     pub approved: bool,
+    /// The workspace's configured pre-push checks, in execution order. The run
+    /// is judged by these AFTER the worker is done, so a worker that never
+    /// sees them can pass its own validation and still land Partial on a
+    /// one-line lint (issue #44).
+    pub pre_push_checks: &'a [GitFinishCheck],
 }
 
 /// Find existing local image files referenced in `text` (e.g. a path dragged
@@ -975,6 +980,26 @@ pub fn compile(inputs: &PacketInputs) -> String {
         ));
     }
     p.push('\n');
+
+    // The delivery gate the run will be judged by. Without this the worker
+    // validates with whatever it picked, passes, merges, and only then fails a
+    // configured style check it never ran (issue #44).
+    if !inputs.pre_push_checks.is_empty() {
+        p.push_str("## Delivery gate (these run after you finish)\n\n");
+        p.push_str(
+            "This workspace runs the following checks before delivering your work, in this \
+             order. They are part of what \"done\" means here: if one fails, the task lands \
+             Partial even when your own validation passed. Run them yourself and fix what they \
+             report BEFORE you write your result files.\n\n",
+        );
+        for check in inputs.pre_push_checks {
+            p.push_str(&format!("- {}: `{}`\n", check.name, check.command));
+        }
+        p.push_str(
+            "\nIf one of these cannot run in your environment, say so in \
+             `validation.failures` instead of skipping it silently.\n\n",
+        );
+    }
 
     // Role guidance: how this kind of task is worked, regardless of worker.
     p.push_str(&format!("## How to work \u{2014} role: {role}\n\n"));
@@ -1974,6 +1999,7 @@ mod tests {
             role_notes: "",
             harness: &harness,
             approved: false,
+            pre_push_checks: &[],
         });
         assert!(p.contains("## Workspace rules (always apply)"));
         assert!(p.contains("Never push without review."));
@@ -2148,6 +2174,7 @@ mod tests {
             role_notes,
             harness: &Harness::default(),
             approved: false,
+            pre_push_checks: &[],
         })
     }
 
@@ -2192,7 +2219,62 @@ mod tests {
             role_notes: "",
             harness: &Harness::default(),
             approved,
+            pre_push_checks: &[],
         })
+    }
+
+    /// Issue #44: the run is judged by the workspace's pre-push checks after
+    /// the worker finishes. A worker that never sees them passes its own
+    /// validation and still lands Partial on a one-line lint.
+    #[test]
+    fn packet_states_the_delivery_gate_commands() {
+        let task: crate::schemas::Task =
+            crate::yaml::from_str("id: YARD-001\ntitle: add a test\nkind: implementation\n")
+                .unwrap();
+        let repo = crate::inspect::RepoSummary::default();
+        let checks = vec![
+            GitFinishCheck {
+                name: "format".into(),
+                command: "cargo fmt --all -- --check".into(),
+            },
+            GitFinishCheck {
+                name: "clippy".into(),
+                command: "cargo clippy --all-targets -- -D warnings".into(),
+            },
+        ];
+        let inputs = |checks: &[GitFinishCheck]| {
+            compile(&PacketInputs {
+                worker_id: "codex",
+                task: &task,
+                intent: None,
+                repo: &repo,
+                run_dir_rel: ".agents/runs/run-x",
+                conversation: &[],
+                continuation: None,
+                chained_from: None,
+                language: "en",
+                images: &[],
+                role_notes: "",
+                harness: &Harness::default(),
+                approved: false,
+                pre_push_checks: checks,
+            })
+        };
+
+        let gated = inputs(&checks);
+        assert!(gated.contains("## Delivery gate"), "{gated}");
+        assert!(gated.contains("cargo fmt --all -- --check"), "{gated}");
+        assert!(
+            gated.contains("cargo clippy --all-targets -- -D warnings"),
+            "{gated}"
+        );
+        // The worker must know these decide the task's outcome, not just that
+        // they exist.
+        assert!(gated.contains("Partial"), "{gated}");
+
+        // A workspace with no configured gate gets no section at all.
+        let ungated = inputs(&[]);
+        assert!(!ungated.contains("## Delivery gate"), "{ungated}");
     }
 
     #[test]
@@ -2250,6 +2332,7 @@ mod tests {
             role_notes: "",
             harness: &Harness::default(),
             approved: false,
+            pre_push_checks: &[],
         });
         assert!(p.contains("## Same session, next task"));
         assert!(p.contains("completed task YARD-1 in this session"));
@@ -2301,6 +2384,7 @@ mod tests {
             role_notes: "",
             harness: &Harness::default(),
             approved: false,
+            pre_push_checks: &[],
         });
         assert!(p.contains("## Continuing a partial run"));
         assert!(p.contains("do not redo finished work"));
@@ -2365,6 +2449,7 @@ mod tests {
             role_notes: "",
             harness: &Harness::default(),
             approved: false,
+            pre_push_checks: &[],
         });
         assert!(p.contains("## Conversation with the user"));
         assert!(p.contains("[you] Forward+ or GL Compatibility?"));

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -496,6 +496,7 @@ pub fn run_batch<F: FnMut(&str)>(
             // The parallel path never carries approval-gated tasks (they are held
             // for the serial path), so no approval directive applies here.
             approved: false,
+            pre_push_checks: &config.git_finish.pre_push_checks,
         });
         write_str(&workers::packet_path(&p.run_dir), &p.packet_text)?;
         state::save_yaml_atomic(
@@ -724,6 +725,7 @@ pub fn run_batch<F: FnMut(&str)>(
                             role_notes: &role_notes,
                             harness: &harness,
                             approved: false,
+                            pre_push_checks: &config.git_finish.pre_push_checks,
                         });
                         write_str(&workers::packet_path(&p.run_dir), &failover_packet)?;
                         // The first worker ran with full access to this run

--- a/src/run.rs
+++ b/src/run.rs
@@ -2507,6 +2507,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         role_notes: &role_notes,
         harness: &harness,
         approved,
+        pre_push_checks: &config.git_finish.pre_push_checks,
     });
     write_str(&workers::packet_path(&run_dir), &packet_text)?;
 
@@ -2983,6 +2984,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             role_notes: &role_notes,
             harness: &harness,
             approved,
+            pre_push_checks: &config.git_finish.pre_push_checks,
         });
         write_str(&workers::packet_path(&run_dir), &recovery_packet)?;
         if worker_run_dir != run_dir.as_path() {
@@ -3116,6 +3118,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                     role_notes: &role_notes,
                     harness: &harness,
                     approved,
+                    pre_push_checks: &config.git_finish.pre_push_checks,
                 });
                 write_str(&workers::packet_path(&run_dir), &failover_packet)?;
                 if serial_worktree.is_some() {
@@ -6772,6 +6775,33 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             if !rules.is_empty() {
                 lines.push(format!("learned rule(s): {}", rules.join(", ")));
             }
+            // These land in the owning root outside the run's integration
+            // commit, so "learned" does not yet mean "durable". Say so, with
+            // the exact command, instead of leaving the operator to notice an
+            // untracked path (issue #45).
+            let untracked = untracked_harness_assets(ws, &learned, &rules);
+            if !untracked.is_empty() {
+                lines.push(format!(
+                    "learned harness assets are NOT in git yet: {}. Track them with `git add {}`",
+                    untracked.join(", "),
+                    untracked.join(" ")
+                ));
+                let note = format!(
+                    "\n## Untracked harness assets\n\nThis run learned harness assets that are \
+                     on disk but not in git:\n\n{}\n\nThey are not durable until committed:\n\n\
+                     ```\ngit add {}\n```\n",
+                    untracked
+                        .iter()
+                        .map(|path| format!("- `{path}`"))
+                        .collect::<Vec<_>>()
+                        .join("\n"),
+                    untracked.join(" ")
+                );
+                let handoff = run_dir.join("handoff.md");
+                let mut existing = std::fs::read_to_string(&handoff).unwrap_or_default();
+                existing.push_str(&note);
+                let _ = state::write_str(&handoff, &existing);
+            }
         }
     }
 
@@ -7796,6 +7826,44 @@ pub(crate) fn continuation_context(ws: &Workspace, task_id: &str) -> Option<Stri
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
+/// Repo-relative paths of just-learned harness assets that git does not track
+/// yet. Only files git reports as untracked are listed: an asset that updated
+/// an already-tracked skill shows up as a modification, which the normal
+/// workspace diff already surfaces.
+fn untracked_harness_assets(ws: &Workspace, skills: &[String], rules: &[String]) -> Vec<String> {
+    // `record_run_rules` returns bare names; the files it writes carry the
+    // `learned-` prefix.
+    let candidates: Vec<String> = skills
+        .iter()
+        .map(|name| format!(".agents/skills/{name}/SKILL.md"))
+        .chain(
+            rules
+                .iter()
+                .map(|name| format!(".agents/rules/learned-{name}.md")),
+        )
+        .collect();
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+    candidates
+        .into_iter()
+        .filter(|path| ws.root.join(path).exists())
+        .filter(|path| {
+            // `ls-files --error-unmatch` exits non-zero for a path git does not
+            // track. Treat an unavailable git as "cannot prove it is tracked"
+            // and stay quiet rather than nagging with a wrong claim.
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(&ws.root)
+                .args(["ls-files", "--error-unmatch", "--"])
+                .arg(path)
+                .output()
+                .map(|out| !out.status.success())
+                .unwrap_or(false)
+        })
+        .collect()
+}
+
 /// Why a run left its task Partial, as recorded in the run's `partial-reason`
 /// marker. The marker's presence means a human is needed before the drain can
 /// continue; its CONTENT says what they actually have to do, and those
@@ -8023,6 +8091,63 @@ mod tests {
             payload: serde_json::Value::Null,
             raw_ref: None,
         }
+    }
+
+    /// Issue #45: a learned skill on disk but not in git is not durable. The
+    /// reminder must fire for exactly the untracked ones, and must use the
+    /// real on-disk paths (rules carry a `learned-` prefix).
+    #[test]
+    fn untracked_learned_harness_assets_are_listed_for_the_operator() {
+        let root =
+            std::env::temp_dir().join(format!("yard-untracked-harness-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let sh = |args: &[&str]| {
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .output()
+                .unwrap();
+        };
+        sh(&["init", "-q"]);
+        sh(&["config", "user.email", "t@example.com"]);
+        sh(&["config", "user.name", "t"]);
+
+        let ws = Workspace::at(&root);
+        let write = |rel: &str| {
+            let path = root.join(rel);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "body\n").unwrap();
+        };
+        write(".agents/skills/tracked-skill/SKILL.md");
+        write(".agents/rules/learned-tracked-rule.md");
+        sh(&["add", "-A"]);
+        sh(&["commit", "-qm", "seed"]);
+
+        write(".agents/skills/fresh-skill/SKILL.md");
+        write(".agents/rules/learned-fresh-rule.md");
+
+        let untracked = untracked_harness_assets(
+            &ws,
+            &["fresh-skill".to_string(), "tracked-skill".to_string()],
+            &["fresh-rule".to_string(), "tracked-rule".to_string()],
+        );
+        assert_eq!(
+            untracked,
+            vec![
+                ".agents/skills/fresh-skill/SKILL.md".to_string(),
+                ".agents/rules/learned-fresh-rule.md".to_string(),
+            ],
+            "only the assets git does not track yet"
+        );
+
+        // Nothing learned, nothing to say.
+        assert!(untracked_harness_assets(&ws, &[], &[]).is_empty());
+        // A name with no file on disk is never reported.
+        assert!(untracked_harness_assets(&ws, &["ghost".to_string()], &[]).is_empty());
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     /// Issue #40: the marker's CONTENT decides the remediation. Reading only

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1825,6 +1825,7 @@ mod tests {
             role_notes: "",
             harness: &harness,
             approved: false,
+            pre_push_checks: &[],
         });
         assert!(selected_packet.contains("frontend-design"));
         assert!(selected_packet.contains(".agents/skills/frontend-design/SKILL.md"));
@@ -1846,6 +1847,7 @@ mod tests {
             role_notes: "",
             harness: &harness,
             approved: false,
+            pre_push_checks: &[],
         });
         assert!(!unrelated_packet.contains("frontend-design"));
         assert!(unrelated_packet.contains("verification-before-completion"));


### PR DESCRIPTION
Closes #44. Partially addresses #45 (option b, not the preferred option a — see below).

**Stacked on #75** (which is stacked on #74) so the diff shows only this commit. Retarget as the stack merges.

## #44: the worker never saw the gate it is judged by

The workspace configures `pre_push_checks`. The run is judged by them after the worker finishes. The worker was never told they exist.

Three consecutive runs in the 2026-07-24 batch (YARD-003/005/009) passed worker validation, passed the evaluator, merged cleanly, and landed Partial solely on a configured style check against their own new test code: `cargo clippy -D warnings` twice, `cargo fmt --check` once. Each one cost a diagnose, fix a one-line lint, re-run the full gates, push, resolve round trip.

The packet now carries:

```
## Delivery gate (these run after you finish)

This workspace runs the following checks before delivering your work, in this
order. They are part of what "done" means here: if one fails, the task lands
Partial even when your own validation passed. ...

- format: `cargo fmt --all -- --check`
- clippy: `cargo clippy --all-targets -- -D warnings`
```

Wired through every packet path: serial run, parallel batch, output-contract recovery, failover, and `yardlet packet`. A workspace with no configured checks gets no section, so this adds nothing for workspaces that do not use the gate.

This is the packet half of the issue's "either / or". Running the checks as evaluator checks before integration is the other half and is not done here.

## #45: partial, and deliberately so

A learned skill or rule is written to the owning root, outside the run's integration commit. "Learned" did not mean "durable": the operator had to notice an untracked `.agents/skills/<name>/SKILL.md` and hand-write a `chore(harness): track learned skill ...` commit, or lose it. Nine such skills in one batch.

The run summary and handoff now list exactly the learned assets git does not track yet, with the command to track them. Assets that updated an already-tracked file are not listed (they show as ordinary modifications). If git is unavailable the reminder stays silent rather than making a claim it cannot support.

**This is option (b) from the issue, not option (a), which the issue prefers and I agree is better.** Option (a) means routing these through the run's own integration commit. `.agents/skills` is already on the integration allowlist, so the mechanism exists — but it requires writing the asset into the worktree, which puts a new file into the staged tree after evidence collection, interacting with the evidence and input-overlay parity protocol. That is the same delicate path as #69/#70 and should be done deliberately rather than slipped in alongside a packet change. **#45 stays open.**

## Verification

- `cargo test`: 770 passed, 0 failed, 20 targets, exit 0
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`: clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets -- -D warnings`: clean

New tests: the gate section carries both commands and the Partial consequence, an unconfigured workspace gets no section, and the untracked-asset reminder fires for exactly the untracked assets using their real on-disk paths (a real git repo fixture; rules carry a `learned-` prefix that the first draft got wrong).