### PR TITLE
fix(runtime): stop the no-change guard from refusing correct review runs

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -211,6 +211,12 @@ pub fn evaluate(
                     .chain(&r.changes.files_modified)
                     .map(|p| norm(p))
                     .filter(|p| !p.is_empty() && !deleted_norm.contains(p))
+                    // The run's own artifacts are not repository output. The
+                    // disclosure check above already exempts them on the actual
+                    // side; this direction has to match or every review run —
+                    // which is REQUIRED to write report.md and forbidden to
+                    // touch code — reports its own deliverable as missing.
+                    .filter(|p| !is_current_run_artifact(p, run_id))
                     .filter(|p| {
                         // A reported directory is present when the diff holds
                         // anything under it.
@@ -354,10 +360,21 @@ pub fn evaluate(
     }
 }
 
-fn is_current_run_artifact(path: &str, run_id: &str) -> bool {
+/// Is this path one of the run's OWN artifacts (result.json, handoff.md,
+/// report.md, …) rather than a repository deliverable?
+///
+/// Matches the absolute form too, because that is what the worker is handed:
+/// an isolated serial run gets its run directory as an absolute path and the
+/// packet tells it to write `{abs}/result.json` and, for every non-implementation
+/// kind, `{abs}/report.md`. A worker echoing those paths back in `changes` is
+/// reporting its own artifacts, not lost repository output (issue #55).
+pub(crate) fn is_current_run_artifact(path: &str, run_id: &str) -> bool {
     let path = path.trim_start_matches("./").trim_matches('"');
     let root = format!(".agents/runs/{run_id}");
-    path == root || path.starts_with(&format!("{root}/"))
+    path == root
+        || path.starts_with(&format!("{root}/"))
+        || path.ends_with(&format!("/{root}"))
+        || path.contains(&format!("/{root}/"))
 }
 
 /// Paths that are sensitive (secrets/keys), escape the workspace, or are

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -368,7 +368,7 @@ pub fn evaluate(
 /// packet tells it to write `{abs}/result.json` and, for every non-implementation
 /// kind, `{abs}/report.md`. A worker echoing those paths back in `changes` is
 /// reporting its own artifacts, not lost repository output (issue #55).
-pub(crate) fn is_current_run_artifact(path: &str, run_id: &str) -> bool {
+fn is_current_run_artifact(path: &str, run_id: &str) -> bool {
     let path = path.trim_start_matches("./").trim_matches('"');
     let root = format!(".agents/runs/{run_id}");
     path == root

--- a/src/run.rs
+++ b/src/run.rs
@@ -3413,16 +3413,54 @@ fn classify_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> DeclaredP
         trimmed.to_string()
     };
     let relative = relative.trim_start_matches("./").trim_end_matches('/');
-    if relative.is_empty() {
-        return DeclaredPath::Nothing;
+    match resolve_repository_relative(relative) {
+        Resolved::Inside(path) => DeclaredPath::Repository(path),
+        Resolved::Root => DeclaredPath::Nothing,
+        Resolved::Escapes => DeclaredPath::Unplaceable(trimmed.to_string()),
     }
-    if std::path::Path::new(relative)
-        .components()
-        .any(|component| component == std::path::Component::ParentDir)
-    {
-        return DeclaredPath::Unplaceable(trimmed.to_string());
+}
+
+/// Where a repository-relative path lands once `.` and `..` are resolved
+/// LEXICALLY (no filesystem access — the path may name something that no longer
+/// exists, or never did).
+enum Resolved {
+    Inside(String),
+    /// Resolves to the repository root itself: a directory, not a deliverable.
+    Root,
+    /// Climbs out of the repository however it was spelled.
+    Escapes,
+}
+
+/// Resolve `.` and `..` inside a repository-relative path.
+///
+/// Rejecting any path that merely CONTAINS `..` is too blunt: `src/../tests/x.rs`
+/// names a file that is squarely inside the repository, and treating it as
+/// unplaceable stops it gating a no-change outcome — silently re-opening
+/// issue #55 for that spelling, while telling the operator the path is
+/// "outside this workspace".
+fn resolve_repository_relative(relative: &str) -> Resolved {
+    use std::path::Component;
+
+    let mut parts: Vec<&str> = Vec::new();
+    for component in std::path::Path::new(relative).components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => match part.to_str() {
+                Some(part) => parts.push(part),
+                None => return Resolved::Escapes,
+            },
+            Component::ParentDir => {
+                if parts.pop().is_none() {
+                    return Resolved::Escapes;
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => return Resolved::Escapes,
+        }
     }
-    DeclaredPath::Repository(relative.to_string())
+    if parts.is_empty() {
+        return Resolved::Root;
+    }
+    Resolved::Inside(parts.join("/"))
 }
 
 /// Declared outputs Yardlet could not place in the repository.
@@ -3438,15 +3476,25 @@ fn unplaceable_declared_outputs(
     let Some(result) = result else {
         return Vec::new();
     };
+    let unplaceable_only = |path: &String| match classify_declared_path(path, roots) {
+        DeclaredPath::Unplaceable(path) => Some(path),
+        _ => None,
+    };
+    // A path the worker also declared deleted was not left behind, so reporting
+    // it would be noise in exactly the scratch-file case this branch exists for.
+    let deleted = result
+        .changes
+        .files_deleted
+        .iter()
+        .filter_map(unplaceable_only)
+        .collect::<HashSet<_>>();
     let mut unplaceable = result
         .changes
         .files_created
         .iter()
         .chain(&result.changes.files_modified)
-        .filter_map(|path| match classify_declared_path(path, roots) {
-            DeclaredPath::Unplaceable(path) => Some(path),
-            _ => None,
-        })
+        .filter_map(unplaceable_only)
+        .filter(|path| !deleted.contains(path))
         .collect::<Vec<_>>();
     unplaceable.sort();
     unplaceable.dedup();
@@ -7112,12 +7160,32 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             workspace: &ws.root,
         };
         // Declared outputs Yardlet cannot place are not repository deliverables
-        // and must not flip a correct run, but they must not vanish either.
-        for path in unplaceable_declared_outputs(result.as_ref(), &declared_path_roots) {
-            lines.push(format!(
-                "{}: declared output {path} is outside this workspace; Yardlet did not integrate it",
-                task.id
-            ));
+        // and must not flip a correct run, but they must not vanish either. The
+        // run lines are transient — a background or parallel drain may never put
+        // them in front of anyone — so the record goes in the handoff too.
+        let unplaceable = unplaceable_declared_outputs(result.as_ref(), &declared_path_roots);
+        if !unplaceable.is_empty() {
+            for path in &unplaceable {
+                lines.push(format!(
+                    "{}: declared output {path} is outside this workspace; Yardlet did not integrate it",
+                    task.id
+                ));
+            }
+            let note = format!(
+                "\n## Declared outputs outside the workspace\n\nThe worker declared these paths, \
+                 which are not inside this repository:\n\n{}\n\nYardlet did not integrate them and \
+                 cannot say anything about them. They are recorded here so they are not lost \
+                 silently; nothing about this run's state depends on them.\n",
+                unplaceable
+                    .iter()
+                    .map(|path| format!("- `{path}`"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+            let handoff = run_dir.join("handoff.md");
+            let mut existing = std::fs::read_to_string(&handoff).unwrap_or_default();
+            existing.push_str(&note);
+            let _ = state::write_str(&handoff, &existing);
         }
         if !m.auto_commit {
             let has_changes = evidence
@@ -12523,8 +12591,15 @@ printf "# worker handoff
             );
         }
 
-        // A root directory itself is neither a deliverable nor a lost output.
-        for root_path in ["/ws", "/ws/.agents/worktrees/run-test", "/ws/"] {
+        // A root directory itself is neither a deliverable nor a lost output —
+        // including when `..` walks back to it.
+        for root_path in [
+            "/ws",
+            "/ws/.agents/worktrees/run-test",
+            "/ws/",
+            "src/..",
+            "./",
+        ] {
             let declared = result(&[root_path], &[], &[]);
             assert_eq!(contradiction(&declared, &[]), None, "{root_path}");
             assert!(
@@ -12532,6 +12607,41 @@ printf "# worker handoff
                 "{root_path} must not be reported as a lost output"
             );
         }
+
+        // An interior `..` that still lands INSIDE the repository names a real
+        // file. Treating "contains .." as unplaceable stops it gating, which is
+        // issue #55 re-opened for that spelling — and tells the operator the
+        // path is "outside this workspace", which it is not.
+        for (inside, resolved) in [
+            ("src/../tests/regression.rs", "tests/regression.rs"),
+            (
+                "./crates/a/../tests/regression.rs",
+                "crates/tests/regression.rs",
+            ),
+            ("/ws/src/../tests/regression.rs", "tests/regression.rs"),
+            (
+                "/ws/.agents/worktrees/run-test/src/../tests/regression.rs",
+                "tests/regression.rs",
+            ),
+        ] {
+            assert_eq!(
+                contradiction(&result(&[inside], &[], &[]), &[]),
+                Some((
+                    "no_change_contradicts_declared_outputs",
+                    vec![resolved.to_string()]
+                )),
+                "{inside} resolves inside the repository and must still gate"
+            );
+        }
+
+        // A declared output that is created and then deleted is not left
+        // behind, wherever it lives.
+        let scratch = result(&["/outside/scratch.txt"], &[], &["/outside/scratch.txt"]);
+        assert_eq!(contradiction(&scratch, &[]), None);
+        assert!(
+            unplaceable_declared_outputs(Some(&scratch), &roots).is_empty(),
+            "a created-then-deleted scratch file must not be reported as lost"
+        );
 
         // A run that genuinely produced nothing stays a clean no-op.
         assert_eq!(contradiction(&result(&[], &[], &[]), &[]), None);

--- a/src/run.rs
+++ b/src/run.rs
@@ -3346,34 +3346,73 @@ fn worker_changed_integratable_path(evidence: Option<&[String]>) -> bool {
         .unwrap_or(false)
 }
 
+/// A worker-declared path as a workspace-relative one, or `None` when it cannot
+/// be attributed to this repository.
+///
+/// `changes` is free-form worker text and the packet itself hands out ABSOLUTE
+/// paths (an isolated serial run receives its run directory as one), so a
+/// declared path arrives in either form. That matters because
+/// `is_integratable_path` tests the `.agents/` prefix lexically: an absolute
+/// `/ws/.agents/runs/<id>/report.md` sails past it and would be read as a lost
+/// repository deliverable (issue #55 remediation).
+///
+/// A path outside the workspace is dropped rather than guessed at. That is
+/// deliberately the fail-OPEN direction for this guard: refusing to integrate
+/// on an unattributable path would strand a correct run, and the forbidden-path
+/// gate already fails a run whose ACTUAL diff escapes the workspace.
+fn workspace_relative_declared_path(raw: &str, ws_root: &std::path::Path) -> Option<String> {
+    let trimmed = raw.trim().trim_matches('"');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let path = std::path::Path::new(trimmed);
+    if !path.is_absolute() {
+        let relative = trimmed.trim_start_matches("./");
+        return (!relative.is_empty()).then(|| relative.to_string());
+    }
+    let canonical_root = ws_root.canonicalize();
+    let root = canonical_root.as_deref().unwrap_or(ws_root);
+    path.strip_prefix(root)
+        .or_else(|_| path.strip_prefix(ws_root))
+        .ok()
+        .and_then(|relative| relative.to_str())
+        .map(|relative| relative.trim_start_matches("./").to_string())
+        .filter(|relative| !relative.is_empty())
+}
+
 /// Repository outputs the worker DECLARED in result.json, normalized and
 /// reduced to the paths a no-change integration would silently drop.
 ///
 /// Receipted core and dependency input overlays are core-delivered validation
 /// inputs, not worker outputs, so naming one is not a missing deliverable. A
-/// path the worker also declared deleted is not one either.
+/// path the worker also declared deleted is not one either, and neither are the
+/// run's OWN artifacts — every non-implementation task is REQUIRED to write
+/// `report.md` into its run directory and forbidden to touch code, so counting
+/// that as lost repository output would fail exactly the runs that behaved.
 fn declared_integratable_outputs(
     result: Option<&RunResult>,
+    ws_root: &std::path::Path,
+    run_id: &str,
     core_input_overlays: &[state::SerialInputOverlay],
     dependency_input_overlays: &[state::DependencyInputOverlay],
 ) -> Vec<String> {
     let Some(result) = result else {
         return Vec::new();
     };
-    let norm = |path: &String| path.trim_start_matches("./").trim_matches('"').to_string();
+    let norm = |path: &String| workspace_relative_declared_path(path, ws_root);
     let deleted = result
         .changes
         .files_deleted
         .iter()
-        .map(norm)
+        .filter_map(norm)
         .collect::<HashSet<_>>();
     let mut declared = result
         .changes
         .files_created
         .iter()
         .chain(&result.changes.files_modified)
-        .map(norm)
-        .filter(|path| !path.is_empty())
+        .filter_map(norm)
+        .filter(|path| !evaluator::is_current_run_artifact(path, run_id))
         .filter(|path| evaluator::is_integratable_path(path))
         .filter(|path| !deleted.contains(path))
         .filter(|path| {
@@ -3408,23 +3447,37 @@ fn declared_integratable_outputs(
 ///
 /// Returning a typed reason lets finalization fail closed to Partial and keep
 /// the worktree instead of shipping a green report over lost work.
+///
+/// Only the `Integration::NoChanges` caller can actually see the first case:
+/// the auto_commit-off caller reaches this only when its own evidence check
+/// already found nothing integratable. Both call it anyway so neither has to
+/// re-derive the rule, but the evidence arm is dead at that second site.
 fn no_change_contradiction(
     result: Option<&RunResult>,
     evidence: Option<&[String]>,
+    ws_root: &std::path::Path,
+    run_id: &str,
     core_input_overlays: &[state::SerialInputOverlay],
     dependency_input_overlays: &[state::DependencyInputOverlay],
 ) -> Option<(&'static str, Vec<String>)> {
     if worker_changed_integratable_path(evidence) {
-        let paths = evidence
+        let mut paths = evidence
             .unwrap_or_default()
             .iter()
+            .filter_map(|path| workspace_relative_declared_path(path, ws_root))
             .filter(|path| evaluator::is_integratable_path(path))
-            .cloned()
             .collect::<Vec<_>>();
+        paths.sort();
+        paths.dedup();
         return Some(("no_change_contradicts_change_evidence", paths));
     }
-    let declared =
-        declared_integratable_outputs(result, core_input_overlays, dependency_input_overlays);
+    let declared = declared_integratable_outputs(
+        result,
+        ws_root,
+        run_id,
+        core_input_overlays,
+        dependency_input_overlays,
+    );
     if !declared.is_empty() {
         return Some(("no_change_contradicts_declared_outputs", declared));
     }
@@ -4717,12 +4770,10 @@ fn recovery_integration_provenance(
     worktree: &std::path::Path,
     branch: &str,
 ) -> IntegrationProvenance {
-    if ws
-        .checkpoints_dir()
-        .join("no-change")
-        .join(format!("{run_id}.yaml"))
-        .exists()
-    {
+    // Read through the loader, not the pending path: a settled receipt now
+    // lives in the `reconciled/` archive, and a raw path check would express
+    // "this run already recorded a no-op" against half the store (issue #43).
+    if ws.load_no_change_receipt(run_id).is_ok() {
         return IntegrationProvenance::Unknown;
     }
     let Some(record) = record else {
@@ -5078,7 +5129,19 @@ fn reconcile_integrated_cleanups(ws: &Workspace, msgs: &mut Vec<String>) {
         for warning in cleanup.warnings {
             msgs.push(format!("{}: {warning}", receipt.task_id));
         }
-        let _ = persist_integrated_cleanup_projection(&run_dir, &receipt, cleanup.complete);
+        // Keep the receipt in the scanned set when its projection could not be
+        // written: retiring it here would leave run.yaml permanently stale with
+        // no retry path, which is exactly what staying pending used to fix. The
+        // no-change sibling above skips the same way.
+        if let Err(error) =
+            persist_integrated_cleanup_projection(&run_dir, &receipt, cleanup.complete)
+        {
+            msgs.push(format!(
+                "{}: could not persist Git cleanup projection: {error}",
+                receipt.task_id
+            ));
+            continue;
+        }
         if cleanup.complete {
             if !was_complete {
                 msgs.push(format!(
@@ -7027,6 +7090,8 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     } else if let Some((reason, paths)) = no_change_contradiction(
                         result.as_ref(),
                         evidence.as_deref(),
+                        &ws.root,
+                        run_id,
                         m.core_input_overlays,
                         m.dependency_input_overlays,
                     ) {
@@ -7183,6 +7248,8 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     if let Some((reason, paths)) = no_change_contradiction(
                         result.as_ref(),
                         evidence.as_deref(),
+                        &ws.root,
+                        run_id,
                         m.core_input_overlays,
                         m.dependency_input_overlays,
                     ) {
@@ -12006,6 +12073,108 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         let _ = std::fs::remove_dir_all(ws.root);
     }
 
+    /// A `review` task is REQUIRED by the packet to write `report.md` into its
+    /// run directory, is forbidden to touch code, and is handed that directory
+    /// as an ABSOLUTE path. It therefore finishes with zero repository changes
+    /// while honestly declaring an absolute run-artifact path — the exact shape
+    /// the no-change guard must not mistake for lost output (issue #55
+    /// remediation).
+    #[test]
+    fn a_review_run_declaring_its_own_report_still_lands_done() {
+        let source = std::env::temp_dir().join(format!(
+            "yard-review-artifact-source-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&source);
+        std::fs::create_dir_all(&source).unwrap();
+        let worker = write_worker_script(
+            &source,
+            "review-worker.sh",
+            r##"#!/bin/sh
+run_dir="$1"
+run_id=$(basename "$run_dir")
+packet=$(cat)
+task_id=$(printf "%s" "$packet" | sed -n 's/^# Yardlet task packet: //p' | head -n 1)
+printf "# findings
+" > "$run_dir/report.md"
+cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "$task_id",
+  "status": "done",
+  "intent_adherence": { "drift_detected": false, "notes": "" },
+  "changes": {
+    "files_modified": [],
+    "files_created": ["$run_dir/report.md"],
+    "files_deleted": []
+  },
+  "validation": { "commands_run": [], "passed": true, "failures": [] },
+  "question_for_user": null,
+  "compact_summary": "review produced findings, no code changes",
+  "verdict": [{ "criterion_id": "AC-001", "pass": true, "evidence": "read the code" }],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+printf "# worker handoff
+" > "$run_dir/handoff.md"
+"##,
+        );
+        let worker_yaml = format!(
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            shell_literal(&worker)
+        );
+        let ws = init_test_workspace("review-artifact", &worker_yaml);
+        let mut config = std::fs::read_to_string(ws.config_path()).unwrap();
+        config.push_str("auto_commit: true\n");
+        write_str(&ws.config_path(), &config).unwrap();
+        let mut review = task("YARD-REVIEW", TaskState::Queued, 10, false);
+        review.kind = "review".into();
+        let mut q = queue(vec![review]);
+        q.intent_id = "intent-test".into();
+        ws.save_queue(&q).unwrap();
+
+        let report = run_next(
+            &ws,
+            &RunOptions {
+                execute: true,
+                target: Some("YARD-REVIEW".into()),
+                ..opts()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            report.result_state,
+            Some(TaskState::Done),
+            "a review that wrote only its own report must not be refused as a lost deliverable: {:?}",
+            report.lines
+        );
+        assert!(
+            !report.run_dir.join("partial-reason").exists(),
+            "no partial-reason should have been written: {:?}",
+            std::fs::read_to_string(report.run_dir.join("partial-reason"))
+        );
+        let evaluation: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(report.run_dir.join("evaluation.json")).unwrap(),
+        )
+        .unwrap();
+        let presence = evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == "reported_changes_present")
+            .unwrap_or_else(|| panic!("the evaluator no longer reports declared-path presence"));
+        assert_eq!(
+            presence["passed"], true,
+            "the run's own artifacts must not read as absent repository output: {presence}"
+        );
+
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
     #[test]
     fn no_change_contradiction_reads_evidence_before_declared_outputs() {
         let overlay = state::SerialInputOverlay {
@@ -12038,41 +12207,60 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
             resources: vec![],
         };
 
+        let root = std::path::Path::new("/ws");
+        let contradiction = |result: &RunResult, evidence: &[String]| {
+            no_change_contradiction(
+                Some(result),
+                Some(evidence),
+                root,
+                "run-test",
+                std::slice::from_ref(&overlay),
+                std::slice::from_ref(&dependency),
+            )
+        };
+
         // Change evidence outranks the self-report: staging would have committed
         // this path, so a no-change outcome contradicts Yardlet's own diff.
         let evidenced = result(&[], &[], &[]);
         assert_eq!(
-            no_change_contradiction(
-                Some(&evidenced),
-                Some(&["src/lib.rs".to_string()]),
-                &[],
-                &[]
-            ),
+            contradiction(&evidenced, &["./src/lib.rs".to_string()]),
             Some((
                 "no_change_contradicts_change_evidence",
                 vec!["src/lib.rs".to_string()]
-            ))
+            )),
+            "evidence paths must be normalized the same way declared ones are"
         );
 
         // No evidence, but the worker still claims a repository output.
         assert_eq!(
-            no_change_contradiction(
-                Some(&result(&["./tests/new.rs"], &[], &[])),
-                Some(&[]),
-                &[],
-                &[]
-            ),
+            contradiction(&result(&["./tests/new.rs"], &[], &[]), &[]),
             Some((
                 "no_change_contradicts_declared_outputs",
                 vec!["tests/new.rs".to_string()]
+            ))
+        );
+        // ...including one it declared as modified rather than created.
+        assert_eq!(
+            contradiction(&result(&[], &["src/lib.rs"], &[]), &[]),
+            Some((
+                "no_change_contradicts_declared_outputs",
+                vec!["src/lib.rs".to_string()]
+            ))
+        );
+        // ...and stated as an absolute path inside the workspace.
+        assert_eq!(
+            contradiction(&result(&["/ws/docs/lost.md"], &[], &[]), &[]),
+            Some((
+                "no_change_contradicts_declared_outputs",
+                vec!["docs/lost.md".to_string()]
             ))
         );
 
         // Core-delivered inputs, canonical/runtime state, and a path the worker
         // also declared deleted are not missing deliverables.
         assert_eq!(
-            no_change_contradiction(
-                Some(&result(
+            contradiction(
+                &result(
                     &[
                         ".agents/skills/seeded/SKILL.md",
                         "dependency-output.txt",
@@ -12081,17 +12269,49 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
                     ],
                     &[],
                     &["scratch.txt"],
-                )),
-                Some(&[]),
-                std::slice::from_ref(&overlay),
-                std::slice::from_ref(&dependency),
+                ),
+                &[]
             ),
             None
         );
 
-        // A run that genuinely produced nothing stays a clean no-op.
+        // The run's OWN artifacts are not repository output. Every
+        // non-implementation task is required to write report.md into its run
+        // directory and forbidden to touch code, and the packet hands it that
+        // directory as an ABSOLUTE path — so a review that behaved perfectly
+        // reports exactly these and must not be flipped to Partial.
         assert_eq!(
-            no_change_contradiction(Some(&result(&[], &[], &[])), Some(&[]), &[], &[]),
+            contradiction(
+                &result(
+                    &[
+                        "/ws/.agents/runs/run-test/report.md",
+                        "/ws/.agents/runs/run-test/result.json",
+                        ".agents/runs/run-test/handoff.md",
+                    ],
+                    &[],
+                    &[]
+                ),
+                &[]
+            ),
+            None,
+            "a review run's own artifacts must not read as lost repository output"
+        );
+
+        // A path that cannot be attributed to this workspace is dropped rather
+        // than guessed at: refusing to integrate on it would strand a correct
+        // run, and the forbidden-path gate already covers an actual diff that
+        // escapes the workspace.
+        assert_eq!(
+            contradiction(&result(&["/elsewhere/other.md"], &[], &[]), &[]),
+            None
+        );
+
+        // A run that genuinely produced nothing stays a clean no-op.
+        assert_eq!(contradiction(&result(&[], &[], &[]), &[]), None);
+
+        // No result.json at all: nothing is declared, so nothing is contradicted.
+        assert_eq!(
+            no_change_contradiction(None, Some(&[]), root, "run-test", &[], &[]),
             None
         );
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -3363,10 +3363,11 @@ struct DeclaredPathRoots<'a> {
 enum DeclaredPath {
     /// Placed in the repository. Judged by the normal integration rules.
     Repository(String),
-    /// Absolute and outside every root Yardlet owns. Not a repository
-    /// deliverable, so it cannot contradict an honest no-change outcome — but
-    /// it is still reported, because silently forgetting a declared output is
-    /// the failure this whole guard exists to prevent.
+    /// Outside every root Yardlet owns — an absolute path elsewhere, or a
+    /// relative one that climbs out. Not a repository deliverable, so it
+    /// cannot contradict an honest no-change outcome, but it is still
+    /// reported: silently forgetting a declared output is the failure this
+    /// whole guard exists to prevent.
     Unplaceable(String),
     /// Empty, or a root directory itself. Nothing to attribute either way.
     Nothing,
@@ -3392,6 +3393,11 @@ fn classify_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> DeclaredP
     }
     let path = std::path::Path::new(trimmed);
     let relative = if path.is_absolute() {
+        // Resolve `.`/`..` BEFORE stripping. A `..` that crosses a root
+        // boundary — `<worktree>/../../../docs/x.md` names a real file in the
+        // owning root — otherwise defeats every `strip_prefix` and the path
+        // looks unplaceable.
+        let path = &lexically_normalized(path);
         let mut candidates = Vec::new();
         for root in [roots.worktree, roots.workspace] {
             if let Ok(canonical) = root.canonicalize() {
@@ -3407,7 +3413,9 @@ fn classify_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> DeclaredP
             // A root itself is a directory, not a deliverable.
             Some("") => return DeclaredPath::Nothing,
             Some(relative) => relative.to_string(),
-            None => return DeclaredPath::Unplaceable(trimmed.to_string()),
+            // Report the normalized spelling so two spellings of the same
+            // outside path dedupe and cancel against each other.
+            None => return DeclaredPath::Unplaceable(path.display().to_string()),
         }
     } else {
         trimmed.to_string()
@@ -3418,6 +3426,26 @@ fn classify_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> DeclaredP
         Resolved::Root => DeclaredPath::Nothing,
         Resolved::Escapes => DeclaredPath::Unplaceable(trimmed.to_string()),
     }
+}
+
+/// Resolve `.` and `..` in an absolute path lexically, without touching the
+/// filesystem. `..` at the root stays at the root, as the kernel does.
+fn lexically_normalized(path: &std::path::Path) -> std::path::PathBuf {
+    use std::path::Component;
+
+    let mut out = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !out.pop() {
+                    out.push(component.as_os_str());
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
 }
 
 /// Where a repository-relative path lands once `.` and `..` are resolved
@@ -3465,10 +3493,11 @@ fn resolve_repository_relative(relative: &str) -> Resolved {
 
 /// Declared outputs Yardlet could not place in the repository.
 ///
-/// These never contradict a no-change outcome: an absolute path outside every
-/// root Yardlet owns is not a repository deliverable, and flipping a correct
-/// run to Partial over a worker's scratch file would recreate the very
-/// false positive this guard was corrected for. They are surfaced instead.
+/// These never contradict a no-change outcome: a path outside every root
+/// Yardlet owns — absolute, or relative and climbing out — is not a repository
+/// deliverable, and flipping a correct run to Partial over a worker's scratch
+/// file would recreate the very false positive this guard was corrected for.
+/// They are surfaced instead.
 fn unplaceable_declared_outputs(
     result: Option<&RunResult>,
     roots: &DeclaredPathRoots<'_>,
@@ -12586,10 +12615,28 @@ printf "# worker handoff
             );
             assert_eq!(
                 unplaceable_declared_outputs(Some(&declared), &roots),
-                vec![outside.to_string()],
-                "{outside} must still be surfaced"
+                vec!["/elsewhere/other.md".to_string()],
+                "{outside} must be surfaced, in one normalized spelling"
             );
         }
+
+        // An absolute `..` that crosses a root boundary still names a real
+        // repository file, so it must gate rather than read as "outside this
+        // workspace". Stripping before resolving would miss it.
+        assert_eq!(
+            contradiction(
+                &result(
+                    &["/ws/.agents/worktrees/run-test/../../../docs/lost.md"],
+                    &[],
+                    &[]
+                ),
+                &[]
+            ),
+            Some((
+                "no_change_contradicts_declared_outputs",
+                vec!["docs/lost.md".to_string()]
+            ))
+        );
 
         // A root directory itself is neither a deliverable nor a lost output —
         // including when `..` walks back to it.

--- a/src/run.rs
+++ b/src/run.rs
@@ -3346,69 +3346,111 @@ fn worker_changed_integratable_path(evidence: Option<&[String]>) -> bool {
         .unwrap_or(false)
 }
 
-/// Where a worker-declared absolute path can be resolved from. The worktree
-/// comes FIRST and is not optional to get right: an isolated serial run's cwd
-/// IS the worktree, so a path the worker forms from its own cwd resolves
-/// against the owning root as `.agents/worktrees/<run>/…` — which the harness
-/// allowlist rejects, silently dropping a real deliverable.
+/// Where a worker-declared absolute path can be resolved from.
+///
+/// The worktree is FIRST and is not optional: an isolated serial run's cwd IS
+/// the worktree, so a path the worker forms from its own cwd resolves against
+/// the owning root as `.agents/worktrees/<run>/…`, which the harness allowlist
+/// rejects — silently dropping a real deliverable. Making the field mandatory
+/// keeps that mistake unrepresentable.
 struct DeclaredPathRoots<'a> {
-    worktree: Option<&'a std::path::Path>,
+    worktree: &'a std::path::Path,
     workspace: &'a std::path::Path,
 }
 
-/// A worker-declared path as a REPOSITORY-relative one, or `None` when it
-/// cannot be placed in this repository.
+/// What a worker-declared path is, once Yardlet tries to place it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeclaredPath {
+    /// Placed in the repository. Judged by the normal integration rules.
+    Repository(String),
+    /// Absolute and outside every root Yardlet owns. Not a repository
+    /// deliverable, so it cannot contradict an honest no-change outcome — but
+    /// it is still reported, because silently forgetting a declared output is
+    /// the failure this whole guard exists to prevent.
+    Unplaceable(String),
+    /// Empty, or a root directory itself. Nothing to attribute either way.
+    Nothing,
+}
+
+/// Classify one worker-declared path.
 ///
 /// `changes` is free-form worker text and the packet itself hands out ABSOLUTE
 /// paths (an isolated serial run receives its run directory as one), so a
 /// declared path arrives in either form. That matters because
 /// `is_integratable_path` tests the `.agents/` prefix lexically: an absolute
 /// `/ws/.agents/runs/<id>/report.md` sails past it and would be read as a lost
-/// repository deliverable (issue #55 remediation).
+/// repository deliverable (issue #55).
 ///
-/// Both roots are tried against their canonical form too, because macOS resolves
-/// the temp roots these run under through `/private`.
-///
-/// `None` means "not attributable", and the caller keeps the raw path rather
-/// than discarding it: a declared output Yardlet cannot place is not evidence
-/// that nothing was lost. A stripped result that still escapes upward is
-/// treated the same way, so `/ws/../elsewhere/x` and `/elsewhere/x` cannot
-/// reach opposite verdicts.
-fn repository_relative_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> Option<String> {
+/// Each root is tried in canonical and literal form, because macOS resolves the
+/// temp roots these run under through `/private`. A result that still climbs out
+/// of the repository is `Unplaceable`, so `/ws/../elsewhere/x` and
+/// `/elsewhere/x` cannot reach opposite verdicts.
+fn classify_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> DeclaredPath {
     let trimmed = raw.trim().trim_matches('"');
     if trimmed.is_empty() {
-        return None;
+        return DeclaredPath::Nothing;
     }
     let path = std::path::Path::new(trimmed);
     let relative = if path.is_absolute() {
         let mut candidates = Vec::new();
-        for root in roots.worktree.into_iter().chain([roots.workspace]) {
+        for root in [roots.worktree, roots.workspace] {
             if let Ok(canonical) = root.canonicalize() {
                 candidates.push(canonical);
             }
             candidates.push(root.to_path_buf());
         }
-        candidates
+        match candidates
             .iter()
             .find_map(|root| path.strip_prefix(root).ok())
             .and_then(|relative| relative.to_str())
-            .map(str::to_string)?
+        {
+            // A root itself is a directory, not a deliverable.
+            Some("") => return DeclaredPath::Nothing,
+            Some(relative) => relative.to_string(),
+            None => return DeclaredPath::Unplaceable(trimmed.to_string()),
+        }
     } else {
         trimmed.to_string()
     };
     let relative = relative.trim_start_matches("./").trim_end_matches('/');
     if relative.is_empty() {
-        return None;
+        return DeclaredPath::Nothing;
     }
-    // A path that still climbs out of the repository is not repository-relative,
-    // however it was spelled.
     if std::path::Path::new(relative)
         .components()
         .any(|component| component == std::path::Component::ParentDir)
     {
-        return None;
+        return DeclaredPath::Unplaceable(trimmed.to_string());
     }
-    Some(relative.to_string())
+    DeclaredPath::Repository(relative.to_string())
+}
+
+/// Declared outputs Yardlet could not place in the repository.
+///
+/// These never contradict a no-change outcome: an absolute path outside every
+/// root Yardlet owns is not a repository deliverable, and flipping a correct
+/// run to Partial over a worker's scratch file would recreate the very
+/// false positive this guard was corrected for. They are surfaced instead.
+fn unplaceable_declared_outputs(
+    result: Option<&RunResult>,
+    roots: &DeclaredPathRoots<'_>,
+) -> Vec<String> {
+    let Some(result) = result else {
+        return Vec::new();
+    };
+    let mut unplaceable = result
+        .changes
+        .files_created
+        .iter()
+        .chain(&result.changes.files_modified)
+        .filter_map(|path| match classify_declared_path(path, roots) {
+            DeclaredPath::Unplaceable(path) => Some(path),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    unplaceable.sort();
+    unplaceable.dedup();
+    unplaceable
 }
 
 /// Repository outputs the worker DECLARED in result.json, normalized and
@@ -3422,9 +3464,8 @@ fn repository_relative_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -
 /// against the right root matters, since every non-implementation task is
 /// REQUIRED to write `report.md` there and forbidden to touch code.
 ///
-/// A path that cannot be placed in the repository is kept VERBATIM rather than
-/// dropped. Yardlet did not integrate it and cannot prove anything about it, so
-/// silently forgetting it would be the same silent loss issue #55 is about.
+/// A path Yardlet cannot place is NOT here — see [`unplaceable_declared_outputs`],
+/// which reports it without letting it flip a correct run.
 fn declared_integratable_outputs(
     result: Option<&RunResult>,
     roots: &DeclaredPathRoots<'_>,
@@ -3434,23 +3475,22 @@ fn declared_integratable_outputs(
     let Some(result) = result else {
         return Vec::new();
     };
-    let norm = |path: &String| {
-        repository_relative_declared_path(path, roots)
-            .unwrap_or_else(|| path.trim().trim_matches('"').to_string())
+    let repository = |path: &String| match classify_declared_path(path, roots) {
+        DeclaredPath::Repository(path) => Some(path),
+        _ => None,
     };
     let deleted = result
         .changes
         .files_deleted
         .iter()
-        .map(norm)
+        .filter_map(repository)
         .collect::<HashSet<_>>();
     let mut declared = result
         .changes
         .files_created
         .iter()
         .chain(&result.changes.files_modified)
-        .map(norm)
-        .filter(|path| !path.is_empty())
+        .filter_map(repository)
         .filter(|path| evaluator::is_integratable_path(path))
         .filter(|path| !deleted.contains(path))
         .filter(|path| {
@@ -7065,6 +7105,20 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         .then(|| recovery_git_finish_ownership(ws, run_id, &task.id))
         .flatten();
     if let Some(m) = &merge {
+        // The worker's cwd IS the worktree, so a path it forms from its own cwd
+        // must resolve against that first (issue #55).
+        let declared_path_roots = DeclaredPathRoots {
+            worktree: m.wt_path,
+            workspace: &ws.root,
+        };
+        // Declared outputs Yardlet cannot place are not repository deliverables
+        // and must not flip a correct run, but they must not vanish either.
+        for path in unplaceable_declared_outputs(result.as_ref(), &declared_path_roots) {
+            lines.push(format!(
+                "{}: declared output {path} is outside this workspace; Yardlet did not integrate it",
+                task.id
+            ));
+        }
         if !m.auto_commit {
             let has_changes = evidence
                 .as_ref()
@@ -7128,10 +7182,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     } else if let Some((reason, paths)) = no_change_contradiction(
                         result.as_ref(),
                         evidence.as_deref(),
-                        &DeclaredPathRoots {
-                            worktree: Some(m.wt_path),
-                            workspace: &ws.root,
-                        },
+                        &declared_path_roots,
                         m.core_input_overlays,
                         m.dependency_input_overlays,
                     ) {
@@ -7288,10 +7339,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     if let Some((reason, paths)) = no_change_contradiction(
                         result.as_ref(),
                         evidence.as_deref(),
-                        &DeclaredPathRoots {
-                            worktree: Some(m.wt_path),
-                            workspace: &ws.root,
-                        },
+                        &declared_path_roots,
                         m.core_input_overlays,
                         m.dependency_input_overlays,
                     ) {
@@ -12115,6 +12163,106 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         let _ = std::fs::remove_dir_all(ws.root);
     }
 
+    /// The wiring, not just the helper: a worker that names a deliverable from
+    /// its OWN cwd (the worktree) while actually writing it somewhere Yardlet
+    /// does not integrate must still be caught. Resolving that path against the
+    /// owning root instead lands it under `.agents/worktrees/**`, which the
+    /// allowlist rejects — so the guard goes silent and issue #55 ships again.
+    /// This is the case the review-artifact test cannot see, because a run
+    /// artifact is non-integratable under either root.
+    #[test]
+    fn a_deliverable_named_from_the_worktree_is_still_caught() {
+        let source = std::env::temp_dir().join(format!(
+            "yard-worktree-declared-source-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&source);
+        std::fs::create_dir_all(&source).unwrap();
+        let owning_root =
+            std::env::temp_dir().join(format!("yard-worktree-declared-{}", std::process::id()));
+        // The worker declares `<its cwd>/tests/new.rs` but writes the file into
+        // the owning root, so its own worktree diff stays empty.
+        let worker = write_worker_script(
+            &source,
+            "worktree-declaring-worker.sh",
+            r##"#!/bin/sh
+run_dir="$1"
+owning_root="$2"
+run_id=$(basename "$run_dir")
+packet=$(cat)
+task_id=$(printf "%s" "$packet" | sed -n 's/^# Yardlet task packet: //p' | head -n 1)
+mkdir -p "$owning_root/tests"
+printf "// deliverable\n" > "$owning_root/tests/new.rs"
+cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "$task_id",
+  "status": "done",
+  "intent_adherence": { "drift_detected": false, "notes": "" },
+  "changes": {
+    "files_modified": [],
+    "files_created": ["$(pwd)/tests/new.rs"],
+    "files_deleted": []
+  },
+  "validation": { "commands_run": [], "passed": true, "failures": [] },
+  "question_for_user": null,
+  "compact_summary": "declared from the worktree, written elsewhere",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+printf "# worker handoff\n" > "$run_dir/handoff.md"
+"##,
+        );
+        let worker_yaml = format!(
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            shell_literal(&worker),
+            shell_literal(&owning_root)
+        );
+        let ws = init_test_workspace("worktree-declared", &worker_yaml);
+        assert_eq!(ws.root, owning_root);
+        let mut config = std::fs::read_to_string(ws.config_path()).unwrap();
+        config.push_str("auto_commit: true\n");
+        write_str(&ws.config_path(), &config).unwrap();
+        let mut q = queue(vec![task("YARD-WT", TaskState::Queued, 10, false)]);
+        q.intent_id = "intent-test".into();
+        ws.save_queue(&q).unwrap();
+
+        let report = run_next(
+            &ws,
+            &RunOptions {
+                execute: true,
+                target: Some("YARD-WT".into()),
+                ..opts()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            report.result_state,
+            Some(TaskState::Partial),
+            "a deliverable declared from the worktree must not be dropped into \
+             .agents/worktrees/**: {:?}",
+            report.lines
+        );
+        assert_eq!(
+            std::fs::read_to_string(report.run_dir.join("partial-reason"))
+                .unwrap()
+                .trim(),
+            "no_change_contradicts_declared_outputs"
+        );
+        let handoff = std::fs::read_to_string(report.run_dir.join("handoff.md")).unwrap();
+        assert!(
+            handoff.contains("tests/new.rs"),
+            "the handoff must name the output, repository-relative: {handoff}"
+        );
+
+        let _ = std::fs::remove_dir_all(&source);
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
     /// A `review` task is REQUIRED by the packet to write `report.md` into its
     /// run directory, is forbidden to touch code, and is handed that directory
     /// as an ABSOLUTE path. It therefore finishes with zero repository changes
@@ -12254,7 +12402,7 @@ printf "# worker handoff
         // lands under `.agents/worktrees/...` and vanishes from the allowlist.
         let worktree = std::path::PathBuf::from("/ws/.agents/worktrees/run-test");
         let roots = DeclaredPathRoots {
-            worktree: Some(&worktree),
+            worktree: &worktree,
             workspace: std::path::Path::new("/ws"),
         };
         let contradiction = |result: &RunResult, evidence: &[String]| {
@@ -12357,18 +12505,31 @@ printf "# worker handoff
             "a review run's own artifacts must not read as lost repository output"
         );
 
-        // A path Yardlet cannot place in the repository is kept VERBATIM, not
-        // dropped: it was not integrated and nothing here can prove otherwise,
-        // so forgetting it would be the same silent loss this guard exists for.
-        // The two spellings of "outside" must also agree.
+        // A path Yardlet cannot place is not a repository deliverable, so it
+        // must NOT flip a correct run — that would recreate the false positive
+        // this guard was corrected for. It is reported instead, and the two
+        // spellings of "outside" must agree.
         for outside in ["/elsewhere/other.md", "/ws/../elsewhere/other.md"] {
+            let declared = result(&[outside], &[], &[]);
             assert_eq!(
-                contradiction(&result(&[outside], &[], &[]), &[]),
-                Some((
-                    "no_change_contradicts_declared_outputs",
-                    vec![outside.to_string()]
-                )),
-                "{outside} must not be silently forgotten"
+                contradiction(&declared, &[]),
+                None,
+                "{outside} must not flip the run"
+            );
+            assert_eq!(
+                unplaceable_declared_outputs(Some(&declared), &roots),
+                vec![outside.to_string()],
+                "{outside} must still be surfaced"
+            );
+        }
+
+        // A root directory itself is neither a deliverable nor a lost output.
+        for root_path in ["/ws", "/ws/.agents/worktrees/run-test", "/ws/"] {
+            let declared = result(&[root_path], &[], &[]);
+            assert_eq!(contradiction(&declared, &[]), None, "{root_path}");
+            assert!(
+                unplaceable_declared_outputs(Some(&declared), &roots).is_empty(),
+                "{root_path} must not be reported as a lost output"
             );
         }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -3346,8 +3346,18 @@ fn worker_changed_integratable_path(evidence: Option<&[String]>) -> bool {
         .unwrap_or(false)
 }
 
-/// A worker-declared path as a workspace-relative one, or `None` when it cannot
-/// be attributed to this repository.
+/// Where a worker-declared absolute path can be resolved from. The worktree
+/// comes FIRST and is not optional to get right: an isolated serial run's cwd
+/// IS the worktree, so a path the worker forms from its own cwd resolves
+/// against the owning root as `.agents/worktrees/<run>/…` — which the harness
+/// allowlist rejects, silently dropping a real deliverable.
+struct DeclaredPathRoots<'a> {
+    worktree: Option<&'a std::path::Path>,
+    workspace: &'a std::path::Path,
+}
+
+/// A worker-declared path as a REPOSITORY-relative one, or `None` when it
+/// cannot be placed in this repository.
 ///
 /// `changes` is free-form worker text and the packet itself hands out ABSOLUTE
 /// paths (an isolated serial run receives its run directory as one), so a
@@ -3356,63 +3366,91 @@ fn worker_changed_integratable_path(evidence: Option<&[String]>) -> bool {
 /// `/ws/.agents/runs/<id>/report.md` sails past it and would be read as a lost
 /// repository deliverable (issue #55 remediation).
 ///
-/// A path outside the workspace is dropped rather than guessed at. That is
-/// deliberately the fail-OPEN direction for this guard: refusing to integrate
-/// on an unattributable path would strand a correct run, and the forbidden-path
-/// gate already fails a run whose ACTUAL diff escapes the workspace.
-fn workspace_relative_declared_path(raw: &str, ws_root: &std::path::Path) -> Option<String> {
+/// Both roots are tried against their canonical form too, because macOS resolves
+/// the temp roots these run under through `/private`.
+///
+/// `None` means "not attributable", and the caller keeps the raw path rather
+/// than discarding it: a declared output Yardlet cannot place is not evidence
+/// that nothing was lost. A stripped result that still escapes upward is
+/// treated the same way, so `/ws/../elsewhere/x` and `/elsewhere/x` cannot
+/// reach opposite verdicts.
+fn repository_relative_declared_path(raw: &str, roots: &DeclaredPathRoots<'_>) -> Option<String> {
     let trimmed = raw.trim().trim_matches('"');
     if trimmed.is_empty() {
         return None;
     }
     let path = std::path::Path::new(trimmed);
-    if !path.is_absolute() {
-        let relative = trimmed.trim_start_matches("./");
-        return (!relative.is_empty()).then(|| relative.to_string());
+    let relative = if path.is_absolute() {
+        let mut candidates = Vec::new();
+        for root in roots.worktree.into_iter().chain([roots.workspace]) {
+            if let Ok(canonical) = root.canonicalize() {
+                candidates.push(canonical);
+            }
+            candidates.push(root.to_path_buf());
+        }
+        candidates
+            .iter()
+            .find_map(|root| path.strip_prefix(root).ok())
+            .and_then(|relative| relative.to_str())
+            .map(str::to_string)?
+    } else {
+        trimmed.to_string()
+    };
+    let relative = relative.trim_start_matches("./").trim_end_matches('/');
+    if relative.is_empty() {
+        return None;
     }
-    let canonical_root = ws_root.canonicalize();
-    let root = canonical_root.as_deref().unwrap_or(ws_root);
-    path.strip_prefix(root)
-        .or_else(|_| path.strip_prefix(ws_root))
-        .ok()
-        .and_then(|relative| relative.to_str())
-        .map(|relative| relative.trim_start_matches("./").to_string())
-        .filter(|relative| !relative.is_empty())
+    // A path that still climbs out of the repository is not repository-relative,
+    // however it was spelled.
+    if std::path::Path::new(relative)
+        .components()
+        .any(|component| component == std::path::Component::ParentDir)
+    {
+        return None;
+    }
+    Some(relative.to_string())
 }
 
 /// Repository outputs the worker DECLARED in result.json, normalized and
 /// reduced to the paths a no-change integration would silently drop.
 ///
 /// Receipted core and dependency input overlays are core-delivered validation
-/// inputs, not worker outputs, so naming one is not a missing deliverable. A
-/// path the worker also declared deleted is not one either, and neither are the
-/// run's OWN artifacts — every non-implementation task is REQUIRED to write
-/// `report.md` into its run directory and forbidden to touch code, so counting
-/// that as lost repository output would fail exactly the runs that behaved.
+/// inputs, not worker outputs, so naming one is not a missing deliverable, and
+/// neither is a path the worker also declared deleted. The run's OWN artifacts
+/// fall out on their own: normalized they live under `.agents/runs/`, which the
+/// integration allowlist already rejects — which is exactly why normalizing
+/// against the right root matters, since every non-implementation task is
+/// REQUIRED to write `report.md` there and forbidden to touch code.
+///
+/// A path that cannot be placed in the repository is kept VERBATIM rather than
+/// dropped. Yardlet did not integrate it and cannot prove anything about it, so
+/// silently forgetting it would be the same silent loss issue #55 is about.
 fn declared_integratable_outputs(
     result: Option<&RunResult>,
-    ws_root: &std::path::Path,
-    run_id: &str,
+    roots: &DeclaredPathRoots<'_>,
     core_input_overlays: &[state::SerialInputOverlay],
     dependency_input_overlays: &[state::DependencyInputOverlay],
 ) -> Vec<String> {
     let Some(result) = result else {
         return Vec::new();
     };
-    let norm = |path: &String| workspace_relative_declared_path(path, ws_root);
+    let norm = |path: &String| {
+        repository_relative_declared_path(path, roots)
+            .unwrap_or_else(|| path.trim().trim_matches('"').to_string())
+    };
     let deleted = result
         .changes
         .files_deleted
         .iter()
-        .filter_map(norm)
+        .map(norm)
         .collect::<HashSet<_>>();
     let mut declared = result
         .changes
         .files_created
         .iter()
         .chain(&result.changes.files_modified)
-        .filter_map(norm)
-        .filter(|path| !evaluator::is_current_run_artifact(path, run_id))
+        .map(norm)
+        .filter(|path| !path.is_empty())
         .filter(|path| evaluator::is_integratable_path(path))
         .filter(|path| !deleted.contains(path))
         .filter(|path| {
@@ -3455,8 +3493,7 @@ fn declared_integratable_outputs(
 fn no_change_contradiction(
     result: Option<&RunResult>,
     evidence: Option<&[String]>,
-    ws_root: &std::path::Path,
-    run_id: &str,
+    roots: &DeclaredPathRoots<'_>,
     core_input_overlays: &[state::SerialInputOverlay],
     dependency_input_overlays: &[state::DependencyInputOverlay],
 ) -> Option<(&'static str, Vec<String>)> {
@@ -3464,8 +3501,8 @@ fn no_change_contradiction(
         let mut paths = evidence
             .unwrap_or_default()
             .iter()
-            .filter_map(|path| workspace_relative_declared_path(path, ws_root))
             .filter(|path| evaluator::is_integratable_path(path))
+            .cloned()
             .collect::<Vec<_>>();
         paths.sort();
         paths.dedup();
@@ -3473,8 +3510,7 @@ fn no_change_contradiction(
     }
     let declared = declared_integratable_outputs(
         result,
-        ws_root,
-        run_id,
+        roots,
         core_input_overlays,
         dependency_input_overlays,
     );
@@ -4770,10 +4806,12 @@ fn recovery_integration_provenance(
     worktree: &std::path::Path,
     branch: &str,
 ) -> IntegrationProvenance {
-    // Read through the loader, not the pending path: a settled receipt now
-    // lives in the `reconciled/` archive, and a raw path check would express
-    // "this run already recorded a no-op" against half the store (issue #43).
-    if ws.load_no_change_receipt(run_id).is_ok() {
+    // Presence, across BOTH the pending and reconciled locations: a settled
+    // receipt now lives in the archive, so a raw pending-path check would
+    // express "this run already recorded a no-op" against half the store
+    // (issue #43). Presence rather than parseability, because a corrupt receipt
+    // is precisely the case that must still force Unknown.
+    if ws.has_no_change_receipt(run_id) {
         return IntegrationProvenance::Unknown;
     }
     let Some(record) = record else {
@@ -7090,8 +7128,10 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     } else if let Some((reason, paths)) = no_change_contradiction(
                         result.as_ref(),
                         evidence.as_deref(),
-                        &ws.root,
-                        run_id,
+                        &DeclaredPathRoots {
+                            worktree: Some(m.wt_path),
+                            workspace: &ws.root,
+                        },
                         m.core_input_overlays,
                         m.dependency_input_overlays,
                     ) {
@@ -7248,8 +7288,10 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
                     if let Some((reason, paths)) = no_change_contradiction(
                         result.as_ref(),
                         evidence.as_deref(),
-                        &ws.root,
-                        run_id,
+                        &DeclaredPathRoots {
+                            worktree: Some(m.wt_path),
+                            workspace: &ws.root,
+                        },
                         m.core_input_overlays,
                         m.dependency_input_overlays,
                     ) {
@@ -12207,13 +12249,19 @@ printf "# worker handoff
             resources: vec![],
         };
 
-        let root = std::path::Path::new("/ws");
+        // The worker's cwd IS the worktree, and its run dir is nested inside it,
+        // so both roots have to resolve or an absolutely-declared deliverable
+        // lands under `.agents/worktrees/...` and vanishes from the allowlist.
+        let worktree = std::path::PathBuf::from("/ws/.agents/worktrees/run-test");
+        let roots = DeclaredPathRoots {
+            worktree: Some(&worktree),
+            workspace: std::path::Path::new("/ws"),
+        };
         let contradiction = |result: &RunResult, evidence: &[String]| {
             no_change_contradiction(
                 Some(result),
                 Some(evidence),
-                root,
-                "run-test",
+                &roots,
                 std::slice::from_ref(&overlay),
                 std::slice::from_ref(&dependency),
             )
@@ -12223,12 +12271,11 @@ printf "# worker handoff
         // this path, so a no-change outcome contradicts Yardlet's own diff.
         let evidenced = result(&[], &[], &[]);
         assert_eq!(
-            contradiction(&evidenced, &["./src/lib.rs".to_string()]),
+            contradiction(&evidenced, &["src/lib.rs".to_string()]),
             Some((
                 "no_change_contradicts_change_evidence",
                 vec!["src/lib.rs".to_string()]
-            )),
-            "evidence paths must be normalized the same way declared ones are"
+            ))
         );
 
         // No evidence, but the worker still claims a repository output.
@@ -12247,13 +12294,26 @@ printf "# worker handoff
                 vec!["src/lib.rs".to_string()]
             ))
         );
-        // ...and stated as an absolute path inside the workspace.
+        // ...stated as an absolute path inside the workspace...
         assert_eq!(
             contradiction(&result(&["/ws/docs/lost.md"], &[], &[]), &[]),
             Some((
                 "no_change_contradicts_declared_outputs",
                 vec!["docs/lost.md".to_string()]
             ))
+        );
+        // ...and — the case a workspace-only normalizer silently drops — stated
+        // from the worker's own cwd, which is the worktree.
+        assert_eq!(
+            contradiction(
+                &result(&["/ws/.agents/worktrees/run-test/tests/new.rs"], &[], &[]),
+                &[]
+            ),
+            Some((
+                "no_change_contradicts_declared_outputs",
+                vec!["tests/new.rs".to_string()]
+            )),
+            "a deliverable named from the worktree must not resolve into .agents/worktrees/**"
         );
 
         // Core-delivered inputs, canonical/runtime state, and a path the worker
@@ -12284,7 +12344,7 @@ printf "# worker handoff
             contradiction(
                 &result(
                     &[
-                        "/ws/.agents/runs/run-test/report.md",
+                        "/ws/.agents/worktrees/run-test/.agents/runs/run-test/report.md",
                         "/ws/.agents/runs/run-test/result.json",
                         ".agents/runs/run-test/handoff.md",
                     ],
@@ -12297,21 +12357,27 @@ printf "# worker handoff
             "a review run's own artifacts must not read as lost repository output"
         );
 
-        // A path that cannot be attributed to this workspace is dropped rather
-        // than guessed at: refusing to integrate on it would strand a correct
-        // run, and the forbidden-path gate already covers an actual diff that
-        // escapes the workspace.
-        assert_eq!(
-            contradiction(&result(&["/elsewhere/other.md"], &[], &[]), &[]),
-            None
-        );
+        // A path Yardlet cannot place in the repository is kept VERBATIM, not
+        // dropped: it was not integrated and nothing here can prove otherwise,
+        // so forgetting it would be the same silent loss this guard exists for.
+        // The two spellings of "outside" must also agree.
+        for outside in ["/elsewhere/other.md", "/ws/../elsewhere/other.md"] {
+            assert_eq!(
+                contradiction(&result(&[outside], &[], &[]), &[]),
+                Some((
+                    "no_change_contradicts_declared_outputs",
+                    vec![outside.to_string()]
+                )),
+                "{outside} must not be silently forgotten"
+            );
+        }
 
         // A run that genuinely produced nothing stays a clean no-op.
         assert_eq!(contradiction(&result(&[], &[], &[]), &[]), None);
 
         // No result.json at all: nothing is declared, so nothing is contradicted.
         assert_eq!(
-            no_change_contradiction(None, Some(&[]), root, "run-test", &[], &[]),
+            no_change_contradiction(None, Some(&[]), &roots, &[], &[]),
             None
         );
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2350,6 +2350,23 @@ impl Workspace {
                 .join(format!("{run_id}.yaml")),
         )
     }
+    /// Does a no-change receipt exist for this run, readable or not?
+    ///
+    /// Presence alone is the safety-relevant question: it means the run already
+    /// recorded a no-op, so re-deriving integration provenance from a
+    /// worker-writable record would be wrong. A corrupt or unreadable receipt is
+    /// exactly the case that must still count, which a parse-based check would
+    /// let through.
+    pub fn has_no_change_receipt(&self, run_id: &str) -> bool {
+        let Ok(pending) = self.no_change_receipt_path(run_id) else {
+            return false;
+        };
+        pending.is_file()
+            || self
+                .no_change_reconciled_dir()
+                .join(format!("{run_id}.yaml"))
+                .is_file()
+    }
     /// Retire a settled no-change receipt. See
     /// [`Workspace::archive_integrated_cleanup_receipt`].
     pub fn archive_no_change_receipt(&self, run_id: &str) -> Result<()> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -6242,8 +6242,6 @@ pub(crate) fn append_private_file(path: &Path) -> Result<fs::File> {
         .with_context(|| format!("opening private evidence {}", path.display()))
 }
 
-/// Write a durable state snapshot through a same-directory temporary file so a
-/// crash cannot leave readers with a truncated JSON/YAML record.
 /// Subdirectory holding receipts whose reconciliation is finished. It carries
 /// no `.yaml` extension, so the `*_receipts` sweeps skip it the same way they
 /// skip any other non-receipt entry.
@@ -6266,6 +6264,8 @@ fn archive_receipt(pending: &Path, archive_dir: &Path) -> Result<()> {
         .with_context(|| format!("archiving {} to {}", pending.display(), archived.display()))
 }
 
+/// Write a durable state snapshot through a same-directory temporary file so a
+/// crash cannot leave readers with a truncated JSON/YAML record.
 pub fn write_str_atomic(path: &Path, contents: &str) -> Result<()> {
     write_bytes_atomic(path, contents.as_bytes())
 }


### PR DESCRIPTION
Remediation of an independent review of PR #82 (issue #55), then of two reviews of this branch. **The original defect was a HIGH-severity false positive in already-merged code.**

## The defect

`is_integratable_path` tests the `.agents/` prefix **lexically**. The packet hands the worker an **absolute** run directory — an isolated serial run (the default) gets `run_dir_rel` as an absolute path, and the packet tells it to write `{abs}/result.json`, plus `{abs}/report.md` for every non-implementation kind, while the reviewer/researcher/security role guidance says *"Make no production code changes; your deliverables are the result files and report.md."*

So the most common shape of a well-behaved review run — zero repository changes, `files_created: ["/ws/.agents/runs/run-X/report.md"]` — sailed past the `.agents/` test and was read as a repository deliverable that integration had dropped. A correct **Done** became **Partial**, the worktree was retained indefinitely, `git finish` was blocked, and the handoff told the operator their output "stayed out of Git".

Reproduced; with the fix reverted the end-to-end test fails with `next task state: ◐ partial`.

## What the fix is now

Declared paths are classified against **two roots, worktree first**:

| declared | classified | verdict |
|---|---|---|
| `./tests/new.rs` | `tests/new.rs` | repository — guard fires |
| `<worktree>/tests/new.rs` | `tests/new.rs` | repository — guard fires |
| `<worktree>/.agents/runs/<run>/report.md` | `.agents/runs/…` | repository, non-integratable — exempt |
| `src/../tests/new.rs` | `tests/new.rs` | repository — guard fires |
| `/elsewhere/other.md` | unplaceable | reported, never a contradiction |
| `../outside/x.md` | unplaceable | reported, never a contradiction |
| `/ws`, `src/..` | nothing | ignored |

**Worktree first is load-bearing, not a nicety.** The worker's cwd *is* the worktree and its run directory is nested inside it, so resolving against the owning root turns every absolutely-declared deliverable into `.agents/worktrees/<run>/…` — which the harness allowlist rejects. Getting that wrong makes the guard blind to exactly what it exists to catch, which is worse than the bug it replaced. The field is mandatory rather than `Option` so that mistake is unrepresentable, and an end-to-end test pins the wiring.

**Unplaceable paths are reported, not enforced on.** A path outside every root Yardlet owns — absolute, or relative and climbing out — is not a repository deliverable. `.` and `..` are resolved lexically first, so a path with an interior `..` that still lands inside the repository is judged as the file it actually names; rejecting anything merely containing `..` would stop it gating and re-open the hole for that spelling. Flipping a zero-change review run to Partial because its worker mentioned a `$TMPDIR` scratch file — and telling the operator to "move it in and re-run" — is the same false positive this PR corrects, on the same run kind. They are recorded on the run's lines AND in handoff.md so nothing is silently forgotten, which was the reason an earlier revision of this branch made them contradict. A path the worker also declared deleted is not reported at all.

`is_current_run_artifact` also learned the absolute form, and `reported_changes_present` applies it to the reported side; it had inherited the one-sided filter that let the original bug through (`diff_matches_report` exempts run artifacts only on the actual side).

## Also from these reviews

- **`recovery_integration_provenance`** read `checkpoints/no-change/<run>.yaml` directly, so after #43 it expressed "this run recorded a no-op" against half the store. Now `Workspace::has_no_change_receipt` checks **presence** across both locations — presence rather than parseability, because a corrupt receipt is precisely the case that must still force `Unknown`, and a loader returns `Err` on one.
- **`reconcile_integrated_cleanups`** swallowed its projection-write error and archived anyway, removing the self-healing that staying in the scanned set provided. Now skips the archive on a failed projection, matching the no-change sibling.
- The new const had been inserted between `write_str_atomic`'s doc comment and its signature.
- The evidence arm of `no_change_contradiction` is unreachable at the auto_commit-off call site; documented rather than claiming a symmetry that does not exist.

## Tests

- `a_deliverable_named_from_the_worktree_is_still_caught` — the discriminating case. RED verified by pointing the worktree root at the workspace: the run ships **Done** with the deliverable lost.
- `a_review_run_declaring_its_own_report_still_lands_done` — the reported false positive. RED verified against true pre-fix behavior.
- The table test covers absolute-inside-workspace, worktree-relative, `files_modified` (the `.chain()` branch was never exercised), run artifacts in both forms, both spellings of outside-the-workspace, root directories, and `result: None`.

## Verification

- `cargo test` — 24 targets, 793 tests, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean

## Known and deliberately not fixed here

- `Integration::Merged` still never cross-checks declared outputs, so a run that integrates *some* of what it declared ships Done with the rest uncommitted. Filed as #91 — promoting `reported_changes_present` to fatal is a policy call, and this PR is what makes it safe to consider.
- The evaluator does not normalize declared paths against the roots, so an absolute *repository* deliverable still produces a spurious "reported but absent" advisory line. Advisory only; it cannot gate Done. It becomes mandatory to fix if #91 goes the fatal route.