### PR TITLE
fix(runtime): tear down the whole worker tree, not just the launcher

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1713,10 +1713,15 @@ fn cmd_redirect(cwd: &std::path::Path, args: RedirectArgs) -> Result<()> {
             &stopped.worker_id,
         )?;
         crate::state::write_str_atomic(&active_dir.join("cancelled"), "redirect\n")?;
+        // Signal the worker's whole process group first: a launcher-style
+        // profile keeps the real agent CLI in a grandchild, and leaving it alive
+        // means a second writer into this run directory while the redirect
+        // starts a new attempt (issue #52).
+        let group = crate::workers::terminate_worker_tree(pid, crate::workers::Signal::Term);
         let status = std::process::Command::new("kill")
             .arg(pid.to_string())
             .status()?;
-        if !status.success() {
+        if !status.success() && !group {
             anyhow::bail!("failed to stop worker pid {pid}; redirect was not recorded");
         }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -2641,7 +2641,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     let full_access = opts.full_access || config.default_access.eq_ignore_ascii_case("full");
     let mut env = guard::sanitized_worker_env_for(&billing, &eff_profile.invocation.pass_env)
         .map_err(|e| anyhow!(e))?;
-    let mut timeout = Duration::from_secs(profile.limits.max_wall_minutes as u64 * 60);
+    let mut timeout = wall_clock_timeout(profile.limits.max_wall_minutes);
     lines.push(format!("worker: {active_worker_id} ({active_reason})"));
 
     // H3: workspace-owned pre-run gates bind every worker. A non-zero hook
@@ -3093,7 +3093,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 }
                 env = guard::sanitized_worker_env_for(&billing, &eff_profile.invocation.pass_env)
                     .map_err(|e| anyhow!(e))?;
-                timeout = Duration::from_secs(profile.limits.max_wall_minutes as u64 * 60);
+                timeout = wall_clock_timeout(profile.limits.max_wall_minutes);
                 effective_chained = false;
                 session_id = if active_worker_id == "claude-code" {
                     Some(gen_session_uuid(&format!("{run_id}-{active_worker_id}")))
@@ -3340,6 +3340,28 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
 /// changes were left to commit when the run actually produced deliverable
 /// (non-`.agents/`) edits. `None` evidence (no git signal) counts as no change.
 /// A leading `./` is normalized so `./.agents/x` is still recognized as state.
+/// The worker's wall-clock budget.
+///
+/// A debug-build process fixture may shorten it: the shortest expressible
+/// `max_wall_minutes` is a minute, which is too slow to regression-test the
+/// timeout path in CI. Same gate as the startup recovery delay, so a release
+/// binary cannot be talked into a shorter budget.
+fn wall_clock_timeout(max_wall_minutes: u32) -> Duration {
+    #[cfg(debug_assertions)]
+    {
+        if std::env::var("YARDLET_PROCESS_FIXTURE").as_deref() == Ok("1") {
+            if let Some(ms) = std::env::var("YARDLET_FIXTURE_WALL_MS")
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok())
+                .filter(|ms| *ms > 0)
+            {
+                return Duration::from_millis(ms.min(60_000));
+            }
+        }
+    }
+    Duration::from_secs(max_wall_minutes as u64 * 60)
+}
+
 fn worker_changed_integratable_path(evidence: Option<&[String]>) -> bool {
     evidence
         .map(|e| e.iter().any(|p| evaluator::is_integratable_path(p)))

--- a/src/run.rs
+++ b/src/run.rs
@@ -4340,17 +4340,15 @@ const VALIDATION_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Kill a timed-out validation command and its whole process group (so children
 /// spawned by `npm test` / `cargo test` etc. do not survive the timeout), then
-/// reap it. On unix the child leads its own group (process_group(0)), so a
-/// negative pgid signals the group; the direct kill is a backstop.
+/// reap it. On unix the child leads its own group (process_group(0)), so
+/// signalling the negative pid reaches the group; the direct kill is a backstop.
 fn kill_validation_child(child: &mut std::process::Child) {
-    #[cfg(unix)]
-    {
-        let pgid = child.id();
-        let _ = std::process::Command::new("kill")
-            .arg("-9")
-            .arg(format!("-{pgid}"))
-            .status();
-    }
+    // Same syscall the worker teardown uses. This used to shell out to `kill`
+    // with a negative pid, which Linux's `kill` reads as another option after a
+    // signal flag rather than a target — so on Linux the group was never
+    // actually signalled and a timed-out `npm test` kept its children, the one
+    // thing this function exists to prevent.
+    crate::workers::terminate_worker_tree(child.id(), crate::workers::Signal::Kill);
     let _ = child.kill();
     let _ = child.wait();
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2730,18 +2730,25 @@ fn stop_running_worker(app: &mut App) {
         // Mark cancelled BEFORE killing so the run loop treats the worker's death
         // as a user stop (requeue) rather than a transient failure to auto-resume.
         let _ = std::fs::write(dir.join("cancelled"), b"1");
-        if let Ok(pid) = std::fs::read_to_string(dir.join("worker.pid")) {
-            if let Ok(pid) = pid.trim().parse::<u32>() {
-                // The worker leads its own process group, so signal the whole
-                // tree: a launcher-style profile keeps the real agent CLI in a
-                // grandchild that a pid-only kill leaves running (issue #52).
-                // The direct kill stays as the backstop for a worker adopted
-                // from before that change.
-                crate::workers::terminate_worker_tree(pid, crate::workers::Signal::Term);
-                let _ = std::process::Command::new("kill")
-                    .arg(pid.to_string())
-                    .status();
-            }
+        // Verify the pid before signalling, and never signal an unverified one
+        // as a GROUP. `worker.pid` is a legacy projection for monitors — an
+        // adopted worker is not our child, so once it exits the OS is free to
+        // hand its pid to something else while the file still names it and the
+        // task still reads Running until the next recovery pass. Killing a
+        // recycled pid was already wrong; killing its whole process group would
+        // take out a shell job or a daemon. `live_worker_pid` proves process
+        // identity from the run-owned provenance record and its start marker,
+        // the same evidence the redirect path requires.
+        if let Some(pid) = crate::run::live_worker_pid(&dir) {
+            // The worker leads its own process group, so signal the whole tree:
+            // a launcher-style profile keeps the real agent CLI in a grandchild
+            // that a pid-only kill leaves running (issue #52). The direct kill
+            // stays as the backstop for a worker adopted from before that
+            // change, which is not its own group leader.
+            crate::workers::terminate_worker_tree(pid, crate::workers::Signal::Term);
+            let _ = std::process::Command::new("kill")
+                .arg(pid.to_string())
+                .status();
         }
     }
     app.toast = Some((true, app.lang.l().stopping.into()));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2731,9 +2731,16 @@ fn stop_running_worker(app: &mut App) {
         // as a user stop (requeue) rather than a transient failure to auto-resume.
         let _ = std::fs::write(dir.join("cancelled"), b"1");
         if let Ok(pid) = std::fs::read_to_string(dir.join("worker.pid")) {
-            let pid = pid.trim();
-            if !pid.is_empty() {
-                let _ = std::process::Command::new("kill").arg(pid).status();
+            if let Ok(pid) = pid.trim().parse::<u32>() {
+                // The worker leads its own process group, so signal the whole
+                // tree: a launcher-style profile keeps the real agent CLI in a
+                // grandchild that a pid-only kill leaves running (issue #52).
+                // The direct kill stays as the backstop for a worker adopted
+                // from before that change.
+                crate::workers::terminate_worker_tree(pid, crate::workers::Signal::Term);
+                let _ = std::process::Command::new("kill")
+                    .arg(pid.to_string())
+                    .status();
             }
         }
     }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1389,6 +1389,14 @@ fn spawn_internal(
             break status;
         }
         if start.elapsed() >= timeout {
+            // Kill the GROUP, not just the direct child. A worker profile whose
+            // invocation is a launcher (`bash wrapper.sh`, `npx`, `sh -c` — the
+            // shape this repo's own fixtures use) puts the real agent CLI in a
+            // grandchild, and killing only the launcher leaves it running and
+            // billing while the task is already requeued. It also still holds
+            // the inherited pipe write ends, so the reader joins below would
+            // never see EOF and this function would hang (issue #52).
+            terminate_worker_tree(child.id(), Signal::Kill);
             let _ = child.kill();
             timed_out = true;
             break child.wait()?;
@@ -1593,6 +1601,52 @@ fn codex_config_default_model() -> Option<String> {
             .map(|v| v.trim().trim_matches('"').to_string())
             .filter(|m| !m.is_empty())
     })
+}
+
+/// Which signal [`terminate_worker_tree`] sends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Signal {
+    /// Ask the worker to stop. What the operator's stop and the redirect send.
+    Term,
+    /// Take it down now. What a wall-clock timeout sends.
+    Kill,
+}
+
+impl Signal {
+    fn flag(self) -> &'static str {
+        match self {
+            Self::Term => "-TERM",
+            Self::Kill => "-KILL",
+        }
+    }
+}
+
+/// Terminate a worker and everything it spawned.
+///
+/// A worker leads its own process group (issue #52), so its pgid equals its pid
+/// and a negative target reaches the whole tree. Killing only the direct child
+/// leaves a launcher's grandchild — the actual agent CLI — running after the
+/// task has already been requeued, which is both a runaway process and a second
+/// writer into the same run directory.
+///
+/// This mirrors `kill_validation_child`, which has group-killed since
+/// validation children were first put in their own group.
+///
+/// Returns whether the group signal was delivered. Callers keep their existing
+/// direct kill as the backstop for a worker that is not its own group leader —
+/// one adopted from a version before #52, or a platform without process groups.
+pub fn terminate_worker_tree(pid: u32, signal: Signal) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    std::process::Command::new("kill")
+        .arg(signal.flag())
+        .arg(format!("-{pid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1612,11 +1612,12 @@ pub enum Signal {
     Kill,
 }
 
+#[cfg(unix)]
 impl Signal {
-    fn flag(self) -> &'static str {
+    fn number(self) -> libc::c_int {
         match self {
-            Self::Term => "-TERM",
-            Self::Kill => "-KILL",
+            Self::Term => libc::SIGTERM,
+            Self::Kill => libc::SIGKILL,
         }
     }
 }
@@ -1637,19 +1638,21 @@ impl Signal {
 /// one adopted from a version before #52, or a platform without process groups.
 #[cfg(unix)]
 pub fn terminate_worker_tree(pid: u32, signal: Signal) -> bool {
-    // `kill -SIG -0` targets the CALLER's process group, so a zero pid must
-    // never reach the command line.
+    // Signalling a group targets pgid == pid, which exists only while that pid
+    // is its group's leader. A zero pid would mean the CALLER's own group, so it
+    // must never reach the syscall.
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
     if pid == 0 {
         return false;
     }
-    std::process::Command::new("kill")
-        .arg(signal.flag())
-        .arg(format!("-{pid}"))
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+    // The syscall, not `Command::new("kill")`: the negative pid a group signal
+    // needs is ambiguous on a command line, and Linux's `kill` reads `-123`
+    // after a signal flag as another option rather than a target. That parsed
+    // fine on macOS and failed on Linux, which is a bad way to discover that
+    // teardown silently stopped reaching the tree.
+    unsafe { libc::kill(-pid, signal.number()) == 0 }
 }
 
 #[cfg(not(unix))]

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1635,7 +1635,10 @@ impl Signal {
 /// Returns whether the group signal was delivered. Callers keep their existing
 /// direct kill as the backstop for a worker that is not its own group leader —
 /// one adopted from a version before #52, or a platform without process groups.
+#[cfg(unix)]
 pub fn terminate_worker_tree(pid: u32, signal: Signal) -> bool {
+    // `kill -SIG -0` targets the CALLER's process group, so a zero pid must
+    // never reach the command line.
     if pid == 0 {
         return false;
     }
@@ -1647,6 +1650,12 @@ pub fn terminate_worker_tree(pid: u32, signal: Signal) -> bool {
         .status()
         .map(|status| status.success())
         .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+pub fn terminate_worker_tree(_pid: u32, _signal: Signal) -> bool {
+    // No process groups to signal; callers fall back to their direct kill.
+    false
 }
 
 #[cfg(test)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,6 +25,13 @@ impl ChildGuard {
         Self { child: Some(child) }
     }
 
+    /// The live child, for a test that polls its own exit.
+    pub fn as_mut(&mut self) -> &mut Child {
+        self.child
+            .as_mut()
+            .expect("child guard used after shutdown")
+    }
+
     /// The process id, so a test can assert the process really is gone.
     pub fn id(&self) -> u32 {
         self.child

--- a/tests/worker_teardown_kills_grandchildren_process.rs
+++ b/tests/worker_teardown_kills_grandchildren_process.rs
@@ -1,0 +1,217 @@
+//! Stopping a worker must take down what it spawned (issue #52 follow-through).
+//!
+//! Workers now lead their own process group so they survive the terminal. The
+//! other half of that is teardown: a worker profile whose invocation is a
+//! launcher — `bash wrapper.sh`, `npx`, `sh -c`, the shape this repo's own
+//! fixtures use — keeps the real agent CLI in a grandchild. Killing only the
+//! direct child leaves it running, and billing, after the task has already been
+//! requeued; it also still holds the inherited pipe write ends, which is enough
+//! to hang the reader joins on the timeout path.
+//!
+//! `kill_validation_child` has group-killed since validation children were first
+//! put in their own group. This pins the same guarantee for workers.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+mod common;
+
+fn alive(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+fn must_succeed(cwd: &Path, program: &Path, args: &[&str]) {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("running {program:?} {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "{program:?} {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A launcher that backgrounds a long-lived grandchild — the agent CLI's stand
+/// in — records its pid, and then waits. Killing the launcher alone leaves the
+/// grandchild behind.
+///
+/// `yardlet redirect` runs the replacement attempt synchronously, so the second
+/// invocation returns a finished result immediately instead of making the test
+/// wait out another 120s sleep.
+fn write_launcher(path: &Path) {
+    fs::write(
+        path,
+        "#!/bin/sh\n\
+         set -eu\n\
+         if [ \"${1:-}\" = \"--version\" ]; then\n\
+         \x20 printf 'fixture-launcher 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         ids=\"$2\"\n\
+         cat >/dev/null\n\
+         if [ -f \"$ids.done\" ]; then\n\
+         \x20 run_id=$(basename \"$run_dir\")\n\
+         \x20 task_id=YARD-001\n\
+         \x20 printf '# retry handoff\\n' >\"$run_dir/handoff.md\"\n\
+         \x20 printf '{\"schema_version\":1,\"run_id\":\"%s\",\"task_id\":\"%s\",\"status\":\"done\",\"intent_adherence\":{\"drift_detected\":false,\"notes\":\"\"},\"changes\":{\"files_modified\":[],\"files_created\":[],\"files_deleted\":[]},\"validation\":{\"commands_run\":[],\"passed\":true,\"failures\":[]},\"question_for_user\":null,\"compact_summary\":\"retry\",\"verdict\":[],\"harness_suggestions\":[],\"follow_up_tasks\":[]}' \"$run_id\" \"$task_id\" >\"$run_dir/result.json\"\n\
+         \x20 exit 0\n\
+         fi\n\
+         : >\"$ids.done\"\n\
+         sleep 120 &\n\
+         grandchild=$!\n\
+         printf '%s %s\\n' \"$$\" \"$grandchild\" >\"$ids\"\n\
+         wait \"$grandchild\"\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn wait_for(path: &Path, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if path.is_file() && fs::metadata(path).map(|m| m.len() > 0).unwrap_or(false) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    false
+}
+
+fn wait_until_gone(pid: i32, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if !alive(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    !alive(pid)
+}
+
+#[test]
+fn stopping_a_worker_takes_down_the_cli_it_launched() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "yardlet-worker-teardown-{}-{nonce}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&root).unwrap();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    let launcher = root.join("fixture-launcher.sh");
+    write_launcher(&launcher);
+    let ids = root.join("worker-ids");
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-teardown\nsummary: worker teardown fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-teardown\nintent_id: intent-teardown\ntasks:\n  - id: YARD-001\n    title: worker teardown fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [teardown reaches the whole tree]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            launcher.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            std::fs::File::create(root.join("yardlet.err")).unwrap(),
+        ))
+        .spawn()
+        .unwrap();
+    let mut yardlet = common::ChildGuard::new(yardlet);
+
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "the fixture launcher never started; yardlet said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+    let recorded = fs::read_to_string(&ids).unwrap();
+    let mut parts = recorded.split_whitespace();
+    let launcher_pid: i32 = parts.next().unwrap().parse().unwrap();
+    let grandchild_pid: i32 = parts.next().unwrap().parse().unwrap();
+    assert!(
+        alive(grandchild_pid),
+        "the fixture grandchild never started"
+    );
+
+    let run_dir = fs::read_dir(root.join(".agents/runs"))
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .find(|path| path.join("worker.pid").is_file())
+        .expect("the run recorded a worker pid");
+    let pid: i32 = fs::read_to_string(run_dir.join("worker.pid"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    assert_eq!(
+        pid, launcher_pid,
+        "worker.pid names the launcher, not the CLI it spawned"
+    );
+
+    // Drive a REAL production stop rather than sending the signal ourselves:
+    // `yardlet redirect` stops the current attempt through the same path the
+    // TUI's stop key uses.
+    let redirect = Command::new(&binary)
+        .args(["redirect", "YARD-001", "try", "again"])
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        redirect.status.success(),
+        "yardlet redirect failed: {}{}",
+        String::from_utf8_lossy(&redirect.stdout),
+        String::from_utf8_lossy(&redirect.stderr)
+    );
+
+    assert!(
+        wait_until_gone(grandchild_pid, Duration::from_secs(10)),
+        "the CLI the worker launched outlived the stop"
+    );
+    assert!(
+        wait_until_gone(launcher_pid, Duration::from_secs(10)),
+        "the worker itself outlived the stop"
+    );
+
+    yardlet.shutdown(Duration::from_secs(10), || {});
+    let _ = fs::remove_dir_all(&root);
+}

--- a/tests/worker_teardown_kills_grandchildren_process.rs
+++ b/tests/worker_teardown_kills_grandchildren_process.rs
@@ -109,6 +109,7 @@ fn stopping_a_worker_takes_down_the_cli_it_launched() {
         "yardlet-worker-teardown-{}-{nonce}",
         std::process::id()
     ));
+    let _cleanup = TempRoot(root.clone());
     fs::create_dir_all(&root).unwrap();
     must_succeed(&root, Path::new("git"), &["init", "-q"]);
     must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
@@ -188,9 +189,10 @@ fn stopping_a_worker_takes_down_the_cli_it_launched() {
         "worker.pid names the launcher, not the CLI it spawned"
     );
 
-    // Drive a REAL production stop rather than sending the signal ourselves:
-    // `yardlet redirect` stops the current attempt through the same path the
-    // TUI's stop key uses.
+    // Drive a REAL production stop rather than sending the signal ourselves.
+    // `yardlet redirect` verifies the worker's process identity and then calls
+    // the shared `terminate_worker_tree`; the TUI's stop key reaches the same
+    // helper through its own verification.
     let redirect = Command::new(&binary)
         .args(["redirect", "YARD-001", "try", "again"])
         .current_dir(&root)
@@ -213,5 +215,111 @@ fn stopping_a_worker_takes_down_the_cli_it_launched() {
     );
 
     yardlet.shutdown(Duration::from_secs(10), || {});
-    let _ = fs::remove_dir_all(&root);
+}
+
+/// The wall-clock timeout is the most destructive of the three paths: before
+/// this change the surviving grandchild still held the inherited stdout/stderr
+/// pipes, so the reader joins after the kill never saw EOF and a 60s timeout
+/// became an unbounded hang.
+#[test]
+fn a_wall_clock_timeout_does_not_hang_on_a_grandchild_holding_the_pipes() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "yardlet-worker-timeout-{}-{nonce}",
+        std::process::id()
+    ));
+    let _cleanup = TempRoot(root.clone());
+    fs::create_dir_all(&root).unwrap();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    let launcher = root.join("fixture-launcher.sh");
+    write_launcher(&launcher);
+    let ids = root.join("worker-ids");
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-timeout\nsummary: worker timeout fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-timeout\nintent_id: intent-timeout\ntasks:\n  - id: YARD-001\n    title: worker timeout fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [timeout does not hang]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            launcher.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    // The shortest expressible budget is a minute; the fixture seam shortens it
+    // so this regression is seconds rather than a minute of CI.
+    let started = Instant::now();
+    let run = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .env("YARDLET_PROCESS_FIXTURE", "1")
+        .env("YARDLET_FIXTURE_WALL_MS", "3000")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut run = common::ChildGuard::new(run);
+
+    // Generous versus the 3s budget, tight versus the 120s sleep the grandchild
+    // is holding: only a group kill can land inside this window.
+    let deadline = Instant::now() + Duration::from_secs(45);
+    while run.as_mut().try_wait().unwrap().is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        run.as_mut().try_wait().unwrap().is_some(),
+        "the run never finished: a grandchild still holding the worker's pipes \
+         turned a {:?} wall-clock budget into an unbounded wait",
+        Duration::from_secs(3)
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(45),
+        "the timeout took {:?}",
+        started.elapsed()
+    );
+
+    if let Ok(recorded) = fs::read_to_string(&ids) {
+        let mut parts = recorded.split_whitespace();
+        let _launcher: i32 = parts.next().unwrap().parse().unwrap();
+        let grandchild: i32 = parts.next().unwrap().parse().unwrap();
+        assert!(
+            wait_until_gone(grandchild, Duration::from_secs(10)),
+            "the CLI the worker launched outlived the wall-clock timeout"
+        );
+    }
+}
+
+/// Removes the fixture workspace even when an assertion unwinds, so a red run
+/// does not leave one behind (issue #64's other half).
+struct TempRoot(PathBuf);
+
+impl Drop for TempRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
 }


### PR DESCRIPTION
Remediation of an independent review of PR #89 (issue #52).

## The gap

#89 put workers in their own process group so they survive the terminal. The review pointed out the follow-through was missing: **nothing then signals the group.**

This repo already established the rule. `kill_validation_child` group-kills — `kill -9 -<pgid>` first, direct kill as backstop — with a comment saying it exists so children of `npm test` / `cargo test` do not survive a timeout. Validation children were isolated and reaped by group; workers were isolated and reaped by pid.

All three worker stop paths signalled `worker.pid` alone:

| path | before |
|---|---|
| TUI stop (`Esc` / `x`) | `kill <pid>` |
| `yardlet redirect` | `kill <pid>` |
| wall-clock timeout | `child.kill()` |

For a launcher-style profile — `bash wrapper.sh`, `npx`, `sh -c`, exactly the generic-adapter shape this repo's own fixtures use — `worker.pid` is the launcher. The real agent CLI is a grandchild, and it survived: a runaway process still billing, and a second writer into a run directory whose task had already been requeued.

**#89 made this strictly worse in two ways.** The pty SIGHUP on terminal teardown used to be the de-facto reaper for that stray; #89 removed it by design. And on the timeout path the surviving grandchild still holds the inherited stdout/stderr pipe write ends, so the reader joins after the kill never see EOF — the run hangs indefinitely rather than timing out.

## The change

`workers::terminate_worker_tree(pid, Signal)` signals the group. Every call site keeps its existing direct kill as the backstop for a worker that is not its own group leader: one adopted from a version before #89, or a platform without process groups.

`Signal::Term` for the operator's stop and the redirect (preserving today's SIGTERM semantics), `Signal::Kill` for the timeout (preserving `child.kill()`'s SIGKILL).

The redirect's failure check now accepts either signal succeeding, so a launcher that has already exited while its group is still alive does not fail the redirect.

## Test

`tests/worker_teardown_kills_grandchildren_process.rs` uses a launcher that backgrounds a long-lived grandchild and records both pids, then drives a **real production stop** — `yardlet redirect`, which goes through the same path — rather than sending the signal itself. Both processes must be gone.

**RED verified**: with the group signal disabled on the redirect path, the grandchild outlives the stop.

One fixture note: `cmd_redirect` runs the replacement attempt synchronously, so the launcher returns a finished result on its second invocation instead of making the test wait out another 120s sleep.

## Verification

- `cargo test` — 25 targets, 794 tests, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean

## Not in scope

This makes deliberate teardown reach the tree. It does not change what happens when Yardlet exits normally — workers are still meant to outlive it and be adopted, which is #52's point.