### PR TITLE
fix(tui): make the key list scrollable and stop the ready count claiming a number it cannot compute

### DIFF
--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -29,11 +29,11 @@ use crate::schemas::{RunnableClass, Task, TaskState, WorkQueue, WorkerProfile};
 use crate::state::{self, write_str, Workspace};
 use crate::{evaluator, guard, inspect, routing, run, workers};
 
-fn is_verifier(task: &Task) -> bool {
+pub(crate) fn is_verifier(task: &Task) -> bool {
     matches!(packet::role_for(&task.kind), "reviewer" | "security")
 }
 
-fn has_queued_non_verifier(queue: &WorkQueue) -> bool {
+pub(crate) fn has_queued_non_verifier(queue: &WorkQueue) -> bool {
     queue
         .tasks
         .iter()

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -65,7 +65,7 @@ pub fn held_by_review_barrier(queue: &WorkQueue) -> Vec<String> {
 
 /// Runnable verifiers that the barrier lets through but the serial cap still
 /// admits one at a time — the "only work left is reviews" case.
-fn serialized_verifiers(queue: &WorkQueue) -> Vec<String> {
+pub fn serialized_verifiers(queue: &WorkQueue) -> Vec<String> {
     let caps = std::collections::BTreeSet::new();
     if has_queued_non_verifier(queue) {
         return Vec::new();

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -2628,10 +2628,11 @@ pub enum PlanningReentry {
 
 /// Read-only re-entry state of the latest planning session.
 ///
-/// Deliberately lock-free and best-effort: it runs on every snapshot load, and
-/// an unreadable or half-written session is a reason to show nothing, never to
-/// fail the snapshot. Anything actionable is confirmed by the review screen
-/// itself, which takes the lock and validates properly.
+/// Deliberately lock-free: it runs on every snapshot load and must never fail
+/// the snapshot. A session that exists but cannot be read reports `Unreadable`
+/// rather than nothing — answering "nothing here" for it reproduces the
+/// invisible dead end #65 exists to kill. Anything actionable is confirmed by
+/// the review screen itself, which takes the lock and validates properly.
 pub fn reentry(ws: &Workspace) -> Option<PlanningReentry> {
     let session = match ws.load_latest_planning_session() {
         Ok(Some(session)) => session,

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -2620,6 +2620,10 @@ pub enum PlanningReentry {
     PendingProposal { count: usize },
     /// A draft was accepted and is waiting for confirm to become the queue.
     AcceptedDraft,
+    /// A session exists but could not be read. Surfaced rather than swallowed:
+    /// answering "nothing here" for an unreadable session reproduces the
+    /// invisible dead end #65 exists to kill, just quietly.
+    Unreadable,
 }
 
 /// Read-only re-entry state of the latest planning session.
@@ -2629,12 +2633,22 @@ pub enum PlanningReentry {
 /// fail the snapshot. Anything actionable is confirmed by the review screen
 /// itself, which takes the lock and validates properly.
 pub fn reentry(ws: &Workspace) -> Option<PlanningReentry> {
-    let session = ws.load_latest_planning_session().ok()??;
+    let session = match ws.load_latest_planning_session() {
+        Ok(Some(session)) => session,
+        // No session at all is the ordinary empty case; a session that exists
+        // but will not load is not.
+        Ok(None) => return None,
+        Err(_) => return Some(PlanningReentry::Unreadable),
+    };
     if session.lifecycle != PlanningLifecycle::Open {
         return None;
     }
-    let proposals = ws.load_planning_proposals(&session.session_id).ok()?;
-    let events = ws.load_planning_events(&session.session_id).ok()?;
+    let Ok(proposals) = ws.load_planning_proposals(&session.session_id) else {
+        return Some(PlanningReentry::Unreadable);
+    };
+    let Ok(events) = ws.load_planning_events(&session.session_id) else {
+        return Some(PlanningReentry::Unreadable);
+    };
     let disposed = events
         .iter()
         .filter(|event| {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -164,18 +164,23 @@ pub struct RecoveryRequired {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct QueueHealth {
     pub runnable: usize,
-    /// Runnable tasks the verifier barrier is holding back, and whether the
-    /// runnable set is reviews that will run one at a time.
+    /// Runnable tasks the verifier barrier is holding back, and runnable
+    /// reviews that will go one at a time because nothing else is queued.
     ///
     /// `runnable` alone counts tasks the scheduler will deliberately refuse to
     /// co-schedule, which reads as parallelism that never arrives (issue #51).
     ///
-    /// There is deliberately no "how many will start" number here. The parallel
-    /// selector works from an empty capability vocabulary, ignores live approval
-    /// grants, and truncates to `max_parallel`, while `runnable` uses the real
-    /// ones — so any count derived from it and printed next to `runnable` is
-    /// wrong in three independent ways. Only the barrier itself is computed from
-    /// the same inputs on both sides, so only the barrier is claimed.
+    /// Both are computed HERE, from `task_class` — the same real capability
+    /// vocabulary and live approval grants `runnable` uses. The scheduler's own
+    /// helpers deliberately work from an empty vocabulary and ignore approval
+    /// grants (so parallel selection falls through to the serial selector for
+    /// those cases), which makes them right for scheduling and wrong to print
+    /// next to `runnable`: a queue of approval-granted reviews would count 3
+    /// runnable and 0 held.
+    ///
+    /// There is deliberately no "how many will start" number. That would also
+    /// have to fold in `max_parallel`, and a count that says "1 parallelizable"
+    /// in a workspace where parallelism is switched off explains nothing.
     pub review_barrier: usize,
     pub serialized_reviews: usize,
     pub running: usize,
@@ -455,8 +460,19 @@ impl Snapshot {
                 RunnableClass::Done => health.done += 1,
             }
         }
-        health.review_barrier = crate::parallel::held_by_review_barrier(&self.queue).len();
-        health.serialized_reviews = crate::parallel::serialized_verifiers(&self.queue).len();
+        let work_pending = crate::parallel::has_queued_non_verifier(&self.queue);
+        for task in &self.queue.tasks {
+            if !crate::parallel::is_verifier(task)
+                || self.task_class(task) != RunnableClass::Runnable
+            {
+                continue;
+            }
+            if work_pending || self.queue.has_active_remediation_for(&task.id) {
+                health.review_barrier += 1;
+            } else {
+                health.serialized_reviews += 1;
+            }
+        }
         health
     }
 
@@ -722,6 +738,29 @@ mod tests {
         assert_eq!(health.runnable, 3);
         assert_eq!(health.review_barrier, 0);
         assert_eq!(health.serialized_reviews, 3);
+
+        // The counts must use the SAME inputs as `runnable`. The scheduler's own
+        // helpers work from an empty capability vocabulary and ignore approval
+        // grants, so reading them here would report 3 runnable and 0 held for a
+        // queue that is entirely reviews requiring a granted approval.
+        let mut approval_gated = reviews_only.queue.clone();
+        for task in &mut approval_gated.tasks {
+            task.approval = Some(crate::yaml::from_str("required: true").unwrap());
+        }
+        let approval_gated = Snapshot {
+            queue: approval_gated,
+            approvals_needed: Vec::new(),
+            ..reviews_only
+        };
+        let health = approval_gated.health();
+        assert_eq!(
+            health.runnable, 3,
+            "approval was granted, so these are ready"
+        );
+        assert_eq!(
+            health.serialized_reviews, 3,
+            "and the count that explains them has to agree"
+        );
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -164,13 +164,20 @@ pub struct RecoveryRequired {
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct QueueHealth {
     pub runnable: usize,
-    /// How many of `runnable` the scheduler would actually start together
-    /// right now, and how many the verifier barrier is holding back.
+    /// Runnable tasks the verifier barrier is holding back, and whether the
+    /// runnable set is reviews that will run one at a time.
     ///
     /// `runnable` alone counts tasks the scheduler will deliberately refuse to
     /// co-schedule, which reads as parallelism that never arrives (issue #51).
-    pub admissible: usize,
+    ///
+    /// There is deliberately no "how many will start" number here. The parallel
+    /// selector works from an empty capability vocabulary, ignores live approval
+    /// grants, and truncates to `max_parallel`, while `runnable` uses the real
+    /// ones — so any count derived from it and printed next to `runnable` is
+    /// wrong in three independent ways. Only the barrier itself is computed from
+    /// the same inputs on both sides, so only the barrier is claimed.
     pub review_barrier: usize,
+    pub serialized_reviews: usize,
     pub running: usize,
     pub waiting_decision: usize,
     pub waiting_approval: usize,
@@ -448,9 +455,8 @@ impl Snapshot {
                 RunnableClass::Done => health.done += 1,
             }
         }
-        health.admissible =
-            crate::parallel::ready_independent(&self.queue, self.config.max_parallel.max(1)).len();
         health.review_barrier = crate::parallel::held_by_review_barrier(&self.queue).len();
+        health.serialized_reviews = crate::parallel::serialized_verifiers(&self.queue).len();
         health
     }
 
@@ -475,10 +481,21 @@ impl Snapshot {
             "planner": self.planner,
             "pending": self.pending.as_ref().map(|(id, q)| serde_json::json!({"task": id, "question": q})),
             "intent": self.intent_summary(),
+            "planning_reentry": self.planning_reentry.map(|reentry| match reentry {
+                crate::planning::PlanningReentry::PendingProposal { count } => {
+                    serde_json::json!({"kind": "pending_proposal", "count": count})
+                }
+                crate::planning::PlanningReentry::AcceptedDraft => {
+                    serde_json::json!({"kind": "accepted_draft"})
+                }
+                crate::planning::PlanningReentry::Unreadable => {
+                    serde_json::json!({"kind": "unreadable"})
+                }
+            }),
             "queue": {
                 "runnable": health.runnable,
-                "admissible": health.admissible,
                 "review_barrier": health.review_barrier,
+                "serialized_reviews": health.serialized_reviews,
                 "running": health.running,
                 "waiting_decision": health.waiting_decision,
                 "waiting_approval": health.waiting_approval,
@@ -687,15 +704,24 @@ mod tests {
         let health = snapshot.health();
         assert_eq!(health.runnable, 4, "all four are class-runnable");
         assert_eq!(
-            health.admissible, 1,
-            "but the scheduler would start exactly one"
+            health.review_barrier, 3,
+            "three of them are reviews the barrier will not co-schedule"
         );
-        assert_eq!(health.review_barrier, 3);
-        assert_eq!(
-            health.admissible + health.review_barrier,
-            health.runnable,
-            "the breakdown must account for every ready task"
-        );
+        assert_eq!(health.serialized_reviews, 0, "a builder is still queued");
+
+        // Reviews as the only work left: nothing is held BEHIND anything, but
+        // they still run one at a time — issue #51's second reported case,
+        // which a barrier-only signal reports as a bare, dishonest count.
+        let mut reviews_only = snapshot.queue.clone();
+        reviews_only.tasks.retain(|task| task.kind == "review");
+        let reviews_only = Snapshot {
+            queue: reviews_only,
+            ..snapshot
+        };
+        let health = reviews_only.health();
+        assert_eq!(health.runnable, 3);
+        assert_eq!(health.review_barrier, 0);
+        assert_eq!(health.serialized_reviews, 3);
     }
 
     #[test]

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -374,10 +374,10 @@ pub struct L {
     pub key_replan: &'static str,
     /// Offered whenever an open planning session is waiting on the operator.
     pub key_plan_review: &'static str,
-    /// Suffixes for the `N ready` breakdown when the verifier barrier is
-    /// holding runnable tasks back (issue #51).
-    pub ready_admissible: &'static str,
+    /// Suffixes for the `N ready` breakdown when the scheduler will not start
+    /// what the count implies (issue #51).
     pub ready_review_barrier: &'static str,
+    pub ready_reviews_serial: &'static str,
     /// Always offered: the full key list. Home's footer can only carry the keys
     /// with a target right now, so the always-valid globals live behind this
     /// one advertised key (issue #71).
@@ -419,6 +419,7 @@ pub struct L {
     /// waiting" from "there is no work" (issue #65). `{n}` is the count.
     pub home_plan_pending: &'static str,
     pub home_plan_accepted: &'static str,
+    pub home_plan_unreadable: &'static str,
     /// Shown when `o` is pressed with no planning session to re-enter.
     pub plan_review_nothing: &'static str,
     pub replan_worker_question_hint: &'static str,
@@ -647,8 +648,8 @@ pub const EN: L = L {
     key_approve: "p approve",
     key_replan: "P replan",
     key_plan_review: "o plan review",
-    ready_admissible: " parallelizable",
     ready_review_barrier: " held by the review barrier",
+    ready_reviews_serial: "reviews run one at a time",
     key_keys: "? keys",
     keys_title: " Home keys ",
     keys_intro: "Every key Home accepts. The footer only lists the ones with something to act on right now; all of these work.",
@@ -680,9 +681,9 @@ pub const EN: L = L {
     key_doc_down: "move the selection down",
     key_doc_act: "act on the selected row",
     key_doc_toggle_worker: "enable or disable the selected worker",
-    home_plan_pending: "\u{25b6} {n} plan proposal(s) waiting for review \u{2014} press o",
-    home_plan_accepted:
-        "\u{25b6} an accepted plan is waiting to be confirmed into the queue \u{2014} press o",
+    home_plan_pending: "\u{25b6} {n} plan proposal(s) waiting for review: press o",
+    home_plan_accepted: "\u{25b6} an accepted plan is waiting to be confirmed into the queue: press o",
+    home_plan_unreadable: "\u{25b6} a planning session exists but could not be read: press o for the error",
     plan_review_nothing: "no open planning session to review; press n to describe new work",
     replan_worker_question_hint: "a worker question is open; press a and answer it instead of replanning",
     replan_live_queue_hint: "the queue still has live work; finish or settle it before replanning",
@@ -903,8 +904,8 @@ pub const KO: L = L {
     key_approve: "p 승인",
     key_replan: "P 재계획",
     key_plan_review: "o 플랜 검토",
-    ready_admissible: " 동시실행",
     ready_review_barrier: " 리뷰 배리어 대기",
+    ready_reviews_serial: "리뷰는 한 번에 하나씩",
     key_keys: "? 키목록",
     keys_title: " 홈 키 목록 ",
     keys_intro: "홈에서 받는 모든 키입니다. 푸터에는 지금 대상이 있는 키만 나오지만, 아래는 전부 동작합니다.",
@@ -936,8 +937,9 @@ pub const KO: L = L {
     key_doc_down: "선택 아래로",
     key_doc_act: "선택한 행에 대해 행동",
     key_doc_toggle_worker: "선택한 워커 켜기/끄기",
-    home_plan_pending: "\u{25b6} 검토 대기 중인 플랜 제안 {n}건 — o 키",
-    home_plan_accepted: "\u{25b6} 수락된 플랜이 큐 확정을 기다리는 중 — o 키",
+    home_plan_pending: "\u{25b6} 검토 대기 중인 플랜 제안 {n}건: o 키",
+    home_plan_accepted: "\u{25b6} 수락된 플랜이 큐 확정을 기다리는 중: o 키",
+    home_plan_unreadable: "\u{25b6} 플래닝 세션이 있으나 읽을 수 없음: o 키로 오류 확인",
     plan_review_nothing: "검토할 열린 플래닝 세션이 없습니다. 새 작업은 n을 누르세요",
     replan_worker_question_hint: "워커 질문이 열려 있음. 재계획 대신 a 눌러 답변하세요",
     replan_live_queue_hint: "큐에 진행 중인 작업이 있음. 완료하거나 종결한 뒤 재계획하세요",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -235,6 +235,9 @@ pub struct App {
     pub report_text: String,
     /// Rendered trust + autonomy panel text (v1 table + v2 autonomy block).
     pub trust_text: String,
+    /// The `?` key list, generated on entry so it scrolls through the same
+    /// clamp every other scrollable screen uses (issue #71 remediation).
+    pub keys_text: String,
     /// When true, NewWork input continues (amends) the current intent instead of
     /// starting a fresh one.
     pub amend: bool,
@@ -501,6 +504,7 @@ impl App {
             intent_text: String::new(),
             report_text: String::new(),
             trust_text: String::new(),
+            keys_text: String::new(),
             amend: false,
             replan: false,
             pause: None,
@@ -1590,7 +1594,9 @@ fn handle_home_key(app: &mut App, code: KeyCode) -> bool {
         // The always-valid globals (g, s, f, l, i, R) do not fit the footer, so
         // this list is where they stay discoverable (issue #71).
         HomeKey::Keys => {
+            app.keys_text = view::key_list_text(app.lang.l());
             app.scroll = 0;
+            app.scroll_viewport = None;
             app.screen = Screen::Keys;
         }
     }
@@ -2458,6 +2464,7 @@ fn scroll_text(app: &App) -> Option<&str> {
         Screen::Handoff => Some(&app.handoff_text),
         Screen::Intent => Some(&app.intent_text),
         Screen::Trust => Some(&app.trust_text),
+        Screen::Keys => Some(&app.keys_text),
         Screen::Completion => Some(&app.report_text),
         _ => None,
     }
@@ -4250,6 +4257,56 @@ mod tests {
                     .any(|code| home_key(code, true) == Some(*key)),
                 "the key list advertises {key:?}, which Home does not dispatch"
             );
+        }
+    }
+
+    /// Busy-gating moved from eight inline `if !app.is_busy()` guards into one
+    /// predicate. Nothing tested it, so dropping `Run` from the set — starting a
+    /// second run while one is in flight — would have failed no test at all.
+    #[test]
+    fn busy_gating_covers_exactly_the_keys_that_start_or_change_work() {
+        let gated: Vec<HomeKey> = HOME_KEYS
+            .iter()
+            .copied()
+            .filter(|key| key.needs_idle())
+            .collect();
+        assert_eq!(
+            gated,
+            vec![
+                HomeKey::New,
+                HomeKey::Run,
+                HomeKey::Auto,
+                HomeKey::Defer,
+                HomeKey::Revive,
+                HomeKey::Tidy,
+                HomeKey::PlanReview,
+                HomeKey::Language,
+            ],
+            "the busy gate changed; every entry here starts or changes work, and \
+             every key NOT here has to stay usable while a worker runs"
+        );
+        // The inverse is the part that actually bit operators: settings, access,
+        // the monitor, the handoff and the key list exist to be reachable
+        // mid-run, and quitting must never be gated.
+        for key in [
+            HomeKey::Settings,
+            HomeKey::Access,
+            HomeKey::Monitor,
+            HomeKey::Handoff,
+            HomeKey::Goal,
+            HomeKey::Trust,
+            HomeKey::Reports,
+            HomeKey::Refresh,
+            HomeKey::Keys,
+            HomeKey::Quit,
+            HomeKey::Stop,
+            HomeKey::ApproveOrPause,
+            HomeKey::Up,
+            HomeKey::Down,
+            HomeKey::Act,
+            HomeKey::ToggleWorker,
+        ] {
+            assert!(!key.needs_idle(), "{key:?} must stay usable while busy");
         }
     }
 

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -712,13 +712,22 @@ fn truncate_width(s: &str, max: usize) -> String {
 /// barrier, and the one-at-a-time cap when reviews are all that is left. A
 /// "how many will start" number is deliberately absent — see `QueueHealth`.
 fn ready_breakdown(health: &crate::snapshot::QueueHealth, l: &L) -> String {
+    let mut parts = Vec::new();
     if health.review_barrier > 0 {
-        return format!(" ({}{})", health.review_barrier, l.ready_review_barrier);
+        parts.push(format!(
+            "{}{}",
+            health.review_barrier, l.ready_review_barrier
+        ));
     }
+    // Both can apply at once — a remediation-held review plus reviews with
+    // nothing else queued. Saying only the first implies the rest are free.
     if health.serialized_reviews > 1 {
-        return format!(" ({})", l.ready_reviews_serial);
+        parts.push(l.ready_reviews_serial.to_string());
     }
-    String::new()
+    if parts.is_empty() {
+        return String::new();
+    }
+    format!(" ({})", parts.join(", "))
 }
 
 fn render_header(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L) {
@@ -1667,6 +1676,19 @@ mod tests {
         assert_eq!(
             ready_breakdown(&reviews_only, i18n::Lang::Ko.l()),
             " (리뷰는 한 번에 하나씩)"
+        );
+
+        // Both can apply at once. Naming only the barrier implies the rest are
+        // free to run together, which is the same overstatement as before.
+        let both = QueueHealth {
+            runnable: 3,
+            review_barrier: 1,
+            serialized_reviews: 2,
+            ..QueueHealth::default()
+        };
+        assert_eq!(
+            ready_breakdown(&both, i18n::Lang::En.l()),
+            " (1 held by the review barrier, reviews run one at a time)"
         );
 
         for honest in [

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -62,12 +62,11 @@ fn render_keys(frame: &mut Frame, app: &mut App) {
     let l = app.lang.l();
     let area = safe_area(frame);
     let chunks = Layout::vertical([Constraint::Min(4), Constraint::Length(3)]).split(area);
-    let text = key_list_text(l);
     let viewport = scroll_viewport(chunks[0]);
     app.scroll_viewport = Some(viewport);
-    app.scroll = app.scroll.min(max_scroll_offset(&text, viewport));
+    app.scroll = app.scroll.min(max_scroll_offset(&app.keys_text, viewport));
     frame.render_widget(
-        Paragraph::new(md_lines(&text))
+        Paragraph::new(md_lines(&app.keys_text))
             .wrap(Wrap { trim: false })
             .scroll((app.scroll, 0))
             .block(Block::bordered().title(l.keys_title)),
@@ -78,7 +77,7 @@ fn render_keys(frame: &mut Frame, app: &mut App) {
 
 /// The key list as markdown, so it reuses the same wrap-aware scroll clamp as
 /// every other scrollable screen.
-fn key_list_text(l: &L) -> String {
+pub(super) fn key_list_text(l: &L) -> String {
     let rows = super::home_key_rows(l);
     let width = rows
         .iter()
@@ -708,14 +707,18 @@ fn truncate_width(s: &str, max: usize) -> String {
 }
 
 /// The parenthetical after `N ready`, empty when the plain count is honest.
+///
+/// Only states what is computed from the SAME inputs as `runnable`: the review
+/// barrier, and the one-at-a-time cap when reviews are all that is left. A
+/// "how many will start" number is deliberately absent — see `QueueHealth`.
 fn ready_breakdown(health: &crate::snapshot::QueueHealth, l: &L) -> String {
-    if health.review_barrier == 0 || health.admissible >= health.runnable {
-        return String::new();
+    if health.review_barrier > 0 {
+        return format!(" ({}{})", health.review_barrier, l.ready_review_barrier);
     }
-    format!(
-        " ({}{}, {}{})",
-        health.admissible, l.ready_admissible, health.review_barrier, l.ready_review_barrier
-    )
+    if health.serialized_reviews > 1 {
+        return format!(" ({})", l.ready_reviews_serial);
+    }
+    String::new()
 }
 
 fn render_header(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L) {
@@ -728,8 +731,7 @@ fn render_header(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L) {
         ),
         // `N ready` on its own counted tasks the scheduler will deliberately
         // refuse to co-schedule, so pressing A after "4 ready" got one task and
-        // read as a bug (issue #51). Say what is actually admissible whenever
-        // the barrier is holding something back.
+        // read as a bug (issue #51). Name what is holding them.
         Span::styled(
             ready_breakdown(&health, l),
             Style::default().fg(Color::DarkGray),
@@ -820,6 +822,7 @@ fn planning_reentry_item(snap: &Snapshot, l: &L) -> Option<ListItem<'static>> {
             l.home_plan_pending.replace("{n}", &count.to_string())
         }
         crate::planning::PlanningReentry::AcceptedDraft => l.home_plan_accepted.to_string(),
+        crate::planning::PlanningReentry::Unreadable => l.home_plan_unreadable.to_string(),
     };
     Some(ListItem::new(Line::from(Span::styled(
         text,
@@ -1630,41 +1633,52 @@ mod tests {
 
     /// `N ready` counted tasks the scheduler would never co-schedule, so the
     /// operator pressed A expecting a 4-wide batch and got one task. The header
-    /// now says what is actually admissible — and stays silent when the plain
-    /// count is already honest (issue #51).
+    /// now names what is holding them — and claims nothing it cannot compute
+    /// from the same inputs as `runnable` (issue #51).
     #[test]
-    fn the_ready_count_breaks_out_what_the_review_barrier_is_holding() {
+    fn the_ready_count_names_what_the_scheduler_is_holding() {
         use crate::snapshot::QueueHealth;
 
         let reported = QueueHealth {
             runnable: 4,
-            admissible: 1,
             review_barrier: 3,
             ..QueueHealth::default()
         };
         assert_eq!(
             ready_breakdown(&reported, i18n::Lang::En.l()),
-            " (1 parallelizable, 3 held by the review barrier)"
+            " (3 held by the review barrier)"
         );
         assert_eq!(
             ready_breakdown(&reported, i18n::Lang::Ko.l()),
-            " (1 동시실행, 3 리뷰 배리어 대기)"
+            " (3 리뷰 배리어 대기)"
+        );
+
+        // Issue #51's second reported case: reviews are all that is left, so
+        // nothing is held BEHIND anything, but they still go one at a time.
+        let reviews_only = QueueHealth {
+            runnable: 3,
+            serialized_reviews: 3,
+            ..QueueHealth::default()
+        };
+        assert_eq!(
+            ready_breakdown(&reviews_only, i18n::Lang::En.l()),
+            " (reviews run one at a time)"
+        );
+        assert_eq!(
+            ready_breakdown(&reviews_only, i18n::Lang::Ko.l()),
+            " (리뷰는 한 번에 하나씩)"
         );
 
         for honest in [
-            // Nothing held back: the plain count already tells the truth.
+            // Nothing held back.
             QueueHealth {
                 runnable: 3,
-                admissible: 3,
-                review_barrier: 0,
                 ..QueueHealth::default()
             },
-            // Reviews are the only work left, so none are held BEHIND anything;
-            // the serial cap is a different reason and not this suffix's job.
+            // A single review left is not "one at a time" news.
             QueueHealth {
-                runnable: 2,
-                admissible: 1,
-                review_barrier: 0,
+                runnable: 1,
+                serialized_reviews: 1,
                 ..QueueHealth::default()
             },
         ] {
@@ -1672,7 +1686,7 @@ mod tests {
                 assert_eq!(
                     ready_breakdown(&honest, lang.l()),
                     "",
-                    "no breakdown when nothing is held back: {honest:?}"
+                    "no breakdown when the plain count is honest: {honest:?}"
                 );
             }
         }

--- a/tests/tui_key_list_process.rs
+++ b/tests/tui_key_list_process.rs
@@ -26,11 +26,17 @@ fn test_root() -> PathBuf {
     std::env::temp_dir().join(format!("yard-tui-key-list-{}-{nonce}", std::process::id()))
 }
 
+/// A realistic default terminal. The list is 27 rows plus chrome, so at this
+/// height the tail of it — including `g`, the key issue #71 was filed about —
+/// is below the fold and only reachable by scrolling. The original test used 40
+/// rows, which fit the whole list and hid that the screen could not scroll.
+const ROWS: u16 = 24;
+
 fn open_pty() -> (File, File) {
     let mut master = -1;
     let mut slave = -1;
     let mut size = libc::winsize {
-        ws_row: 40,
+        ws_row: ROWS,
         ws_col: 140,
         ws_xpixel: 0,
         ws_ypixel: 0,
@@ -52,6 +58,29 @@ fn open_pty() -> (File, File) {
     let rc = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
     assert_eq!(rc, 0);
     (master, slave)
+}
+
+/// Force a full repaint.
+///
+/// Ratatui writes only CHANGED cells, so after scrolling a string can lose any
+/// character whose cell happened to already hold it — exact matching on
+/// scrolled content is unreliable. A resize makes the next frame a complete
+/// one. The column change is cosmetic and preserves the scroll offset, so what
+/// is on screen is still what scrolling brought there.
+fn force_repaint(master: &File, cols: u16) {
+    let size = libc::winsize {
+        ws_row: ROWS,
+        ws_col: cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let rc = unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCSWINSZ, &size) };
+    assert_eq!(
+        rc,
+        0,
+        "TIOCSWINSZ failed: {}",
+        std::io::Error::last_os_error()
+    );
 }
 
 fn drain(master: &mut File, sink: &mut Vec<u8>) {
@@ -184,27 +213,68 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
     master.write_all(b"?").unwrap();
     wait_for_marker(&mut master, &mut sink, "Home keys", Duration::from_secs(10));
 
+    // The list opens at the top, so the tail is genuinely below the fold at this
+    // height. Assert that BEFORE scrolling, otherwise "it scrolled" proves
+    // nothing.
+    assert!(
+        !seen(&sink, "reload the workspace"),
+        "`g` was already visible at {ROWS} rows, so this test cannot prove scrolling;\n{}",
+        recent(&sink)
+    );
+
+    // Page down to the end. Without a scroll clamp for this screen the offset is
+    // forced back to 0 on every keypress and nothing below the fold ever
+    // appears — which is how `g`, the key the issue is about, stayed
+    // unreachable on a default terminal.
+    for _ in 0..8 {
+        master.write_all(b"\x1b[6~").unwrap();
+        std::thread::sleep(Duration::from_millis(40));
+        drain(&mut master, &mut sink);
+    }
+
+    force_repaint(&master, 139);
+    std::thread::sleep(Duration::from_millis(300));
+    drain(&mut master, &mut sink);
+    let after_repaint = sink.len();
+    force_repaint(&master, 140);
+    std::thread::sleep(Duration::from_millis(300));
+    drain(&mut master, &mut sink);
+
     // The always-valid globals the issue named: each present with its meaning,
     // on a surface the operator can reach without already knowing the key.
-    for (glyph, doc) in [
-        ("g", "reload the workspace"),
-        ("s", "open settings"),
-        ("f", "toggle the worker access level"),
-        ("l", "switch language"),
-        ("i", "show the intent contract"),
-        ("R", "reports and past intents"),
+    for doc in [
+        "reload the workspace",
+        "open settings",
+        "toggle the worker access level",
+        "switch language",
+        "show the intent contract",
+        "reports and past intents",
     ] {
-        wait_for_marker(&mut master, &mut sink, doc, Duration::from_secs(10));
         assert!(
-            seen(&sink, glyph),
-            "key list is missing the {glyph:?} glyph;\n{}",
+            seen(&sink[after_repaint..], doc),
+            "{doc:?} never came into view after scrolling at {ROWS} rows;\n{}",
             recent(&sink)
         );
     }
 
-    // Esc returns to Home rather than dead-ending on the list.
+    // Esc returns to Home rather than dead-ending on the list. Match only what
+    // arrives AFTER the keypress: the cumulative sink already holds every
+    // marker this session has ever rendered.
+    let before_escape = sink.len();
     master.write_all(b"\x1b").unwrap();
-    wait_for_marker(&mut master, &mut sink, "? keys", Duration::from_secs(10));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        drain(&mut master, &mut sink);
+        if seen(&sink[before_escape..], "A auto") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "Esc did not return to Home;\n{}",
+            recent(&sink)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
 
     std::thread::sleep(Duration::from_millis(200));
     let _ = master.write_all(b"q");

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -391,9 +391,24 @@ fn an_accepted_unconfirmed_plan_is_reachable_from_home_after_a_restart() {
         recent(&sink)
     );
 
+    // Match only what arrives AFTER the keypress. The cumulative sink already
+    // holds "o 플랜 검토" from the footer, so waiting for "플랜 검토" on the whole
+    // buffer would return instantly whatever `o` did.
+    let before_open = sink.len();
     master.write_all(b"o").unwrap();
-    wait_for_marker(&mut master, &mut sink, "플랜 검토", Duration::from_secs(10));
-    wait_for_marker(&mut master, &mut sink, "c 확정", Duration::from_secs(10));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        drain(&mut master, &mut sink);
+        if seen(&sink[before_open..], "c 확정") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "`o` did not open the planning review;\n{}",
+            recent(&sink)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
     assert!(
         seen(&sink, "reentry fixture slice"),
         "the review screen opened without the accepted draft's content;\n{}",


### PR DESCRIPTION
Remediation of an independent review of PRs #85, #86 and #87. Two findings were verified against a running build.

## 1. The `?` key list could not scroll — HIGH

`scroll_text` never got a `Screen::Keys` arm, so `max_scroll_for_current_screen` returned 0 and `clamp_scroll` forced `app.scroll` back to zero after every keypress. The screen's own footer advertised `↑/↓/PgUp/PgDn scroll` the whole time.

The list is 27 rows plus intro, borders and footer — about 34. At **24×120**, a default terminal, the reviewer measured the rendered list stopping at `i  show the intent contract`, with `h T R s f l g u ? q` below the fold and 8×PageDown + 30×Down producing zero movement.

Among the cut-off keys: **`g`, the exact key the operator in #71 could not find.** The fix did not reach its own stated goal on a default-size terminal.

Why it survived: my PTY test hardcoded `ws_row: 40`, just large enough for all 27 rows. Issue #71's own closing paragraph warns about tests written only around the new behavior; I repeated it.

The key list now lives on `App` like `intent_text`/`trust_text` and goes through the same wrap-aware clamp as every other scrollable screen.

## 2. The `N ready` breakdown was not a partition — MEDIUM

`health.runnable` is computed by `Snapshot::task_class` with the **real** capability vocabulary and live approval grants. `admissible` came from `parallel::ready_independent`, which deliberately uses an **empty** vocabulary, ignores approval grants, and truncates to `max_parallel`. Three independent leaks, all measured by the reviewer on a running build:

| config | rendered | wrong because |
|---|---|---|
| default `max_parallel: 1`, 2 impl + 1 review | `3 ready (1 parallelizable, 1 held by the review barrier)` | one task unaccounted for; "parallelizable" asserted where parallelism is **off** |
| 1 impl requiring a **satisfied** capability + 1 review | `2 ready (0 parallelizable, 1 held…)` | claims nothing is startable while a ready task sits there |
| an approval-**granted** ready task | in `runnable`, in neither bucket | `ready_independent` filters `!approval_required()` unconditionally |

And my snapshot test asserted `admissible + review_barrier == runnable`, which is simply false.

**`admissible` is removed, not repaired.** Any number derived from the selector's restricted inputs is wrong when printed next to `runnable`, and #51 never needed one. What is claimed now is the review barrier and the one-at-a-time review cap — and after review, both are computed **in the snapshot from `task_class`**, the same real capability vocabulary and live approval grants `runnable` uses. Reading the scheduler's own helpers instead reproduced two of the three divergences on a smaller input set: a queue of approval-granted reviews rendered a bare `3 ready` while one task would start. The scheduler helpers keep their restricted inputs, which are correct for selection and wrong only for printing.

That also closes #51's second reported case — *"verifiers are then capped at one at a time even when they are the only work left"* — which the barrier-only signal short-circuited to a bare `3 ready` while exactly one task would start.

## 3. An unreadable planning session looked like no session — LOW

`reentry` mapped every read failure through `.ok()?` to "show nothing", which reproduces the invisible dead end #65 exists to kill, just quietly. It now reports `Unreadable` and Home says so.

## Also

- `planning_reentry` reaches `yardlet status --json`, so the CLI is no longer blind to the state the TUI just learned to show.
- Entering the key list resets `scroll_viewport` (stricter than `Intent`/`Handoff`/`Trust`, which do not).
- The em-dashes in the strings added by #65 are gone.

## Tests

- The key-list PTY test runs at **24 rows** — the size that hid the defect. It asserts the tail is below the fold **before** scrolling, then that scrolling brings it into view. RED verified by removing the `Screen::Keys` scroll arm.
- `busy_gating_covers_exactly_the_keys_that_start_or_change_work` — `needs_idle` carries the whole busy-gating contract that used to be eight inline guards, and nothing tested it. Dropping `Run` from the set (starting a run mid-run) would have failed no test.
- `the_ready_count_names_what_the_scheduler_is_holding` and the snapshot test now assert what is true, including the reviews-only case.
- The reentry test's `o` step was matching the cumulative sink, so it passed on output from before the key was pressed. Fixed to match only the tail.

Two harness facts worth recording, both hit while writing these: ratatui writes only **changed** cells, so exact matching on scrolled content drops characters unless a full repaint is forced (a resize does it); and the cumulative sink makes any post-keypress assertion vacuous unless it matches only the tail. Both are the subject of #92.

## Verification

- `cargo test` — 24 targets, 792 tests, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean