### PR TITLE
fix(tui): say what the ready count will actually run in parallel

### DIFF
--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -40,6 +40,48 @@ fn has_queued_non_verifier(queue: &WorkQueue) -> bool {
         .any(|task| task.state == TaskState::Queued && !is_verifier(task))
 }
 
+/// Runnable tasks the verifier barrier will refuse to co-schedule right now.
+///
+/// The barrier is a parallel-selection concept, so `runnable_class` — and every
+/// count derived from it — knows nothing about it. That is how `4 ready` came
+/// to mean four tasks the scheduler would never start together (issue #51).
+/// Both the selector below and the surfaced counts read this one predicate, so
+/// they cannot drift apart again.
+pub fn held_by_review_barrier(queue: &WorkQueue) -> Vec<String> {
+    let caps = std::collections::BTreeSet::new();
+    let work_pending = has_queued_non_verifier(queue);
+    queue
+        .tasks
+        .iter()
+        .filter(|task| is_verifier(task))
+        .filter(|task| work_pending || queue.has_active_remediation_for(&task.id))
+        .filter(|task| {
+            queue.runnable_class(task, false, &caps) == RunnableClass::Runnable
+                && !task.approval_required()
+        })
+        .map(|task| task.id.clone())
+        .collect()
+}
+
+/// Runnable verifiers that the barrier lets through but the serial cap still
+/// admits one at a time — the "only work left is reviews" case.
+fn serialized_verifiers(queue: &WorkQueue) -> Vec<String> {
+    let caps = std::collections::BTreeSet::new();
+    if has_queued_non_verifier(queue) {
+        return Vec::new();
+    }
+    queue
+        .tasks
+        .iter()
+        .filter(|task| is_verifier(task) && !queue.has_active_remediation_for(&task.id))
+        .filter(|task| {
+            queue.runnable_class(task, false, &caps) == RunnableClass::Runnable
+                && !task.approval_required()
+        })
+        .map(|task| task.id.clone())
+        .collect()
+}
+
 /// Indices of tasks eligible to run together right now: queued, dependencies
 /// met, not approval-gated. Priority order, up to `max`.
 ///
