### PR TITLE
fix(runtime): spawn workers in their own process group so they survive the terminal

### DIFF
--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1043,6 +1043,21 @@ fn spawn_internal(
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
+    // A worker must outlive the terminal that started it. Yardlet's contract is
+    // that quitting the orchestrator does not kill workers — the next start
+    // ADOPTS a live one — and that held for `q` but not for the window closing:
+    // a plain spawn inherits Yardlet's process group, which is the controlling
+    // pty's foreground group, so pty teardown SIGHUPs the worker too and a whole
+    // reasoning pass is lost (issue #52). Leading its own group detaches it from
+    // that signal. Safe here because all three of its stdio ends are pipes, so
+    // it never reads or writes the controlling terminal (no SIGTTIN/SIGTTOU).
+    // Deliberate termination is unaffected: the stop path writes the `cancelled`
+    // marker and kills `worker.pid` explicitly.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
 
     let attempt_raw_files = if let Some(capture) = attempt_capture {
         for path in [&capture.stdout_log, &capture.stderr_log] {

--- a/tests/worker_survives_terminal_hangup_process.rs
+++ b/tests/worker_survives_terminal_hangup_process.rs
@@ -1,0 +1,188 @@
+//! A worker must outlive the terminal that started it (issue #52).
+//!
+//! Yardlet's contract is that quitting the orchestrator does not kill workers —
+//! the next start adopts a live one. That held for `q`, but not for the window
+//! closing: a plain spawn inherits Yardlet's process group, which is the
+//! controlling pty's foreground group, so pty teardown SIGHUPs the worker too.
+//! An operator quitting the host app mid-review lost the entire reasoning pass.
+//!
+//! This reproduces the shape without a terminal: the `yardlet` child is put in
+//! its own process group (as it is when it leads a pty's foreground group), its
+//! worker is allowed to start, and then SIGHUP is delivered to **that group**.
+//! The worker must still be alive afterwards.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+mod common;
+
+fn alive(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+fn pgid_of(pid: i32) -> i32 {
+    unsafe { libc::getpgid(pid) }
+}
+
+fn must_succeed(cwd: &Path, program: &Path, args: &[&str]) {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("running {program:?} {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "{program:?} {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A worker that records its own pid and process group, then stays alive long
+/// enough for the test to signal Yardlet's group and check on it.
+fn write_worker(path: &Path) {
+    fs::write(
+        path,
+        "#!/bin/sh\n\
+         set -eu\n\
+         if [ \"${1:-}\" = \"--version\" ]; then\n\
+         \x20 printf 'fixture-worker 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         ids=\"$2\"\n\
+         cat >/dev/null\n\
+         printf '%s %s\\n' \"$$\" \"$(ps -o pgid= -p $$ | tr -d ' ')\" >\"$ids\"\n\
+         sleep 30\n\
+         printf '{}' >\"$run_dir/result.json\"\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn wait_for(path: &Path, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    path.exists()
+}
+
+#[test]
+fn a_worker_survives_a_hangup_delivered_to_yardlets_process_group() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "yardlet-worker-hangup-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    let worker = root.join("fixture-worker.sh");
+    write_worker(&worker);
+    let ids = root.join("worker-ids");
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-hangup\nsummary: worker hangup fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-hangup\nintent_id: intent-hangup\ntasks:\n  - id: YARD-001\n    title: worker hangup fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [worker outlives the terminal]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            worker.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    // Yardlet leads its own process group, exactly as it does as a terminal's
+    // foreground process group leader. SIGHUP below then targets that group and
+    // nothing else — including not this test harness.
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            std::fs::File::create(root.join("yardlet.err")).unwrap(),
+        ))
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let yardlet_pid = yardlet.id() as i32;
+    let mut yardlet = common::ChildGuard::new(yardlet);
+
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "the fixture worker never started; yardlet said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+    let recorded = fs::read_to_string(&ids).unwrap();
+    let mut parts = recorded.split_whitespace();
+    let worker_pid: i32 = parts.next().unwrap().parse().unwrap();
+    let worker_pgid: i32 = parts.next().unwrap().parse().unwrap();
+
+    let yardlet_pgid = pgid_of(yardlet_pid);
+
+    // The observable property first, so a regression reports what the operator
+    // would live through rather than an implementation detail: hang up
+    // Yardlet's whole process group, exactly as pty teardown does.
+    assert_eq!(
+        unsafe { libc::kill(-yardlet_pgid, libc::SIGHUP) },
+        0,
+        "could not signal Yardlet's process group"
+    );
+    yardlet.shutdown(Duration::from_secs(5), || {});
+    assert!(
+        alive(worker_pid),
+        "the worker died with the terminal that started it"
+    );
+
+    // And the reason it survived: it leads its own group instead of sitting in
+    // the one the hangup targets.
+    assert_eq!(
+        worker_pgid, worker_pid,
+        "the worker is not its own process group leader"
+    );
+    assert_ne!(
+        worker_pgid, yardlet_pgid,
+        "the worker shares Yardlet's process group, so pty teardown would take it down"
+    );
+
+    unsafe {
+        libc::kill(worker_pid, libc::SIGKILL);
+    }
+    drop(yardlet);
+    let _ = fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
Closes #52.

## The asymmetry

Yardlet documents that workers outlive the orchestrator — `recover_orphans`: *"if its worker is still alive (quitting Yardlet does not kill workers) — ADOPT it"* — and that adoption path is real and exercised. It held when the operator pressed `q`. It did not hold when the terminal itself went away.

The worker was spawned with a plain `cmd.spawn()`, so it inherited Yardlet's process group, which is the controlling pty's **foreground** group. Destroying the hosting terminal (closing the window, quitting an app with an embedded terminal) delivers SIGHUP to that whole group. The worker went down with the TUI mid-stream, the run sealed `failed`, and a full review reasoning pass was lost.

The issue also names the tell: validation children already opt out via `cmd.process_group(0)`, for the analogous reason. The worker — the one child that is *supposed* to outlive its parent — did not.

## The change

One call: `process_group(0)` at the worker spawn.

Safe here specifically because the worker's stdin, stdout and stderr are all pipes, so it never reads or writes the controlling terminal and cannot take SIGTTIN/SIGTTOU from being in a background group.

Deliberate termination is unaffected: the stop path writes the `cancelled` marker and kills `worker.pid` directly, which does not care about groups.

## Test

`tests/worker_survives_terminal_hangup_process.rs` reproduces the shape without needing a real terminal:

1. The `yardlet` child is spawned with `process_group(0)` — the same position it occupies as a pty's foreground process group leader. This also keeps the signal off the test harness.
2. A fixture worker records its own pid and pgid, then stays alive.
3. SIGHUP goes to **Yardlet's group**, exactly as pty teardown delivers it.
4. The worker must still be alive.

Assertion order is deliberate: the survival check comes first so a regression reports what the operator lives through ("the worker died with the terminal that started it"), with the process-group facts underneath as the explanation.

**RED verified**: with `process_group(0)` removed, the test fails on that survival assertion.

## Verification

- `cargo test` — 657 unit + all integration targets pass, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean

## Scope note

This makes the worker survive; it does not add killing the worker's whole *subtree* on a deliberate stop. The stop path still kills only `worker.pid`, so a worker that backgrounds its own grandchildren can still leave them behind — same limitation as before this change, and unchanged by it.