### PR TITLE
fix(tui): make an open planning session reachable after a restart

### DIFF
--- a/src/planning.rs
+++ b/src/planning.rs
@@ -2607,6 +2607,59 @@ pub fn active_is_confirmed_or_running(ws: &Workspace) -> Result<bool> {
     Ok(gate == ActivationGate::Confirmed)
 }
 
+/// What an OPEN planning session still needs from the operator.
+///
+/// The planning flow is only complete once a draft is confirmed into a queue.
+/// Between those points the work lives entirely in the session, so a surface
+/// that shows only the queue reads as "nothing here" while a whole plan is
+/// waiting (issue #65). This is the projection a read-only snapshot carries so
+/// re-entry after a restart is visible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanningReentry {
+    /// Worker proposal(s) waiting for accept/reject.
+    PendingProposal { count: usize },
+    /// A draft was accepted and is waiting for confirm to become the queue.
+    AcceptedDraft,
+}
+
+/// Read-only re-entry state of the latest planning session.
+///
+/// Deliberately lock-free and best-effort: it runs on every snapshot load, and
+/// an unreadable or half-written session is a reason to show nothing, never to
+/// fail the snapshot. Anything actionable is confirmed by the review screen
+/// itself, which takes the lock and validates properly.
+pub fn reentry(ws: &Workspace) -> Option<PlanningReentry> {
+    let session = ws.load_latest_planning_session().ok()??;
+    if session.lifecycle != PlanningLifecycle::Open {
+        return None;
+    }
+    let proposals = ws.load_planning_proposals(&session.session_id).ok()?;
+    let events = ws.load_planning_events(&session.session_id).ok()?;
+    let disposed = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event.event_type,
+                PlanningEventType::DraftAccepted
+                    | PlanningEventType::DraftRevised
+                    | PlanningEventType::DraftRejected
+            )
+        })
+        .map(|event| event.proposal_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let pending = proposals
+        .iter()
+        .filter(|proposal| !disposed.contains(proposal.proposal_id.as_str()))
+        .count();
+    if pending > 0 {
+        return Some(PlanningReentry::PendingProposal { count: pending });
+    }
+    if session.current_head.is_some() && session.confirmation_id.is_none() {
+        return Some(PlanningReentry::AcceptedDraft);
+    }
+    None
+}
+
 pub fn projection(ws: &Workspace) -> Result<PlanningProjection> {
     let _lock = ws.acquire_planning_lock()?;
     let session = ws
@@ -2865,6 +2918,57 @@ queue:
         let mut conflicting = audit;
         conflicting.max_cycles = 2;
         assert!(ws.save_planning_capability_audit(&conflicting).is_err());
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// Re-entry has to name the state a restarted surface would otherwise show
+    /// as an empty workspace (issue #65).
+    #[test]
+    fn reentry_reports_pending_then_accepted_then_nothing() {
+        let ws = temp_workspace("reentry");
+        assert_eq!(reentry(&ws), None, "no session means nothing to re-enter");
+
+        let (session, turn) = begin_user_turn_exact(&ws, "bounded test").unwrap();
+        let mut content = draft();
+        content.intent.id = session.intent_id.clone();
+        content.queue.intent_id = session.intent_id.clone();
+        content.queue.queue_id = session.queue_id.clone();
+        assert_eq!(
+            reentry(&ws),
+            None,
+            "an open session with no proposal yet has nothing for the operator"
+        );
+
+        let proposal = record_worker_proposal(
+            &ws,
+            &turn,
+            "planner",
+            "attempt-reentry",
+            "proposal",
+            "rationale",
+            content,
+        )
+        .unwrap();
+        assert_eq!(
+            reentry(&ws),
+            Some(PlanningReentry::PendingProposal { count: 1 }),
+            "a proposal waiting for accept/reject must be re-enterable"
+        );
+
+        let revision =
+            accept_proposal(&ws, &proposal.proposal_id, None, "action-reentry-accept").unwrap();
+        assert_eq!(
+            reentry(&ws),
+            Some(PlanningReentry::AcceptedDraft),
+            "an accepted draft is still unconfirmed work, not a finished session"
+        );
+
+        confirm(&ws, &revision.draft_revision_id, "action-reentry-confirm").unwrap();
+        assert_eq!(
+            reentry(&ws),
+            None,
+            "a confirmed session became the queue; the queue surface owns it now"
+        );
         let _ = std::fs::remove_dir_all(ws.root);
     }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -39,6 +39,10 @@ pub struct Snapshot {
     /// harness-copy warnings as evidence. Absence of the evidence file means
     /// preparation was clean, so such runs never appear here.
     pub harness_copy_warnings: Vec<HarnessCopyWarning>,
+    /// An open planning session still waiting on the operator. The queue is
+    /// legitimately empty in this state, so without this the surface is
+    /// indistinguishable from having no work at all (issue #65).
+    pub planning_reentry: Option<crate::planning::PlanningReentry>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -401,6 +405,7 @@ impl Snapshot {
             last_transitions,
             recovery_required,
             harness_copy_warnings,
+            planning_reentry: crate::planning::reentry(ws),
         })
     }
 

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -372,6 +372,15 @@ pub struct L {
     pub key_answer: &'static str,
     pub key_approve: &'static str,
     pub key_replan: &'static str,
+    /// Offered whenever an open planning session is waiting on the operator.
+    pub key_plan_review: &'static str,
+    /// Home rows for an open planning session. The queue is legitimately empty
+    /// in this state, so these are the only thing distinguishing "a plan is
+    /// waiting" from "there is no work" (issue #65). `{n}` is the count.
+    pub home_plan_pending: &'static str,
+    pub home_plan_accepted: &'static str,
+    /// Shown when `o` is pressed with no planning session to re-enter.
+    pub plan_review_nothing: &'static str,
     pub replan_worker_question_hint: &'static str,
     pub replan_live_queue_hint: &'static str,
     pub replan_nothing_hint: &'static str,
@@ -597,6 +606,11 @@ pub const EN: L = L {
     key_answer: "a answer",
     key_approve: "p approve",
     key_replan: "P replan",
+    key_plan_review: "o plan review",
+    home_plan_pending: "\u{25b6} {n} plan proposal(s) waiting for review \u{2014} press o",
+    home_plan_accepted:
+        "\u{25b6} an accepted plan is waiting to be confirmed into the queue \u{2014} press o",
+    plan_review_nothing: "no open planning session to review; press n to describe new work",
     replan_worker_question_hint: "a worker question is open; press a and answer it instead of replanning",
     replan_live_queue_hint: "the queue still has live work; finish or settle it before replanning",
     replan_nothing_hint: "this settled queue has no failed approach to replan; press n for follow-up work",
@@ -815,6 +829,10 @@ pub const KO: L = L {
     key_answer: "a 답변",
     key_approve: "p 승인",
     key_replan: "P 재계획",
+    key_plan_review: "o 플랜 검토",
+    home_plan_pending: "\u{25b6} 검토 대기 중인 플랜 제안 {n}건 — o 키",
+    home_plan_accepted: "\u{25b6} 수락된 플랜이 큐 확정을 기다리는 중 — o 키",
+    plan_review_nothing: "검토할 열린 플래닝 세션이 없습니다. 새 작업은 n을 누르세요",
     replan_worker_question_hint: "워커 질문이 열려 있음. 재계획 대신 a 눌러 답변하세요",
     replan_live_queue_hint: "큐에 진행 중인 작업이 있음. 완료하거나 종결한 뒤 재계획하세요",
     replan_nothing_hint: "이 종결 큐에는 재계획할 실패 접근이 없음. 후속 작업은 n을 누르세요",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1351,6 +1351,21 @@ fn handle_home_key(app: &mut App, code: KeyCode) -> bool {
                 toggle_worker(app, app.selected - tasks);
             }
         }
+        // Re-enter an open planning session. Until today the review screen had
+        // exactly one entry point — a planning job finishing in THIS process —
+        // so a restart mid-flow left an accepted-but-unconfirmed plan with no
+        // TUI path at all (issue #65).
+        KeyCode::Char('o') if !app.is_busy() => {
+            if app
+                .snapshot
+                .as_ref()
+                .is_some_and(|snap| snap.planning_reentry.is_some())
+            {
+                let _ = open_planning_review(app);
+            } else {
+                app.toast = Some((false, app.lang.l().plan_review_nothing.to_string()));
+            }
+        }
         // Reports/history browser: current final report + past intents.
         KeyCode::Char('R') => open_reports(app),
         _ if app.is_busy() => app.toast = Some((true, app.lang.l().busy.into())),

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -499,25 +499,39 @@ fn render_home(frame: &mut Frame, app: &App) {
             l.footer_home_busy_nodrain.to_string()
         }
     } else {
-        let (availability, answerable, approvable, replannable) = if let Some(snap) = &app.snapshot
-        {
-            let answerable = snap.pending.is_some()
-                || snap.gate.is_some()
-                || snap
-                    .queue
-                    .tasks
-                    .iter()
-                    .any(|t| !matches!(t.state, TaskState::Running | TaskState::Done));
-            (
-                snap.home_footer,
-                answerable,
-                !snap.approvals_needed.is_empty(),
-                same_intent_replan_availability(&snap.queue) == ReplanAvailability::Available,
-            )
-        } else {
-            (HomeFooterAvailability::default(), false, false, false)
-        };
-        home_footer(l, availability, answerable, approvable, replannable)
+        let (availability, answerable, approvable, replannable, plan_reviewable) =
+            if let Some(snap) = &app.snapshot {
+                let answerable = snap.pending.is_some()
+                    || snap.gate.is_some()
+                    || snap
+                        .queue
+                        .tasks
+                        .iter()
+                        .any(|t| !matches!(t.state, TaskState::Running | TaskState::Done));
+                (
+                    snap.home_footer,
+                    answerable,
+                    !snap.approvals_needed.is_empty(),
+                    same_intent_replan_availability(&snap.queue) == ReplanAvailability::Available,
+                    snap.planning_reentry.is_some(),
+                )
+            } else {
+                (
+                    HomeFooterAvailability::default(),
+                    false,
+                    false,
+                    false,
+                    false,
+                )
+            };
+        home_footer(
+            l,
+            availability,
+            answerable,
+            approvable,
+            replannable,
+            plan_reviewable,
+        )
     };
     render_footer(frame, chunks[4], &footer);
 }
@@ -580,6 +594,7 @@ fn home_footer(
     answerable: bool,
     approvable: bool,
     replannable: bool,
+    plan_reviewable: bool,
 ) -> String {
     let mut fragments = vec![l.footer_home];
     for (available, fragment) in [
@@ -603,6 +618,9 @@ fn home_footer(
     }
     if replannable {
         fragments.push(l.key_replan);
+    }
+    if plan_reviewable {
+        fragments.push(l.key_plan_review);
     }
     fragments.join("  ")
 }
@@ -732,14 +750,36 @@ fn render_header(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L) {
     );
 }
 
+/// The Home row for an open planning session, if one is waiting. It leads the
+/// queue box in both the empty and populated cases: an accepted-but-unconfirmed
+/// plan leaves the queue legitimately empty, which is exactly the state that
+/// read as "my plan disappeared" (issue #65).
+fn planning_reentry_item(snap: &Snapshot, l: &L) -> Option<ListItem<'static>> {
+    let text = match snap.planning_reentry? {
+        crate::planning::PlanningReentry::PendingProposal { count } => {
+            l.home_plan_pending.replace("{n}", &count.to_string())
+        }
+        crate::planning::PlanningReentry::AcceptedDraft => l.home_plan_accepted.to_string(),
+    };
+    Some(ListItem::new(Line::from(Span::styled(
+        text,
+        Style::default().fg(Color::Cyan).bold(),
+    ))))
+}
+
 fn render_queue(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L, selected: usize) {
+    let planning = planning_reentry_item(snap, l);
     let items: Vec<ListItem> = if snap.tasks().is_empty() {
-        vec![ListItem::new(Line::from(Span::styled(
-            l.queue_empty,
-            Style::default().fg(Color::DarkGray),
-        )))]
+        planning
+            .into_iter()
+            .chain(std::iter::once(ListItem::new(Line::from(Span::styled(
+                l.queue_empty,
+                Style::default().fg(Color::DarkGray),
+            )))))
+            .collect()
     } else {
         let mut items = Vec::new();
+        items.extend(planning);
         if snap
             .tasks()
             .iter()
@@ -1601,8 +1641,8 @@ mod tests {
         ];
 
         for (availability, en_hint, ko_hint) in cases {
-            let en = home_footer(i18n::Lang::En.l(), availability, false, false, false);
-            let ko = home_footer(i18n::Lang::Ko.l(), availability, false, false, false);
+            let en = home_footer(i18n::Lang::En.l(), availability, false, false, false, false);
+            let ko = home_footer(i18n::Lang::Ko.l(), availability, false, false, false, false);
             assert!(en.contains(en_hint), "missing English hint: {en_hint}");
             assert!(ko.contains(ko_hint), "missing Korean hint: {ko_hint}");
             for other in [
@@ -1643,12 +1683,12 @@ mod tests {
             trust: true,
         };
         assert_eq!(
-            home_footer(i18n::Lang::En.l(), availability, true, true, true),
-            "\u{2191}\u{2193} select  Enter action  n new  r run  A auto  t tidy  d defer  v revive  m monitor  h handoff  T trust  q quit  a answer  p approve  P replan"
+            home_footer(i18n::Lang::En.l(), availability, true, true, true, true),
+            "\u{2191}\u{2193} select  Enter action  n new  r run  A auto  t tidy  d defer  v revive  m monitor  h handoff  T trust  q quit  a answer  p approve  P replan  o plan review"
         );
         assert_eq!(
-            home_footer(i18n::Lang::Ko.l(), availability, true, true, true),
-            "\u{2191}\u{2193} 선택  Enter 행동  n 새작업  r 실행  A 자동  t 정리  d 보류  v 되살림  m 모니터  h 핸드오프  T 신뢰  q 종료  a 답변  p 승인  P 재계획"
+            home_footer(i18n::Lang::Ko.l(), availability, true, true, true, true),
+            "\u{2191}\u{2193} 선택  Enter 행동  n 새작업  r 실행  A 자동  t 정리  d 보류  v 되살림  m 모니터  h 핸드오프  T 신뢰  q 종료  a 답변  p 승인  P 재계획  o 플랜 검토"
         );
     }
 

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -1,0 +1,409 @@
+//! End-to-end PTY integration for planning re-entry across a process boundary
+//! (issue #65).
+//!
+//! Every existing planning test drives the whole flow inside ONE process:
+//! plan -> review -> accept -> confirm. That is exactly why the reported dead
+//! end was invisible — the review screen had a single production entry point
+//! ("a planning job just finished in THIS process"), so an accepted but
+//! unconfirmed draft became unreachable the moment the TUI restarted.
+//!
+//! This test therefore uses two separate `yardlet` processes over real
+//! pseudo-terminals against the same workspace:
+//!
+//!   1. Process one plans and accepts a draft, then quits WITHOUT confirming.
+//!      The session is left `lifecycle: open`, `current_head` set,
+//!      `confirmation_id: null` — the exact on-disk state from the report.
+//!   2. Process two starts fresh. Home must say a plan is waiting (the queue is
+//!      legitimately empty here, so without that row it looks like no work at
+//!      all), advertise the key, and open the review screen when it is pressed.
+//!
+//! The planner is a deterministic shell fixture on the workspace's own path, so
+//! nothing here needs a real worker CLI or network.
+
+#![cfg(unix)]
+
+use std::fs::{self, File};
+use std::io::{ErrorKind, Read, Write};
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+fn test_root() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "yard-tui-planning-reentry-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+/// A deterministic planning worker: one valid single-task proposal per turn.
+fn write_planner(path: &Path) {
+    fs::write(
+        path,
+        "#!/usr/bin/env bash\n\
+         set -euo pipefail\n\
+         if [[ \"${1:-}\" == \"--version\" ]]; then\n\
+         \x20 printf 'fixture-planner 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         cat >/dev/null\n\
+         mkdir -p \"$run_dir\"\n\
+         cat >\"$run_dir/planning-result.json\" <<'EOF'\n\
+         {\n\
+         \x20 \"summary\": \"reentry fixture slice\",\n\
+         \x20 \"rationale\": \"deterministic reentry fixture\",\n\
+         \x20 \"allowed_scope\": [\"tests/\"],\n\
+         \x20 \"out_of_scope\": [\"src/ui/**\"],\n\
+         \x20 \"acceptance\": [{\"id\": \"AC-001\", \"statement\": \"reentry fixture proposal\"}],\n\
+         \x20 \"ambiguity\": {\"score\": \"low\", \"open_questions\": []},\n\
+         \x20 \"tasks\": [{\n\
+         \x20 \x20 \"id\": \"YARD-001\",\n\
+         \x20 \x20 \"title\": \"reentry fixture task\",\n\
+         \x20 \x20 \"kind\": \"implementation\",\n\
+         \x20 \x20 \"risk\": \"low\",\n\
+         \x20 \x20 \"preferred_worker\": \"fixture-planner\",\n\
+         \x20 \x20 \"model\": \"auto\",\n\
+         \x20 \x20 \"effort\": \"auto\",\n\
+         \x20 \x20 \"depends_on\": [],\n\
+         \x20 \x20 \"skills\": [],\n\
+         \x20 \x20 \"required_capabilities\": [],\n\
+         \x20 \x20 \"allowed_scope\": [\"tests/\"],\n\
+         \x20 \x20 \"acceptance\": [\"reentry fixture proposal\"],\n\
+         \x20 \x20 \"worker_rationale\": \"deterministic fixture\"\n\
+         \x20 }],\n\
+         \x20 \"questions_for_user\": []\n\
+         }\n\
+         EOF\n\
+         printf 'fixture planning turn\\n'\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn open_pty() -> (File, File) {
+    let mut master = -1;
+    let mut slave = -1;
+    let mut size = libc::winsize {
+        ws_row: 40,
+        ws_col: 140,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let rc = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut size as *mut libc::winsize,
+        )
+    };
+    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+    let master = unsafe { File::from_raw_fd(master) };
+    let slave = unsafe { File::from_raw_fd(slave) };
+    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+    assert!(flags >= 0);
+    let rc = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    assert_eq!(rc, 0);
+    (master, slave)
+}
+
+/// Drain everything currently readable. Draining continuously is mandatory: a
+/// full PTY buffer blocks the child on its next render.
+fn drain(master: &mut File, sink: &mut Vec<u8>) {
+    let mut buffer = [0_u8; 8192];
+    loop {
+        match master.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(count) => sink.extend_from_slice(&buffer[..count]),
+            Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+            Err(error) => panic!("PTY read failed: {error}"),
+        }
+    }
+}
+
+/// Ratatui positions every wide (CJK) cell with its own cursor-move escape, so
+/// a Korean word is not a contiguous byte run until the escapes are stripped.
+fn strip_ansi(bytes: &[u8]) -> String {
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == 0x1b {
+            match bytes.get(i + 1) {
+                Some(b'[') => {
+                    i += 2;
+                    while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                        i += 1;
+                    }
+                    i += usize::from(i < bytes.len());
+                }
+                Some(b']') => {
+                    i += 2;
+                    while i < bytes.len() {
+                        if bytes[i] == 0x07 {
+                            i += 1;
+                            break;
+                        }
+                        if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
+                            i += 2;
+                            break;
+                        }
+                        i += 1;
+                    }
+                }
+                Some(_) => i += 2,
+                None => break,
+            }
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Whitespace between cells is emitted as cursor motion too, so compare the
+/// visible text with all whitespace removed.
+fn norm(s: &str) -> String {
+    s.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+fn seen(sink: &[u8], marker: &str) -> bool {
+    norm(&strip_ansi(sink)).contains(&norm(marker))
+}
+
+fn recent(sink: &[u8]) -> String {
+    let text = strip_ansi(sink);
+    let chars: Vec<char> = text.chars().collect();
+    let start = chars.len().saturating_sub(800);
+    chars[start..].iter().collect()
+}
+
+fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: Duration) {
+    let deadline = Instant::now() + within;
+    loop {
+        drain(master, sink);
+        if seen(sink, marker) {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "marker {marker:?} not seen within {within:?}; recent output:\n{}",
+            recent(sink)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Poll a workspace predicate while still draining the PTY, so the child never
+/// blocks on render while we wait for its side effect.
+fn wait_until(
+    master: &mut File,
+    sink: &mut Vec<u8>,
+    label: &str,
+    within: Duration,
+    ready: impl Fn() -> bool,
+) {
+    let deadline = Instant::now() + within;
+    loop {
+        drain(master, sink);
+        if ready() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "{label} did not happen within {within:?}; recent output:\n{}",
+            recent(sink)
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+fn spawn_tui(binary: &Path, root: &Path) -> (Child, File, Vec<u8>) {
+    let (master, slave) = open_pty();
+    let stdin = Stdio::from(slave.try_clone().unwrap());
+    let stdout = Stdio::from(slave.try_clone().unwrap());
+    let stderr = Stdio::from(slave);
+    let child = Command::new(binary)
+        .current_dir(root)
+        .env("TERM", "xterm-256color")
+        .env("YARDLET_PROCESS_FIXTURE", "1")
+        .stdin(stdin)
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .unwrap();
+    (child, master, Vec::new())
+}
+
+fn quit_tui(child: &mut Child, master: &mut File, sink: &mut Vec<u8>) {
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = master.write_all(b"q");
+    std::thread::sleep(Duration::from_millis(150));
+    let _ = master.write_all(b"q");
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while child.try_wait().unwrap().is_none() && Instant::now() < deadline {
+        drain(master, sink);
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    if child.try_wait().unwrap().is_none() {
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+}
+
+/// The single open session's record, read straight off disk.
+fn session_yaml(root: &Path) -> String {
+    let sessions = root.join(".agents/planning-sessions");
+    let latest = fs::read_to_string(sessions.join("latest")).unwrap();
+    fs::read_to_string(sessions.join(latest.trim()).join("session.yaml")).unwrap()
+}
+
+fn accepted_but_unconfirmed(root: &Path) -> bool {
+    let sessions = root.join(".agents/planning-sessions");
+    let Ok(latest) = fs::read_to_string(sessions.join("latest")) else {
+        return false;
+    };
+    let Ok(record) = fs::read_to_string(sessions.join(latest.trim()).join("session.yaml")) else {
+        return false;
+    };
+    record.contains("lifecycle: open")
+        && record.contains("current_head: drv_")
+        && !record.contains("confirmation_id: cnf")
+}
+
+#[test]
+fn an_accepted_unconfirmed_plan_is_reachable_from_home_after_a_restart() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let root = test_root();
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&root).unwrap();
+
+    let init = Command::new(&binary)
+        .arg("init")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "yardlet init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let config_path = root.join(".agents/yardlet.yaml");
+    let config = fs::read_to_string(&config_path)
+        .unwrap()
+        .replace("language: auto", "language: ko");
+    fs::write(&config_path, config).unwrap();
+
+    let planner = root.join("fixture-planner.sh");
+    write_planner(&planner);
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\n\
+             workers:\n\
+             \x20 - id: fixture-planner\n\
+             \x20 \x20 kind: cli_worker\n\
+             \x20 \x20 best_for: deterministic planning fixture\n\
+             \x20 \x20 billing:\n\
+             \x20 \x20 \x20 mode: subscription_backed_only\n\
+             \x20 \x20 invocation:\n\
+             \x20 \x20 \x20 command: {}\n\
+             \x20 \x20 \x20 supports_noninteractive: true\n\
+             \x20 \x20 \x20 output_contract: files\n\
+             \x20 \x20 \x20 args: [\"{{run_dir}}\"]\n\
+             \x20 \x20 limits:\n\
+             \x20 \x20 \x20 max_wall_minutes: 1\n\
+             \x20 \x20 \x20 max_retries: 0\n\
+             routing:\n\
+             \x20 default_worker: fixture-planner\n\
+             \x20 fallback_order: [fixture-planner]\n\
+             \x20 planning_gate:\n\
+             \x20 \x20 primary: fixture-planner\n\
+             \x20 \x20 fallback: \"\"\n",
+            planner.display()
+        ),
+    )
+    .unwrap();
+
+    // ---- process one: plan, accept, quit without confirming ---------------
+    let (mut first, mut master, mut sink) = spawn_tui(&binary, &root);
+    wait_for_marker(&mut master, &mut sink, "새작업", Duration::from_secs(20));
+    master.write_all(b"n").unwrap();
+    wait_for_marker(
+        &mut master,
+        &mut sink,
+        "작업을 몇 문장으로",
+        Duration::from_secs(5),
+    );
+    master.write_all("REENTRY-PLAN-REQUEST".as_bytes()).unwrap();
+    master.write_all(b"\x13").unwrap(); // Ctrl+S submit
+    wait_for_marker(&mut master, &mut sink, "플랜 검토", Duration::from_secs(20));
+    wait_for_marker(&mut master, &mut sink, "a 수락", Duration::from_secs(10));
+    master.write_all(b"a").unwrap(); // accept, but never `c` confirm
+    {
+        let root = root.clone();
+        wait_until(
+            &mut master,
+            &mut sink,
+            "draft acceptance",
+            Duration::from_secs(15),
+            move || accepted_but_unconfirmed(&root),
+        );
+    }
+    quit_tui(&mut first, &mut master, &mut sink);
+
+    // The reported on-disk state: a whole plan waiting, and no queue.
+    let record = session_yaml(&root);
+    assert!(
+        record.contains("lifecycle: open") && record.contains("current_head: drv_"),
+        "process one did not leave an open session with an accepted head:\n{record}"
+    );
+    assert!(
+        !record.contains("confirmation_id: cnf"),
+        "process one confirmed the draft; the re-entry state was never reached:\n{record}"
+    );
+    let queue = fs::read_to_string(root.join(".agents/work-queue.yaml")).unwrap();
+    assert!(
+        !queue.contains("YARD-001"),
+        "an unconfirmed draft must not have produced a queue:\n{queue}"
+    );
+
+    // ---- process two: the restart the operator actually did ---------------
+    let (mut second, mut master, mut sink) = spawn_tui(&binary, &root);
+    // A frame is drawn top to bottom, so wait on the LAST thing the re-entry
+    // state adds — the footer key. Reaching it means the whole Home frame,
+    // queue row included, has been emitted. (Timing out here is itself the
+    // "key is not advertised" failure, reported with the rendered tail.)
+    wait_for_marker(
+        &mut master,
+        &mut sink,
+        "o 플랜 검토",
+        Duration::from_secs(20),
+    );
+    assert!(
+        seen(&sink, "수락된 플랜이 큐 확정을 기다리는 중"),
+        "Home did not say a plan is waiting, so an empty queue is all the operator sees;\n{}",
+        recent(&sink)
+    );
+
+    master.write_all(b"o").unwrap();
+    wait_for_marker(&mut master, &mut sink, "플랜 검토", Duration::from_secs(10));
+    wait_for_marker(&mut master, &mut sink, "c 확정", Duration::from_secs(10));
+    assert!(
+        seen(&sink, "reentry fixture slice"),
+        "the review screen opened without the accepted draft's content;\n{}",
+        recent(&sink)
+    );
+
+    quit_tui(&mut second, &mut master, &mut sink);
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes #65.

## The dead end

`open_planning_review` had exactly one production call site: `finish_background_job`, i.e. "a planning job just completed **in this process**". There was no startup routing to the review screen and no Home key that opened it.

So after a restart mid-flow, an accepted-but-unconfirmed draft had no TUI path at all. The plan was intact on disk — `lifecycle: open`, `current_head: drv_…`, `confirmation_id: null`, and correctly no queue — but Home showed an empty queue, which is exactly how the operator read it: the plan had disappeared. `yardlet planning confirm` from the CLI was the only way forward.

## The change

- **`planning::reentry`** — a read-only projection of what an OPEN session still needs from the operator: `PendingProposal { count }` or `AcceptedDraft`. Deliberately lock-free and best-effort, because it runs on every snapshot load: an unreadable or half-written session is a reason to show nothing, never to fail the snapshot. Anything actionable is re-validated by the review screen, which takes the lock.
- **Home row** — leads the queue box in both the empty and populated cases. The queue being empty is legitimate in this state, so this row is the only thing distinguishing "a plan is waiting" from "there is no work".
- **`o` opens the review screen** on demand, advertised on the idle footer whenever there is something to re-enter (content-dependent, matching the existing footer gating). Pressing it with nothing to review says so rather than opening an empty screen.

Auto-routing at startup was the other option the issue offered. I did not take it: it hijacks the first screen for someone who restarted just to look at the queue, and the row plus an advertised key restores discoverability without that.

## Test

`tests/tui_planning_reentry_process.rs` crosses the process boundary the existing tests never did — the issue calls this out directly ("every test covers the in-session path, so a process boundary in the middle of the flow was never exercised").

1. Process one plans over a real PTY, accepts the draft, and quits **without** confirming. The test then asserts the on-disk shape from the report: open session, `current_head` set, no confirmation, no queue.
2. Process two starts fresh against the same workspace and must show the Home row, advertise `o`, and open the review screen with the accepted draft's content in it.

RED verified: with the projection disabled, process two renders a plain Home with an empty queue and the marker never appears — the reported dead end, reproduced.

Also `planning::reentry_reports_pending_then_accepted_then_nothing` walks all four states (no session → open with no proposal → pending → accepted → confirmed).

One test-authoring note worth keeping: a frame is drawn top to bottom, so waiting on a marker from the queue box can return a drain *before* the footer line exists. The wait is on the footer key, which is the last thing this state adds.

## Verification

- `cargo test` — 650 unit + all integration targets pass, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked`, `cargo +1.97.1 clippy --all-targets` clean