@@ -85,11 +127,33 @@ pub fn ready_independent(queue: &WorkQueue, max: usize) -> Vec<usize> {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "kind")]
 pub enum SequentialReason {
-    ParallelDisabled { max_parallel: usize },
-    RunnableTaskCount { runnable: usize },
-    DependencyChain { tasks: Vec<String> },
-    ApprovalRequired { tasks: Vec<String> },
-    ValidationRequired { tasks: Vec<String> },
+    ParallelDisabled {
+        max_parallel: usize,
+    },
+    RunnableTaskCount {
+        runnable: usize,
+    },
+    DependencyChain {
+        tasks: Vec<String>,
+    },
+    ApprovalRequired {
+        tasks: Vec<String>,
+    },
+    ValidationRequired {
+        tasks: Vec<String>,
+    },
+    /// Verifiers held behind queued non-verifier work. Named explicitly because
+    /// "only 1 runnable task" is not what the operator sees on the queue, and
+    /// reading it against a visible `4 ready` is what made the scheduler look
+    /// broken rather than deliberate (issue #51).
+    ReviewBarrier {
+        tasks: Vec<String>,
+    },
+    /// Verifiers are the only work left, and they still run one at a time so
+    /// each observes the previous one's remediation.
+    VerifierSerial {
+        tasks: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -125,6 +189,16 @@ impl ParallelAssessment {
                 SequentialReason::ValidationRequired { tasks } => {
                     format!("validation required: {}", tasks.join(", "))
                 }
+                SequentialReason::ReviewBarrier { tasks } => format!(
+                    "{} review(s) held behind queued work: {}",
+                    tasks.len(),
+                    tasks.join(", ")
+                ),
+                SequentialReason::VerifierSerial { tasks } => format!(
+                    "{} review(s) run one at a time: {}",
+                    tasks.len(),
+                    tasks.join(", ")
+                ),
             })
             .collect::<Vec<_>>()
             .join("; ")
@@ -173,6 +247,18 @@ pub fn assess_parallelism(queue: &WorkQueue, max_parallel: usize) -> ParallelAss
         reasons.push(SequentialReason::ApprovalRequired {
             tasks: approval_required,
         });
+    }
+
+    // Name the barrier before falling back to the bare count: a queue whose
+    // ready tasks are reviews is not "only 1 runnable task" from where the
+    // operator is standing (issue #51).
+    let held = held_by_review_barrier(queue);
+    if !held.is_empty() {
+        reasons.push(SequentialReason::ReviewBarrier { tasks: held });
+    }
+    let serialized = serialized_verifiers(queue);
+    if serialized.len() > 1 {
+        reasons.push(SequentialReason::VerifierSerial { tasks: serialized });
     }
 
     if max_parallel > 1 && runnable.len() < 2 {
@@ -2357,6 +2443,85 @@ mod tests {
 
         q.tasks[1].state = TaskState::Done;
         assert_eq!(ready_independent(&q, 4), vec![0]);
+    }
+
+    /// The reported shape: `4 ready` with `max_parallel: 4`, of which three are
+    /// reviews the barrier will refuse to co-schedule. The assessment has to
+    /// name the barrier — "only 1 runnable task" contradicts what the operator
+    /// is looking at and made a deliberate scheduler look broken (issue #51).
+    #[test]
+    fn assessment_names_the_review_barrier_instead_of_a_bare_runnable_count() {
+        let mut builder = task("BUILD", TaskState::Queued, 10, vec![]);
+        builder.kind = "implementation".into();
+        let mut reviews = Vec::new();
+        for (index, id) in ["REVIEW-A", "REVIEW-B", "REVIEW-C"].iter().enumerate() {
+            let mut review = task(id, TaskState::Queued, 20 + index as i64, vec![]);
+            review.kind = "review".into();
+            reviews.push(review);
+        }
+        let mut tasks = vec![builder];
+        tasks.extend(reviews);
+        let q = queue(tasks);
+
+        assert_eq!(
+            ready_independent(&q, 4),
+            vec![0],
+            "the scheduler admits only the builder"
+        );
+        assert_eq!(
+            held_by_review_barrier(&q),
+            vec![
+                "REVIEW-A".to_string(),
+                "REVIEW-B".to_string(),
+                "REVIEW-C".to_string()
+            ]
+        );
+
+        let assessment = assess_parallelism(&q, 4);
+        let held = assessment
+            .reasons
+            .iter()
+            .find_map(|reason| match reason {
+                SequentialReason::ReviewBarrier { tasks } => Some(tasks.clone()),
+                _ => None,
+            })
+            .expect("the barrier must be a named reason");
+        assert_eq!(held.len(), 3);
+        assert!(
+            assessment
+                .summary()
+                .contains("review(s) held behind queued work"),
+            "summary must say why: {}",
+            assessment.summary()
+        );
+    }
+
+    /// Reviews as the only work left: nothing is "held behind" anything, but
+    /// they still run one at a time, which is its own invisible cap.
+    #[test]
+    fn assessment_names_the_serial_verifier_cap_when_reviews_are_all_that_is_left() {
+        let mut tasks = Vec::new();
+        for (index, id) in ["REVIEW-A", "REVIEW-B"].iter().enumerate() {
+            let mut review = task(id, TaskState::Queued, 10 + index as i64, vec![]);
+            review.kind = "review".into();
+            tasks.push(review);
+        }
+        let q = queue(tasks);
+
+        assert_eq!(ready_independent(&q, 4).len(), 1, "verifiers stay serial");
+        assert!(
+            held_by_review_barrier(&q).is_empty(),
+            "with no queued builder there is nothing to hold them behind"
+        );
+        let assessment = assess_parallelism(&q, 4);
+        assert!(
+            assessment.reasons.iter().any(|reason| matches!(
+                reason,
+                SequentialReason::VerifierSerial { tasks } if tasks.len() == 2
+            )),
+            "the serial verifier cap must be named: {:?}",
+            assessment.reasons
+        );
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -164,6 +164,13 @@ pub struct RecoveryRequired {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct QueueHealth {
     pub runnable: usize,
+    /// How many of `runnable` the scheduler would actually start together
+    /// right now, and how many the verifier barrier is holding back.
+    ///
+    /// `runnable` alone counts tasks the scheduler will deliberately refuse to
+    /// co-schedule, which reads as parallelism that never arrives (issue #51).
+    pub admissible: usize,
+    pub review_barrier: usize,
     pub running: usize,
     pub waiting_decision: usize,
     pub waiting_approval: usize,
@@ -441,6 +448,9 @@ impl Snapshot {
                 RunnableClass::Done => health.done += 1,
             }
         }
+        health.admissible =
+            crate::parallel::ready_independent(&self.queue, self.config.max_parallel.max(1)).len();
+        health.review_barrier = crate::parallel::held_by_review_barrier(&self.queue).len();
         health
     }
 
@@ -467,6 +477,8 @@ impl Snapshot {
             "intent": self.intent_summary(),
             "queue": {
                 "runnable": health.runnable,
+                "admissible": health.admissible,
+                "review_barrier": health.review_barrier,
                 "running": health.running,
                 "waiting_decision": health.waiting_decision,
                 "waiting_approval": health.waiting_approval,
@@ -633,6 +645,57 @@ mod tests {
             crate::yaml::from_str(&format!("id: {id}\ntitle: Home footer {id}\n")).unwrap();
         task.state = state;
         task
+    }
+
+    /// The health projection and the scheduler must agree on what "ready"
+    /// buys you. `runnable` alone counted three reviews the barrier would
+    /// refuse to co-schedule (issue #51).
+    #[test]
+    fn health_reports_what_the_scheduler_would_actually_admit() {
+        let mut builder = home_footer_task("BUILD", TaskState::Queued);
+        builder.kind = "implementation".into();
+        let mut tasks = vec![builder];
+        for id in ["REVIEW-A", "REVIEW-B", "REVIEW-C"] {
+            let mut review = home_footer_task(id, TaskState::Queued);
+            review.kind = "review".into();
+            tasks.push(review);
+        }
+        let mut queue = WorkQueue::empty();
+        queue.tasks = tasks;
+        let mut config: YardConfig = crate::yaml::from_str(
+            "schema_version: 1\nproduct: yardlet\nworkspace_id: health\ncreated_at: \"2026-07-27T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: \"\"\n",
+        )
+        .unwrap();
+        config.max_parallel = 4;
+        let snapshot = Snapshot {
+            config,
+            intent: None,
+            queue,
+            home_footer: HomeFooterAvailability::default(),
+            workers: Vec::new(),
+            planner: String::new(),
+            pending: None,
+            gate: None,
+            approvals_needed: Vec::new(),
+            capabilities: Default::default(),
+            last_transitions: BTreeMap::new(),
+            recovery_required: Vec::new(),
+            harness_copy_warnings: Vec::new(),
+            planning_reentry: None,
+        };
+
+        let health = snapshot.health();
+        assert_eq!(health.runnable, 4, "all four are class-runnable");
+        assert_eq!(
+            health.admissible, 1,
+            "but the scheduler would start exactly one"
+        );
+        assert_eq!(health.review_barrier, 3);
+        assert_eq!(
+            health.admissible + health.review_barrier,
+            health.runnable,
+            "the breakdown must account for every ready task"
+        );
     }
 
     #[test]

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -374,6 +374,10 @@ pub struct L {
     pub key_replan: &'static str,
     /// Offered whenever an open planning session is waiting on the operator.
     pub key_plan_review: &'static str,
+    /// Suffixes for the `N ready` breakdown when the verifier barrier is
+    /// holding runnable tasks back (issue #51).
+    pub ready_admissible: &'static str,
+    pub ready_review_barrier: &'static str,
     /// Always offered: the full key list. Home's footer can only carry the keys
     /// with a target right now, so the always-valid globals live behind this
     /// one advertised key (issue #71).
@@ -643,6 +647,8 @@ pub const EN: L = L {
     key_approve: "p approve",
     key_replan: "P replan",
     key_plan_review: "o plan review",
+    ready_admissible: " parallelizable",
+    ready_review_barrier: " held by the review barrier",
     key_keys: "? keys",
     keys_title: " Home keys ",
     keys_intro: "Every key Home accepts. The footer only lists the ones with something to act on right now; all of these work.",
@@ -897,6 +903,8 @@ pub const KO: L = L {
     key_approve: "p 승인",
     key_replan: "P 재계획",
     key_plan_review: "o 플랜 검토",
+    ready_admissible: " 동시실행",
+    ready_review_barrier: " 리뷰 배리어 대기",
     key_keys: "? 키목록",
     keys_title: " 홈 키 목록 ",
     keys_intro: "홈에서 받는 모든 키입니다. 푸터에는 지금 대상이 있는 키만 나오지만, 아래는 전부 동작합니다.",

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -707,6 +707,17 @@ fn truncate_width(s: &str, max: usize) -> String {
     out
 }
 
+/// The parenthetical after `N ready`, empty when the plain count is honest.
+fn ready_breakdown(health: &crate::snapshot::QueueHealth, l: &L) -> String {
+    if health.review_barrier == 0 || health.admissible >= health.runnable {
+        return String::new();
+    }
+    format!(
+        " ({}{}, {}{})",
+        health.admissible, l.ready_admissible, health.review_barrier, l.ready_review_barrier
+    )
+}
+
 fn render_header(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L) {
     let health = snap.health();
     let status = Line::from(vec![
@@ -714,6 +725,14 @@ fn render_header(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L) {
         Span::styled(
             format!("{} {}", health.runnable, l.c_ready),
             Style::default().fg(Color::Green),
+        ),
+        // `N ready` on its own counted tasks the scheduler will deliberately
+        // refuse to co-schedule, so pressing A after "4 ready" got one task and
+        // read as a bug (issue #51). Say what is actually admissible whenever
+        // the barrier is holding something back.
+        Span::styled(
+            ready_breakdown(&health, l),
+            Style::default().fg(Color::DarkGray),
         ),
         Span::raw(", "),
         Span::styled(
@@ -1607,6 +1626,56 @@ mod tests {
         assert!(failed.contains("activation fixture mismatch"));
         assert!(failed.contains("g retry  q quit"));
         assert!(!failed.contains("r run"));
+    }
+
+    /// `N ready` counted tasks the scheduler would never co-schedule, so the
+    /// operator pressed A expecting a 4-wide batch and got one task. The header
+    /// now says what is actually admissible — and stays silent when the plain
+    /// count is already honest (issue #51).
+    #[test]
+    fn the_ready_count_breaks_out_what_the_review_barrier_is_holding() {
+        use crate::snapshot::QueueHealth;
+
+        let reported = QueueHealth {
+            runnable: 4,
+            admissible: 1,
+            review_barrier: 3,
+            ..QueueHealth::default()
+        };
+        assert_eq!(
+            ready_breakdown(&reported, i18n::Lang::En.l()),
+            " (1 parallelizable, 3 held by the review barrier)"
+        );
+        assert_eq!(
+            ready_breakdown(&reported, i18n::Lang::Ko.l()),
+            " (1 동시실행, 3 리뷰 배리어 대기)"
+        );
+
+        for honest in [
+            // Nothing held back: the plain count already tells the truth.
+            QueueHealth {
+                runnable: 3,
+                admissible: 3,
+                review_barrier: 0,
+                ..QueueHealth::default()
+            },
+            // Reviews are the only work left, so none are held BEHIND anything;
+            // the serial cap is a different reason and not this suffix's job.
+            QueueHealth {
+                runnable: 2,
+                admissible: 1,
+                review_barrier: 0,
+                ..QueueHealth::default()
+            },
+        ] {
+            for lang in [i18n::Lang::En, i18n::Lang::Ko] {
+                assert_eq!(
+                    ready_breakdown(&honest, lang.l()),
+                    "",
+                    "no breakdown when nothing is held back: {honest:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #51.

## What the operator saw

`4 ready` with `max_parallel: 4`, pressed `A`, got a single task. Run records confirm strict serialization. Working as designed: three of the four were reviews, and `ready_independent` drops every verifier while any non-verifier is still Queued, leaving one candidate — below the two-task threshold for a batch.

The defect is what was visible. The barrier is a **parallel-selection** concept, so `runnable_class` — and every count derived from it — knew nothing about it. Two surfaces then disagreed about the same word: the header said `4 ready`, and `assess_parallelism` said `only 1 runnable task(s)`.

## The change

Extract the predicate the selector already applies into `parallel::held_by_review_barrier`, and read the surfaced counts from that same source so the projection and the scheduler cannot drift apart again.

- `QueueHealth` gains **`admissible`** (what the scheduler would actually start together, i.e. `ready_independent(...).len()`) and **`review_barrier`** (how many ready tasks it is holding back). Both are in `yardlet status --json`.
- The header renders `4 ready (1 parallelizable, 3 held by the review barrier)` whenever the plain count would overstate it, and stays silent when it is already honest.
- `assess_parallelism` gains two typed reasons so `RunnableTaskCount` is no longer the whole story: `ReviewBarrier { tasks }` for reviews held behind queued work, and `VerifierSerial { tasks }` for the separate one-at-a-time cap that applies when reviews are all that is left (the issue's second sentence about verifiers being capped even with nothing else queued).

**Scheduling behavior is unchanged.** The barrier is correct; only its visibility changed.

## On item 2 (the reason is ephemeral in the TUI)

I did not persist the toast. The header breakdown is rendered from the snapshot on every frame, idle and busy, so the cause is readable *before* pressing `A`, during the drain, and after — which is strictly better than making one transient message stick around. The issue's own framing agrees: "A count like `4 ready (1 parallelizable, 3 held by the review barrier)` would have prevented the confusion entirely." The CLI's durable `parallel sequential: …` line is unchanged and now carries the named reasons.

## Tests

- `assessment_names_the_review_barrier_instead_of_a_bare_runnable_count` — rebuilds the reported queue (1 builder + 3 reviews, `max_parallel: 4`), asserts the scheduler admits exactly one, the barrier names all three, and the summary says why.
- `assessment_names_the_serial_verifier_cap_when_reviews_are_all_that_is_left` — nothing is held *behind* anything, but the serial cap is still named.
- `health_reports_what_the_scheduler_would_actually_admit` — pins `admissible + review_barrier == runnable` on the same queue, so the projection has to account for every ready task.
- `the_ready_count_breaks_out_what_the_review_barrier_is_holding` — the exact rendered strings in both languages, and silence in the two cases where the plain count is already honest.

## Verification

- `cargo test` — 657 unit + all integration targets pass, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean