### PR TITLE
perf(runtime): retire settled receipts so startup reconcile is O(pending)

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -5014,7 +5014,17 @@ fn reconcile_no_change_outcomes(ws: &Workspace, msgs: &mut Vec<String>) {
             &receipt.task_id,
             TaskState::Done,
         ) {
-            Ok(record) if record.status.verified_complete() => {}
+            // Cleanup is done and delivery reached a verified end state, so
+            // this receipt has no work left for any later startup to find
+            // (issue #43). An unverified finish stays in the pending set.
+            Ok(record) if record.status.verified_complete() => {
+                if let Err(error) = ws.archive_no_change_receipt(&receipt.run_id) {
+                    msgs.push(format!(
+                        "{}: could not archive a settled no-change receipt: {error}",
+                        receipt.task_id
+                    ));
+                }
+            }
             Ok(record) => msgs.push(format!(
                 "{}: no-change Git finish remains {}",
                 receipt.task_id,
@@ -5069,11 +5079,22 @@ fn reconcile_integrated_cleanups(ws: &Workspace, msgs: &mut Vec<String>) {
             msgs.push(format!("{}: {warning}", receipt.task_id));
         }
         let _ = persist_integrated_cleanup_projection(&run_dir, &receipt, cleanup.complete);
-        if cleanup.complete && !was_complete {
-            msgs.push(format!(
-                "{}: reconciled integrated worktree cleanup",
-                receipt.task_id
-            ));
+        if cleanup.complete {
+            if !was_complete {
+                msgs.push(format!(
+                    "{}: reconciled integrated worktree cleanup",
+                    receipt.task_id
+                ));
+            }
+            // Nothing about this receipt can change again, so retire it from
+            // the set every later startup replays (issue #43). Failing to
+            // archive only costs the old repeated work, so it is not fatal.
+            if let Err(error) = ws.archive_integrated_cleanup_receipt(&receipt.run_id) {
+                msgs.push(format!(
+                    "{}: could not archive a reconciled Git cleanup receipt: {error}",
+                    receipt.task_id
+                ));
+            }
         }
     }
 }
@@ -7147,6 +7168,9 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                         }
                         if cleanup.complete {
                             persist_integrated_cleanup_projection(run_dir, &cleanup_receipt, true)?;
+                            // Settled here means no later startup has to
+                            // rediscover that by replaying git (issue #43).
+                            let _ = ws.archive_integrated_cleanup_receipt(run_id);
                         }
                     }
                 }
@@ -7326,6 +7350,12 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         crate::git_finish::finish_owned_run(ws, run_dir, run_id, &task.id, next_state, ownership)?
     };
     lines.push(git_finish.user_line());
+    // A no-op whose cleanup and delivery both settled here leaves the pending
+    // reconcile set immediately, instead of being rediscovered and replayed by
+    // every later startup (issue #43).
+    if git_finish_not_needed && git_finish.status.verified_complete() {
+        let _ = ws.archive_no_change_receipt(run_id);
+    }
     let projected_state = state_after_git_finish(next_state, &git_finish);
     if projected_state != next_state {
         next_state = projected_state;
@@ -14275,6 +14305,184 @@ exit 1
 
             let _ = std::fs::remove_dir_all(ws.root);
         }
+    }
+
+    /// Startup reconcile cost must track OUTSTANDING work, not the number of
+    /// runs a workspace has ever completed. Every settled receipt left in the
+    /// scanned directory is several git subprocesses re-spent on every launch,
+    /// which is what made startup 11s on a workspace with a few hundred runs
+    /// (issue #43). Once a receipt is settled it leaves that directory, while
+    /// staying loadable by run id as ownership and overlay evidence.
+    #[test]
+    fn startup_reconcile_retires_settled_receipts_from_the_scanned_set() {
+        let ws = init_test_workspace(
+            "reconcile-hot-set",
+            "schema_version: 1\nrouting: {default_worker: builder}\nworkers: []\n",
+        );
+        let mut config = ws.load_config().unwrap();
+        config.git_finish.auto_push = true;
+        state::save_yaml(&ws.config_path(), &config).unwrap();
+
+        // A run whose integration merged and whose worktree and branch are
+        // already gone: cleanup has nothing left to do, forever.
+        let merged_run = "run-20990101-000001-merged";
+        let merged_task = "YARD-MERGED";
+        let baseline = git_stdout(&ws.root, &["rev-parse", "HEAD"])
+            .unwrap()
+            .trim()
+            .to_string();
+        write_str(&ws.root.join("merged.txt"), "merged\n").unwrap();
+        git_stdout(&ws.root, &["add", "merged.txt"]).unwrap();
+        let tree = git_stdout(&ws.root, &["write-tree"])
+            .unwrap()
+            .trim()
+            .to_string();
+        let worker_oid = git_stdout(
+            &ws.root,
+            &["commit-tree", &tree, "-p", &baseline, "-m", "worker"],
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        let integration_oid = git_stdout(
+            &ws.root,
+            &[
+                "commit-tree",
+                &tree,
+                "-p",
+                &baseline,
+                "-p",
+                &worker_oid,
+                "-m",
+                "integration",
+            ],
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        git_stdout(&ws.root, &["reset", "-q", "--hard", &integration_oid]).unwrap();
+        let merged_run_dir = ws.runs_dir().join(merged_run);
+        std::fs::create_dir_all(&merged_run_dir).unwrap();
+        ws.save_integrated_cleanup_receipt(&state::IntegratedCleanupReceipt {
+            schema_version: 1,
+            run_id: merged_run.into(),
+            task_id: merged_task.into(),
+            intent_id: "intent-test".into(),
+            worker: "codex".into(),
+            worktree: ws
+                .agents_dir()
+                .join("worktrees")
+                .join(merged_run)
+                .display()
+                .to_string(),
+            branch: format!("yard/{}/{merged_run}", merged_task.to_lowercase()),
+            baseline_oid: baseline.clone(),
+            integration_base_oid: baseline.clone(),
+            integration_worker_oid: worker_oid.clone(),
+            integration_oid: integration_oid.clone(),
+            provenance: IntegrationProvenance::ParallelWorkerDirect,
+            owned_oids: vec![worker_oid, integration_oid],
+            core_input_overlays: vec![],
+            dependency_input_overlays: vec![],
+        })
+        .unwrap();
+
+        // A no-op run whose cleanup and `not_needed` finish both settle during
+        // this very recovery pass.
+        let no_change_run = "run-20990101-000002-nochange";
+        let no_change_task = "YARD-NOCHANGE";
+        let branch = format!("yard/{}/{no_change_run}", no_change_task.to_lowercase());
+        let worktree = ws.agents_dir().join("worktrees").join(no_change_run);
+        crate::parallel::create_worktree(&ws.root, &worktree, &branch).unwrap();
+        let no_change_run_dir = ws.runs_dir().join(no_change_run);
+        std::fs::create_dir_all(&no_change_run_dir).unwrap();
+        write_str(
+            &no_change_run_dir.join("result.json"),
+            &serde_json::to_string(&RunResult {
+                schema_version: 1,
+                run_id: no_change_run.into(),
+                task_id: no_change_task.into(),
+                status: "done".into(),
+                intent_adherence: Default::default(),
+                changes: Default::default(),
+                validation: Default::default(),
+                question_for_user: None,
+                compact_summary: "no changes".into(),
+                verdict: vec![],
+                harness_suggestions: vec![],
+                follow_up_tasks: vec![],
+                artifacts: vec![],
+                resources: vec![],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+        write_str(&no_change_run_dir.join("handoff.md"), "# Handoff\n").unwrap();
+        let head = git_stdout(&ws.root, &["rev-parse", "HEAD"])
+            .unwrap()
+            .trim()
+            .to_string();
+        ws.save_no_change_receipt(&state::NoChangeReceipt {
+            schema_version: 1,
+            run_id: no_change_run.into(),
+            task_id: no_change_task.into(),
+            intent_id: "intent-test".into(),
+            worker: "codex".into(),
+            worktree: worktree.display().to_string(),
+            branch,
+            baseline_oid: head.clone(),
+            worker_oid: head,
+            provenance: IntegrationProvenance::ParallelWorkerDirect,
+            core_input_overlays: vec![],
+            dependency_input_overlays: vec![],
+        })
+        .unwrap();
+
+        let mut running = task(no_change_task, TaskState::Running, 10, false);
+        running.kind = "implementation".into();
+        let mut q = queue(vec![running]);
+        q.intent_id = "intent-test".into();
+        ws.save_queue(&q).unwrap();
+
+        assert_eq!(ws.load_integrated_cleanup_receipts().unwrap().len(), 1);
+        assert_eq!(ws.load_no_change_receipts().unwrap().len(), 1);
+
+        let first = recover_orphans(&ws);
+
+        assert!(
+            ws.load_integrated_cleanup_receipts().unwrap().is_empty(),
+            "a reconciled cleanup receipt must leave the scanned set: {first:?}"
+        );
+        assert!(
+            ws.load_no_change_receipts().unwrap().is_empty(),
+            "a settled no-change receipt must leave the scanned set: {first:?}"
+        );
+        // Retired, not discarded: both stay addressable as ownership evidence.
+        assert_eq!(
+            ws.load_integrated_cleanup_receipt(merged_run)
+                .unwrap()
+                .task_id,
+            merged_task
+        );
+        assert_eq!(
+            ws.load_no_change_receipt(no_change_run).unwrap().task_id,
+            no_change_task
+        );
+        assert_eq!(
+            ws.load_git_finish_record(&no_change_run_dir)
+                .unwrap()
+                .status,
+            crate::git_finish::GitFinishStatus::NotNeeded
+        );
+        assert_eq!(ws.load_queue().unwrap().tasks[0].state, TaskState::Done);
+
+        let second = recover_orphans(&ws);
+        assert!(
+            second.is_empty(),
+            "second recovery was not inert: {second:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(ws.root);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -2178,6 +2178,20 @@ impl Workspace {
     fn no_change_receipts_dir(&self) -> PathBuf {
         self.checkpoints_dir().join("no-change")
     }
+    /// Terminal receipts, moved out of the directory startup reconcile scans.
+    ///
+    /// A reconciled receipt is audit history, not pending work: replaying it
+    /// costs several git subprocesses and can never change anything. Startup
+    /// cost has to track outstanding work, not the number of runs a workspace
+    /// has ever completed (issue #43). They stay addressable by run id because
+    /// ownership reconstruction and overlay lookups still read them by name.
+    fn integrated_cleanup_reconciled_dir(&self) -> PathBuf {
+        self.integrated_cleanup_receipts_dir()
+            .join(RECONCILED_RECEIPTS_DIR)
+    }
+    fn no_change_reconciled_dir(&self) -> PathBuf {
+        self.no_change_receipts_dir().join(RECONCILED_RECEIPTS_DIR)
+    }
     fn resolved_dependency_outputs_dir(&self) -> PathBuf {
         self.checkpoints_dir().join("dependency-outputs")
     }
@@ -2287,7 +2301,22 @@ impl Workspace {
         &self,
         run_id: &str,
     ) -> Result<IntegratedCleanupReceipt> {
-        load_yaml(&self.integrated_cleanup_receipt_path(run_id)?)
+        let pending = self.integrated_cleanup_receipt_path(run_id)?;
+        if pending.is_file() {
+            return load_yaml(&pending);
+        }
+        load_yaml(
+            &self
+                .integrated_cleanup_reconciled_dir()
+                .join(format!("{run_id}.yaml")),
+        )
+    }
+    /// Retire a receipt whose cleanup is finished so later startups stop
+    /// replaying it. Nothing is deleted: the receipt keeps its exact bytes and
+    /// stays loadable by run id.
+    pub fn archive_integrated_cleanup_receipt(&self, run_id: &str) -> Result<()> {
+        let pending = self.integrated_cleanup_receipt_path(run_id)?;
+        archive_receipt(&pending, &self.integrated_cleanup_reconciled_dir())
     }
     pub fn load_integrated_cleanup_receipts(&self) -> Result<Vec<IntegratedCleanupReceipt>> {
         let directory = self.integrated_cleanup_receipts_dir();
@@ -2311,7 +2340,21 @@ impl Workspace {
         write_str_atomic(&path, &yaml::to_string(receipt)?)
     }
     pub fn load_no_change_receipt(&self, run_id: &str) -> Result<NoChangeReceipt> {
-        load_yaml(&self.no_change_receipt_path(run_id)?)
+        let pending = self.no_change_receipt_path(run_id)?;
+        if pending.is_file() {
+            return load_yaml(&pending);
+        }
+        load_yaml(
+            &self
+                .no_change_reconciled_dir()
+                .join(format!("{run_id}.yaml")),
+        )
+    }
+    /// Retire a settled no-change receipt. See
+    /// [`Workspace::archive_integrated_cleanup_receipt`].
+    pub fn archive_no_change_receipt(&self, run_id: &str) -> Result<()> {
+        let pending = self.no_change_receipt_path(run_id)?;
+        archive_receipt(&pending, &self.no_change_reconciled_dir())
     }
     pub fn load_no_change_receipts(&self) -> Result<Vec<NoChangeReceipt>> {
         let directory = self.no_change_receipts_dir();
@@ -6201,6 +6244,28 @@ pub(crate) fn append_private_file(path: &Path) -> Result<fs::File> {
 
 /// Write a durable state snapshot through a same-directory temporary file so a
 /// crash cannot leave readers with a truncated JSON/YAML record.
+/// Subdirectory holding receipts whose reconciliation is finished. It carries
+/// no `.yaml` extension, so the `*_receipts` sweeps skip it the same way they
+/// skip any other non-receipt entry.
+const RECONCILED_RECEIPTS_DIR: &str = "reconciled";
+
+/// Move a settled receipt into its archive directory, preserving its bytes and
+/// its `<run_id>.yaml` name. A receipt that is already archived (or was never
+/// written) is a no-op, so this is safe to call on every reconcile pass.
+fn archive_receipt(pending: &Path, archive_dir: &Path) -> Result<()> {
+    if !pending.is_file() {
+        return Ok(());
+    }
+    let file_name = pending
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("receipt path has no file name"))?;
+    fs::create_dir_all(archive_dir)
+        .with_context(|| format!("creating {}", archive_dir.display()))?;
+    let archived = archive_dir.join(file_name);
+    fs::rename(pending, &archived)
+        .with_context(|| format!("archiving {} to {}", pending.display(), archived.display()))
+}
+
 pub fn write_str_atomic(path: &Path, contents: &str) -> Result<()> {
     write_bytes_atomic(path, contents.as_bytes())
 }

--- a/tests/fixtures/git_finish_process_recovery/scripts/run.sh
+++ b/tests/fixtures/git_finish_process_recovery/scripts/run.sh
@@ -371,7 +371,9 @@ import sys
 
 directory = pathlib.Path(sys.argv[1])
 root = sys.argv[2]
-for path in directory.glob("*.yaml"):
+# Receipts whose cleanup already reconciled live in the `reconciled/`
+# archive, so a copied workspace has to rebind those too (issue #43).
+for path in directory.rglob("*.yaml"):
     run_id = path.stem
     lines = path.read_text(encoding="utf-8").splitlines()
     lines = [


### PR DESCRIPTION
Closes #43.

## What was slow

`recover_orphans` runs before the TUI can become interactive, and it re-processed the whole checkpoint history every launch:

- `reconcile_integrated_cleanups` loads **every** integrated-cleanup receipt the workspace has ever written and calls `cleanup_integrated_worktree` on each — check-ref-format, two `ref_tip` rev-parses, plus symbolic-ref / rev-parse / overlay digest reads when a worktree still exists.
- `reconcile_no_change_outcomes` does the same for no-change receipts.

Both re-confirm what an earlier startup already confirmed. This workspace holds 96 + 37 = 133 such receipts against 416 runs, which is the several-hundred-subprocess startup the issue measured at 11.1s wall / 4.2s sys.

`was_complete` existed but only picked the log message — the git work was paid regardless. The issue suggests skipping on it; that is a worker-writable projection in the run dir, so using it as the skip condition would let a run's own `run.yaml` decide whether core reconciliation runs. Archiving keys off the core-owned receipt instead.

## The change

A settled receipt moves to a `reconciled/` subdirectory next to the pending set:

- the sweeps that scan for pending work no longer see it (the subdirectory has no `.yaml` extension, so the existing filter skips it)
- `load_integrated_cleanup_receipt` / `load_no_change_receipt` fall back to the archive, so ownership reconstruction (`recovery_git_finish_ownership`, `already_integrated_ownership`) and `cleanup_input_overlays` still resolve by run id
- nothing is deleted; the receipt keeps its exact bytes as audit history

Settled means:

| receipt | condition |
|---|---|
| integrated cleanup | `cleanup_integrated_worktree` reported complete |
| no change | cleanup complete **and** Git finish reached a verified end state |

Fresh finalization archives on the same conditions, so a receipt normally never enters the pending set at all. An existing workspace pays the old cost one more time, then converges — no migration step.

## Measured

100 settled cleanup receipts, `recover_orphans` twice:

| | first pass | second pass |
|---|---|---|
| before | 7.89s | 7.75s |
| after | 7.55s | **48ms** |

The remaining first-pass cost is the real reconciliation, paid once.

## Tests

- `startup_reconcile_retires_settled_receipts_from_the_scanned_set` — a merged run with cleanup already done and a no-op run that settles during the pass; asserts both leave the scanned set, both stay loadable by run id, the `not_needed` finish and Done projection still land, and the second pass is inert. RED verified: without archiving, the receipt stays in the scanned set.
- `tests/fixtures/git_finish_process_recovery` — the fixture copies a workspace and rebinds receipt worktree paths; its glob now walks the archive too. This one caught the change honestly (the copied snapshot silently kept stale worktree paths and recovery went `safety_blocked`).

## Verification

- `cargo test` — 649 unit + all integration targets pass, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked`, `cargo +1.97.1 clippy --all-targets` clean

## Not in this change

The issue also lists the git-finish checkpoint scan (172 entries) and `import_completed_serial_staging`. Those are run.yaml parse sweeps with no per-entry git subprocess (`pending_git_finishes` spawns one `rev-list` total and skips other-intent runs early), and the issue itself measures a full run.yaml sweep at ~0.25s. They are not where the seconds are.