### PR TITLE
test: stop PTY tests from leaking their TUI child when an assertion fails

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,70 @@
+//! Helpers shared by the PTY integration tests.
+//!
+//! Compiled into each test binary that declares `mod common;`, so a helper only
+//! some of them need still looks unused to the rest.
+#![allow(dead_code)]
+
+use std::process::Child;
+use std::time::{Duration, Instant};
+
+/// Kills and reaps a spawned child on drop.
+///
+/// `std::process::Child` does NOT kill on drop, so a failing assertion unwinds
+/// straight past a test's own cleanup and abandons a live process. Every red
+/// run during PTY work left one behind (issue #64: seven orphaned `yardlet`
+/// processes after a day of it).
+///
+/// The clean-quit path stays in the tests — it exercises the app's own shutdown
+/// and is worth asserting on — and this sits underneath it as the backstop.
+pub struct ChildGuard {
+    child: Option<Child>,
+}
+
+impl ChildGuard {
+    pub fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    /// The process id, so a test can assert the process really is gone.
+    pub fn id(&self) -> u32 {
+        self.child
+            .as_ref()
+            .expect("child guard used after shutdown")
+            .id()
+    }
+
+    /// Wait out a clean exit, killing after `within` if it never comes.
+    ///
+    /// `tick` runs between polls so a test can keep draining its PTY: a child
+    /// blocked writing into a full buffer would otherwise never reach its own
+    /// shutdown and would always be killed here.
+    pub fn shutdown(&mut self, within: Duration, mut tick: impl FnMut()) {
+        let Some(child) = self.child.as_mut() else {
+            return;
+        };
+        let deadline = Instant::now() + within;
+        while Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => {}
+                Err(_) => break,
+            }
+            tick();
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        if matches!(child.try_wait(), Ok(None)) {
+            let _ = child.kill();
+        }
+        let _ = child.wait();
+    }
+}

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -1,0 +1,100 @@
+//! The PTY tests' leak backstop (issue #64).
+//!
+//! `std::process::Child` does not kill on drop, so before this guard existed a
+//! failing assertion unwound straight past a test's own cleanup and abandoned a
+//! live process — seven orphaned `yardlet` processes accumulated over a day of
+//! PTY work. This pins the property that mattered: when a test panics, the
+//! child it spawned is dead by the time the panic leaves the scope.
+
+#![cfg(unix)]
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+mod common;
+
+/// Is `pid` still a live (or zombie) process? `kill(pid, 0)` reports
+/// permission-checked existence without sending a signal.
+fn alive(pid: u32) -> bool {
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+fn spawn_long_lived() -> std::process::Child {
+    Command::new("sleep")
+        .arg("120")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn sleep")
+}
+
+/// Wait out the reap so the assertion is not racing `Drop`'s own `wait`.
+fn wait_until_gone(pid: u32, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if !alive(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    !alive(pid)
+}
+
+#[test]
+fn a_panicking_assertion_does_not_leak_the_spawned_child() {
+    let pid = std::cell::Cell::new(0_u32);
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let guard = common::ChildGuard::new(spawn_long_lived());
+        pid.set(guard.id());
+        assert!(alive(guard.id()), "the fixture child never started");
+        // Exactly the shape the issue describes: an assertion fires before the
+        // test reaches its own clean-quit path.
+        panic!("simulated assertion failure");
+    }));
+    assert!(result.is_err(), "the fixture panic did not propagate");
+    let pid = pid.get();
+    assert_ne!(pid, 0, "the child was never spawned");
+    assert!(
+        wait_until_gone(pid, Duration::from_secs(5)),
+        "child {pid} survived a panicking assertion"
+    );
+}
+
+#[test]
+fn a_clean_shutdown_reaps_without_killing_and_the_guard_stays_idempotent() {
+    let mut guard = common::ChildGuard::new(
+        Command::new("true")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn true"),
+    );
+    let pid = guard.id();
+    let mut ticks = 0;
+    guard.shutdown(Duration::from_secs(5), || ticks += 1);
+    assert!(
+        wait_until_gone(pid, Duration::from_secs(5)),
+        "child {pid} was not reaped by a clean shutdown"
+    );
+    // Dropping after shutdown must not panic or try to kill a reaped pid.
+    drop(guard);
+}
+
+#[test]
+fn shutdown_kills_a_child_that_never_exits_on_its_own() {
+    let mut guard = common::ChildGuard::new(spawn_long_lived());
+    let pid = guard.id();
+    let mut ticks = 0;
+    guard.shutdown(Duration::from_millis(200), || ticks += 1);
+    assert!(
+        ticks > 0,
+        "shutdown never ran its tick, so a PTY-blocked child would deadlock"
+    );
+    assert!(
+        wait_until_gone(pid, Duration::from_secs(5)),
+        "child {pid} outlived a shutdown deadline"
+    );
+}

--- a/tests/tui_key_list_process.rs
+++ b/tests/tui_key_list_process.rs
@@ -16,6 +16,8 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+mod common;
+
 fn test_root() -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -160,7 +162,7 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
     let stdin = Stdio::from(slave.try_clone().unwrap());
     let stdout = Stdio::from(slave.try_clone().unwrap());
     let stderr = Stdio::from(slave);
-    let mut child = Command::new(&binary)
+    let child = Command::new(&binary)
         .current_dir(&root)
         .env("TERM", "xterm-256color")
         .env("YARDLET_PROCESS_FIXTURE", "1")
@@ -169,6 +171,9 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
         .stderr(stderr)
         .spawn()
         .unwrap();
+    // Killed and reaped even if an assertion below unwinds past the clean quit
+    // (issue #64).
+    let mut child = common::ChildGuard::new(child);
 
     let mut sink: Vec<u8> = Vec::new();
 
@@ -203,14 +208,6 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
 
     std::thread::sleep(Duration::from_millis(200));
     let _ = master.write_all(b"q");
-    let exit_deadline = Instant::now() + Duration::from_secs(5);
-    while child.try_wait().unwrap().is_none() && Instant::now() < exit_deadline {
-        drain(&mut master, &mut sink);
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    if child.try_wait().unwrap().is_none() {
-        child.kill().unwrap();
-        child.wait().unwrap();
-    }
+    child.shutdown(Duration::from_secs(5), || drain(&mut master, &mut sink));
     let _ = fs::remove_dir_all(&root);
 }

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -27,8 +27,10 @@ use std::io::{ErrorKind, Read, Write};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+mod common;
 
 fn test_root() -> PathBuf {
     let nonce = SystemTime::now()
@@ -227,7 +229,7 @@ fn wait_until(
     }
 }
 
