### PR TITLE
fix(runtime): second finalize confirms an already-integrated run; prove prompt completion under backpressure

### DIFF
--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -889,6 +889,7 @@ fn record_failover(run_dir: &Path, from: &str, to: &str, reason: &str) {
     );
 }
 
+#[derive(Debug)]
 pub(crate) enum Integration {
     Merged {
         oid: String,
@@ -900,6 +901,15 @@ pub(crate) enum Integration {
         worker_oid: String,
     },
     Conflict(String),
+    /// The run-owned branch does not resolve, so there is nothing left to
+    /// integrate from it. The normal cause is that this run was ALREADY
+    /// integrated and its cleanup deleted the branch: a second finalize of the
+    /// same run must confirm that outcome, not re-integrate it (issues #69,
+    /// #70). Returned as a typed outcome rather than letting an unresolvable
+    /// revision reach git and surface as a raw error.
+    BranchMissing {
+        branch: String,
+    },
 }
 
 const GIT_INTEGRATION_RECORD: &str = "git-integration.json";
@@ -1435,12 +1445,15 @@ where
         None => {}
     }
     let branch_ref = format!("refs/heads/{branch}");
-    let observed_tip = git(
-        root,
-        &["rev-parse", "--verify", &format!("{branch_ref}^{{commit}}")],
-    )?
-    .trim()
-    .to_string();
+    // Checked lookup: a run whose branch was already integrated and cleaned up
+    // no longer has this ref. Letting that reach `rev-parse --verify` produces
+    // a raw "Needed a single revision" error that the caller cannot tell apart
+    // from a real merge failure (issues #69, #70).
+    let Some(observed_tip) = ref_tip(root, &branch_ref) else {
+        return Ok(Integration::BranchMissing {
+            branch: branch.to_string(),
+        });
+    };
     if let Some(expected_tip_oid) = expected_tip_oid.filter(|oid| !oid.is_empty()) {
         if observed_tip != expected_tip_oid {
             return Ok(Integration::Conflict(format!(
@@ -4755,6 +4768,68 @@ exit 0
             _ => panic!("expected no changes"),
         }
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Issues #69 and #70. A second finalize of a run that was ALREADY
+    /// integrated finds its branch deleted by the first pass's cleanup. That
+    /// used to reach `rev-parse --verify refs/heads/<gone>^{commit}` and come
+    /// back as a raw `fatal: Needed a single revision`, which the caller could
+    /// not tell apart from a merge failure: it recorded `merge_conflict` and
+    /// demoted a correct Done to Partial.
+    #[test]
+    fn integrating_an_already_cleaned_up_branch_is_typed_not_a_raw_git_error() {
+        let root = temp_repo("branch-missing-after-cleanup");
+        let wt = root.join(".agents/worktrees/run-branch-missing");
+        let branch = "yard/yard-gone/run-branch-missing";
+        let baseline = sh_git(&root, &["rev-parse", "HEAD"]).trim().to_string();
+        create_worktree(&root, &wt, branch).unwrap();
+        std::fs::write(wt.join("feature.txt"), "worker output\n").unwrap();
+
+        // First finalize: integrates and then cleans up, exactly as the real
+        // path does.
+        let (oid, worker_oid) = match integrate_parallel_worktree(
+            &root,
+            &wt,
+            branch,
+            "YARD-GONE",
+            &baseline,
+            None,
+            &[],
+        )
+        .unwrap()
+        {
+            Integration::Merged {
+                oid, worker_oid, ..
+            } => (oid, worker_oid),
+            other => panic!("expected a merge, got {other:?}"),
+        };
+        let cleanup = cleanup_integrated_worktree(
+            &root,
+            &wt,
+            branch,
+            &worker_oid,
+            run::IntegrationProvenance::ParallelWorkerDirect,
+        );
+        assert!(cleanup.complete, "{:?}", cleanup.warnings);
+        assert!(
+            ref_tip(&root, &format!("refs/heads/{branch}")).is_none(),
+            "cleanup must have removed the run-owned branch"
+        );
+        assert_eq!(sh_git(&root, &["rev-parse", "HEAD"]).trim(), oid);
+
+        // Second finalize of the same run: the branch is gone. This must be a
+        // typed outcome, never a raw git error and never a conflict.
+        let second =
+            integrate_parallel_worktree(&root, &wt, branch, "YARD-GONE", &baseline, None, &[]);
+        match second {
+            Ok(Integration::BranchMissing { branch: reported }) => {
+                assert_eq!(reported, branch);
+            }
+            Ok(other) => panic!("expected BranchMissing, got {other:?}"),
+            Err(error) => panic!("a missing branch must not surface as a raw error: {error:#}"),
+        }
+
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[test]

--- a/src/run.rs
+++ b/src/run.rs
@@ -7100,6 +7100,36 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     let _ = state::write_str(&hp, &existing);
                     lines.push(format!("{}: integration error: {e}", task.id));
                 }
+                // The run-owned branch is gone. If THIS run already recorded a
+                // published integration, a second finalize is re-running over
+                // work that is already in the target: confirm it instead of
+                // demoting a correct terminal state (issue #69). Ownership is
+                // reconstructed from the run's own durable receipt, so the
+                // confirmation cannot claim commits this run does not own.
+                Ok(crate::parallel::Integration::BranchMissing { branch }) => {
+                    match already_integrated_ownership(ws, run_dir, run_id, &task.id) {
+                        Some(owned) => {
+                            ownership = Some(owned);
+                            lines.push(format!(
+                                "{}: {branch} was already integrated and cleaned up; \
+                                 confirming the recorded outcome",
+                                task.id
+                            ));
+                        }
+                        None => {
+                            next_state = TaskState::Partial;
+                            let _ = state::write_str(
+                                &run_dir.join("partial-reason"),
+                                "integration_branch_missing",
+                            );
+                            lines.push(format!(
+                                "{}: run-owned branch {branch} does not exist and this run \
+                                 recorded no integration; nothing to merge",
+                                task.id
+                            ));
+                        }
+                    }
+                }
             }
         } else {
             lines.push(format!(
@@ -7824,6 +7854,36 @@ pub(crate) fn continuation_context(ws: &Workspace, task_id: &str) -> Option<Stri
     }
     let trimmed = s.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Ownership for a run whose branch is gone because it was ALREADY integrated.
+/// Read only from this run's own durable receipt, and only when that receipt
+/// names this run and task and its integration commit is still reachable from
+/// the workspace head. Anything else returns None so a missing branch can never
+/// be mistaken for a completed integration.
+fn already_integrated_ownership(
+    ws: &Workspace,
+    run_dir: &std::path::Path,
+    run_id: &str,
+    task_id: &str,
+) -> Option<crate::git_finish::GitFinishOwnership> {
+    let record: RunRecord = state::load_yaml(&run_dir.join("run.yaml")).ok()?;
+    if record.run_id != run_id || record.task_id != task_id {
+        return None;
+    }
+    let integration_oid = (!record.integration_oid.is_empty()).then_some(record.integration_oid)?;
+    // The recorded merge must actually be in this workspace's history; a
+    // receipt alone is not proof the work is present.
+    git_stdout(
+        &ws.root,
+        &["merge-base", "--is-ancestor", &integration_oid, "HEAD"],
+    )
+    .ok()?;
+    Some(crate::git_finish::GitFinishOwnership {
+        baseline_oid: record.integration_base_oid,
+        expected_oid: integration_oid,
+        owned_oids: record.owned_oids,
+    })
 }
 
 /// Repo-relative paths of just-learned harness assets that git does not track

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -2289,6 +2289,109 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         let _ = std::fs::remove_dir_all(root);
     }
 
+    /// Issue #20: under sink backpressure the parent stayed busy long after the
+    /// worker had produced a successful result. The bounded queue must shed
+    /// rather than block, and completion must not wait for a slow sink to
+    /// consume the backlog.
+    #[cfg(unix)]
+    #[test]
+    fn codex_saturated_publisher_sheds_and_completes_without_draining_the_backlog() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        const EMITTED: usize = 400;
+        const SINK_DELAY: Duration = Duration::from_millis(25);
+
+        let root = std::env::temp_dir().join(format!(
+            "yard-codex-saturated-publisher-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let fake_codex = root.join("codex");
+        // Many small events, emitted as fast as the shell can write them, so the
+        // reader outruns the deliberately slow sink and fills the 64-slot queue.
+        std::fs::write(
+            &fake_codex,
+            format!(
+                "#!/bin/sh\ni=0\nwhile [ $i -lt {EMITTED} ]; do \
+                 printf '{{\"type\":\"item.completed\",\"item\":{{\"type\":\"agent_message\",\
+                 \"text\":\"e%s\"}}}}\\n' \"$i\"; i=$((i+1)); done\n"
+            ),
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&fake_codex).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions).unwrap();
+
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+        )
+        .unwrap();
+        let capture = AttemptCapture {
+            combined_log: root.join("worker-output.log"),
+            stdout_log: root.join("attempts/att_1/stdout.log"),
+            stderr_log: root.join("attempts/att_1/stderr.log"),
+        };
+        let delivered = Arc::new(AtomicUsize::new(0));
+        let sink_delivered = Arc::clone(&delivered);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink_seen = Arc::clone(&seen);
+        let sink: AttemptEventSink = Arc::new(move |event| {
+            std::thread::sleep(SINK_DELAY);
+            sink_delivered.fetch_add(1, Ordering::Relaxed);
+            sink_seen.lock().unwrap().push(event);
+            Ok(())
+        });
+
+        let started = std::time::Instant::now();
+        let outcome = spawn_attempt_with_sink(
+            &profile,
+            &fake_codex,
+            "packet",
+            &root,
+            &root,
+            &[],
+            &capture,
+            Some(sink),
+            LOAD_TOLERANT_WORKER_CEILING,
+            false,
+            &[],
+            None,
+            false,
+        )
+        .unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(outcome.exit_ok);
+        assert!(
+            outcome.public_events_dropped,
+            "a saturated publisher queue must report shed events"
+        );
+        // Delivering every event through this sink would take EMITTED *
+        // SINK_DELAY (10s here). Completion must not wait for that backlog.
+        let full_drain = SINK_DELAY * EMITTED as u32;
+        assert!(
+            elapsed < full_drain / 3,
+            "parent did not complete promptly under backpressure: {elapsed:?} \
+             (full drain would be {full_drain:?})"
+        );
+        assert!(
+            delivered.load(Ordering::Relaxed) < EMITTED,
+            "shedding must drop events rather than deliver all of them"
+        );
+        // The authoritative raw stream is never shed: every emitted event is on
+        // disk even though the live sink saw only some of them.
+        let raw = std::fs::read_to_string(&capture.stdout_log).unwrap();
+        assert_eq!(raw.lines().count(), EMITTED);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[cfg(unix)]
     #[test]
     fn codex_resume_cumulative_file_changes_keep_public_log_bounded_and_raw_refs_exact() {


### PR DESCRIPTION
Closes #70, closes #20. Fixes the demotion half of #69.

**Stacked on #76** (which is on #75, on #74).

> Note: this PR carries two independent commits. I intended them as separate PRs and pushed the second onto this branch by mistake; splitting them now would need a force push, which this project's rules require explicit approval for. Both are green and reviewable on their own, and the sections below are in commit order.

---

## Commit 1 — `test(runtime)`: prompt completion under backpressure (#20)

Test-only, no production change.

The issue (against 0.9.2) reported a resumed Codex run whose parent stayed CPU-busy draining output for 40+ minutes after the worker had produced a successful result, forcing Ctrl-C and a recovery that landed the good result as Partial.

Three of its four acceptance checks are already satisfied by code and tests written since then: cumulative `file_change` events are not re-logged in full, the public log grows with changed bytes rather than changed bytes times edit count, and a fixture covers resumed codex output with repeated `file_change` events (the accumulated diff grows 156 to 795 bytes across 10 events). The bounded 64-slot queue, its `try_send` shedding, and the stop-on-shed completion path are all present.

The remaining check, "parent exits promptly after worker completion under queue backpressure", had **no test**: the existing publisher test covers only the unsaturated queue. This adds the saturated case. A fake codex emits 400 events as fast as the shell can write them against a sink that takes 25ms each, filling the queue. It asserts shedding is reported, that completion takes under a third of the 10s a full drain would need (about 0.3s in practice), that not every event was delivered, and that all 400 lines survive in the authoritative raw stdout log. That last pairing matters: shedding is only acceptable because the raw stream is never shed.

## Commit 2 — `fix(runtime)`: a second finalize confirms, it does not demote (#70, half of #69)

**#69 and #70 are the same defect seen from two sides.**

The normal finalize path hardcodes `provenance: SerialCoreStaged` and, unlike the recovery path, has no registered-worktree gate. So when the same run is finalized twice, the second pass runs against a branch the first pass's cleanup already deleted:

```
rev-parse --verify refs/heads/<gone>^{commit}
  -> fatal: Needed a single revision
  -> Err -> partial-reason = merge_conflict -> Done demoted to Partial
```

That single failure produced both reports. #69 saw a Done task flipped to Partial and blamed on a merge conflict that never happened; #70 saw the raw git error halt a drain.

**Neither issue's stated cause holds up.** #70 attributes it to a worker tip resolving to an empty string; it is a branch ref that no longer exists. #69 describes two distinct defects; they share this one origin.

### The fix

`Integration::BranchMissing` makes the missing ref a typed outcome through a checked lookup, instead of letting an unresolvable revision reach git. Finalize then decides what it means:

- **This run's own receipt records an integration OID, and that commit is still reachable from the workspace head** → the work is already in the target. Confirm the recorded outcome, keep the evaluated state, reconstruct ownership from that receipt so a confirmation cannot claim commits the run does not own.
- **Otherwise** → Partial under `integration_branch_missing`, never `merge_conflict`.

Both proofs are required. A receipt alone is not evidence the work is present, so the ancestry check is not optional.

### Scope

This removes the *damage* a concurrent finalize causes. It does **not** serialize finalize across processes, which is the remaining half of #69. The regression test added here is the harness that work needs, so #69 stays open.

### RED verified

With the guard reverted, the new test fails with exactly the string from #70:

```
a missing branch must not surface as a raw error: git rev-parse failed: fatal: Needed a single revision
```

With the guard in place it passes.

## Verification

- `cargo test`: 772 passed, 0 failed, 20 targets, exit 0
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`: clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets -- -D warnings`: clean