-fn spawn_tui(binary: &Path, root: &Path) -> (Child, File, Vec<u8>) {
+fn spawn_tui(binary: &Path, root: &Path) -> (common::ChildGuard, File, Vec<u8>) {
     let (master, slave) = open_pty();
     let stdin = Stdio::from(slave.try_clone().unwrap());
     let stdout = Stdio::from(slave.try_clone().unwrap());
@@ -241,23 +243,17 @@ fn spawn_tui(binary: &Path, root: &Path) -> (Child, File, Vec<u8>) {
         .stderr(stderr)
         .spawn()
         .unwrap();
-    (child, master, Vec::new())
+    // Killed and reaped even if an assertion unwinds past the clean quit
+    // (issue #64).
+    (common::ChildGuard::new(child), master, Vec::new())
 }
 
-fn quit_tui(child: &mut Child, master: &mut File, sink: &mut Vec<u8>) {
+fn quit_tui(child: &mut common::ChildGuard, master: &mut File, sink: &mut Vec<u8>) {
     std::thread::sleep(Duration::from_millis(200));
     let _ = master.write_all(b"q");
     std::thread::sleep(Duration::from_millis(150));
     let _ = master.write_all(b"q");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while child.try_wait().unwrap().is_none() && Instant::now() < deadline {
-        drain(master, sink);
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    if child.try_wait().unwrap().is_none() {
-        child.kill().unwrap();
-        child.wait().unwrap();
-    }
+    child.shutdown(Duration::from_secs(5), || drain(master, sink));
 }
 
 /// The single open session's record, read straight off disk.

--- a/tests/tui_startup_process.rs
+++ b/tests/tui_startup_process.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+mod common;
+
 fn test_root(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("yard-tui-startup-{name}-{}", std::process::id()))
 }
@@ -99,7 +101,7 @@ fn slow_probe_and_recovery_do_not_block_first_safe_tui_frame() {
         std::env::var("PATH").unwrap_or_default()
     );
     let started = Instant::now();
-    let mut child = Command::new(&binary)
+    let child = Command::new(&binary)
         .current_dir(&root)
         .env("PATH", path)
         .env("TERM", "xterm-256color")
@@ -110,6 +112,9 @@ fn slow_probe_and_recovery_do_not_block_first_safe_tui_frame() {
         .stderr(stderr)
         .spawn()
         .unwrap();
+    // Killed and reaped even if an assertion below unwinds past the clean quit
+    // (issue #64).
+    let mut child = common::ChildGuard::new(child);
 
     let marker = b"Starting Yardlet safely";
     let deadline = started + Duration::from_secs(3);
@@ -150,13 +155,6 @@ fn slow_probe_and_recovery_do_not_block_first_safe_tui_frame() {
     );
     master.write_all(b"q").unwrap();
 
-    let exit_deadline = Instant::now() + Duration::from_secs(3);
-    while child.try_wait().unwrap().is_none() && Instant::now() < exit_deadline {
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    if child.try_wait().unwrap().is_none() {
-        child.kill().unwrap();
-        child.wait().unwrap();
-    }
+    child.shutdown(Duration::from_secs(3), || {});
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/tui_startup_review_revision_process.rs
+++ b/tests/tui_startup_review_revision_process.rs
@@ -32,6 +32,8 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+mod common;
+
 /// Slow-recovery injection (debug + `YARDLET_PROCESS_FIXTURE=1` only). Big enough
 /// that the loading screen is unmistakably shown before Home, small enough to
 /// keep the test quick.
@@ -318,7 +320,7 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     let stdout = Stdio::from(slave.try_clone().unwrap());
     let stderr = Stdio::from(slave);
     let started = Instant::now();
-    let mut child = Command::new(&binary)
+    let child = Command::new(&binary)
         .current_dir(&root)
         .env("TERM", "xterm-256color")
         .env("YARDLET_PROCESS_FIXTURE", "1")
@@ -331,6 +333,9 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         .stderr(stderr)
         .spawn()
         .unwrap();
+    // Killed and reaped even if an assertion below unwinds past the clean quit
+    // (issue #64).
+    let mut child = common::ChildGuard::new(child);
 
     let mut sink: Vec<u8> = Vec::new();
 
@@ -436,14 +441,6 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     let _ = master.write_all(b"q");
     std::thread::sleep(Duration::from_millis(150));
     let _ = master.write_all(b"q");
-    let exit_deadline = Instant::now() + Duration::from_secs(5);
-    while child.try_wait().unwrap().is_none() && Instant::now() < exit_deadline {
-        drain(&mut master, &mut sink);
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    if child.try_wait().unwrap().is_none() {
-        child.kill().unwrap();
-        child.wait().unwrap();
-    }
+    child.shutdown(Duration::from_secs(5), || drain(&mut master, &mut sink));
     let _ = fs::remove_dir_all(&root);
 }


### PR DESCRIPTION
Closes #64.

## The leak

`std::process::Child` does not kill on drop. The PTY tests killed their child on the **happy path only**, so any `assert!` firing earlier unwound straight past that cleanup and abandoned a live `yardlet` process. Every red run during PTY development left one behind — which is exactly the seven orphans the issue found, each with its cwd in a per-test temp workspace.

## The fix

`tests/common/mod.rs` adds a `ChildGuard` whose `Drop` kills and reaps. Each PTY test's child goes behind it at spawn.

The clean-quit path stays exactly as it was: it exercises the app's own shutdown and is worth asserting on. The guard sits underneath as the backstop, which is what the issue asked for.

One detail worth naming: `shutdown` takes a tick callback so the test keeps draining its PTY while waiting for exit. A child blocked writing into a full PTY buffer can never reach its own shutdown, so without the tick every "clean" quit would silently become a kill and the shutdown path would stop being tested at all.

Covered:

| test | note |
|---|---|
| `tui_startup_process` | named in the issue |
| `tui_startup_review_revision_process` | named in the issue |
| `tui_planning_reentry_process` | added since (#65), same shape |
| `tui_key_list_process` | added since (#71), same shape |

## Test

`tests/pty_child_guard.rs` reproduces the exact shape rather than asserting on the guard's internals:

- `a_panicking_assertion_does_not_leak_the_spawned_child` — spawns a long-lived child inside a scope that panics before any cleanup, catches the unwind, and asserts via `kill(pid, 0)` that the process is gone. **RED verified**: with `Drop` disabled the child survives and the assertion fires.
- `a_clean_shutdown_reaps_without_killing_and_the_guard_stays_idempotent` — a normally-exiting child is reaped, and dropping afterwards does not touch a reaped pid.
- `shutdown_kills_a_child_that_never_exits_on_its_own` — the deadline path kills, and the tick callback actually runs (the deadlock guard above).

## Verification

- `cargo test` — 653 unit + all integration targets pass, 0 failed; `pgrep` for test-workspace processes afterwards finds none
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean