### PR TITLE
fix(runtime): include committed paths in parallel change evidence

### DIFF
--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -380,6 +380,11 @@ fn is_current_run_artifact(path: &str, run_id: &str) -> bool {
 /// Paths that are sensitive (secrets/keys), escape the workspace, or are
 /// Yardlet-owned canonical state a worker must never write directly. A worker
 /// touching any of these fails the run regardless of its self-report.
+#[cfg(test)]
+pub(crate) fn forbidden_paths<'a>(paths: impl Iterator<Item = &'a String>) -> Vec<String> {
+    forbidden_in(paths)
+}
+
 fn forbidden_in<'a>(paths: impl Iterator<Item = &'a String>) -> Vec<String> {
     const SENSITIVE: &[&str] = &[
         ".env",

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -511,9 +511,22 @@ fn git_changed_paths_with(cwd: &Path, git_bin: &OsStr) -> Result<Vec<String>, Gi
             paths.push(path);
         }
         if xy.starts_with('R') || xy.starts_with('C') {
-            chunks.next();
+            // A rename/copy record carries "<new>\0<orig>\0". The original is
+            // part of the diff too — a rename DELETES it — and dropping it hid
+            // a forbidden source from the gate: `git mv config/secret.pem
+            // config/plain.txt` reported only the destination, so
+            // `forbidden_paths_untouched` certified "no sensitive paths" for a
+            // diff that removed one. The committed enumeration passes
+            // `--no-renames` for the same reason.
+            if let Some(original) = chunks.next() {
+                if !original.is_empty() {
+                    paths.push(original.to_string());
+                }
+            }
         }
     }
+    paths.sort();
+    paths.dedup();
     Ok(paths)
 }
 

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -2940,6 +2940,101 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    /// The status side had the same rename blind spot the committed side closed:
+    /// `git status` reports a rename as one record naming the destination, and
+    /// dropping the original hid a forbidden source from the gate.
+    #[test]
+    fn an_uncommitted_rename_still_reports_the_forbidden_source() {
+        let root = temp_repo("uncommitted-rename");
+        std::fs::create_dir_all(root.join("config")).unwrap();
+        std::fs::write(root.join("config/secret.pem"), "key\n").unwrap();
+        sh_git(&root, &["add", "config/secret.pem"]);
+        sh_git(&root, &["commit", "-q", "-m", "add key"]);
+
+        let run_id = "run-uncommitted-rename";
+        let worktree = root.join(".agents/worktrees").join(run_id);
+        let branch = format!("yard/uncommitted-rename/{run_id}");
+        create_worktree(&root, &worktree, &branch).unwrap();
+        let run_dir = root.join(".agents/runs").join(run_id);
+        std::fs::create_dir_all(&run_dir).unwrap();
+
+        // Staged but NOT committed, so only `git status` can see it.
+        sh_git(&worktree, &["mv", "config/secret.pem", "config/plain.txt"]);
+
+        let changed = crate::evaluator::changed_paths(&worktree).unwrap();
+        assert!(
+            changed.iter().any(|path| path == "config/secret.pem"),
+            "the renamed-away source must be in the diff: {changed:?}"
+        );
+        assert!(
+            !crate::evaluator::forbidden_paths(changed.iter()).is_empty(),
+            "and the gate must call it forbidden"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A seeded harness copy the worker COMMITTED is the worker's, not a
+    /// dispatcher overlay — serial's rule, now applied on the core side too.
+    #[test]
+    fn a_committed_seed_copy_is_worker_evidence_not_a_core_overlay() {
+        let root = temp_repo("committed-seed-copy");
+        let rules = root.join(".agents/rules");
+        std::fs::create_dir_all(&rules).unwrap();
+        std::fs::write(rules.join("seeded.md"), "seed bytes\n").unwrap();
+        sh_git(&root, &["add", ".agents/rules/seeded.md"]);
+        sh_git(&root, &["commit", "-q", "-m", "seed rule"]);
+
+        let run_id = "run-committed-seed";
+        let worktree = root.join(".agents/worktrees").join(run_id);
+        let branch = format!("yard/seed/{run_id}");
+        create_worktree(&root, &worktree, &branch).unwrap();
+        let baseline = sh_git(&worktree, &["rev-parse", "HEAD"]).trim().to_string();
+        let run_dir = root.join(".agents/runs").join(run_id);
+        std::fs::create_dir_all(&run_dir).unwrap();
+        crate::state::write_str(
+            &run_dir.join("run.yaml"),
+            &format!(
+                "schema_version: 1\nrun_id: {run_id}\ntask_id: YARD-001\nintent_id: intent-test\n\
+                 worker: fixture\nstate: running\nstarted_at: \"2026-07-28T00:00:00+00:00\"\n\
+                 worktree: {}\nworktree_branch: {branch}\nbaseline_oid: {baseline}\n",
+                worktree.display()
+            ),
+        )
+        .unwrap();
+        // Yardlet's pre-worker seed snapshot: the same bytes it copied in.
+        let seed = run_dir.join(run::HARNESS_SEED_DIR).join("rules");
+        std::fs::create_dir_all(&seed).unwrap();
+        std::fs::write(seed.join("seeded.md"), "seed bytes\n").unwrap();
+
+        // The worker commits a change, then restores the seed bytes — so the
+        // working tree matches the seed while the commit does not.
+        std::fs::write(worktree.join(".agents/rules/seeded.md"), "worker bytes\n").unwrap();
+        sh_git(&worktree, &["add", ".agents/rules/seeded.md"]);
+        sh_git(
+            &worktree,
+            &["commit", "-q", "-m", "worker rewrote the rule"],
+        );
+        std::fs::write(worktree.join(".agents/rules/seeded.md"), "seed bytes\n").unwrap();
+
+        let evidence = parallel_worker_evidence(&root, &worktree, &run_dir).unwrap();
+        assert!(
+            evidence
+                .paths
+                .iter()
+                .any(|path| path == ".agents/rules/seeded.md"),
+            "a committed seed copy stays worker evidence: {:?}",
+            evidence.paths
+        );
+        assert!(
+            evidence.core_input_overlays.is_empty(),
+            "and must not also be recorded as a dispatcher overlay: {:?}",
+            evidence.core_input_overlays
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     /// Git's default rename detection reports only a rename's DESTINATION, so
     /// moving a forbidden path out of the way would hide the source from the
     /// gate entirely. The serial enumeration has always passed `--no-renames`.

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -2052,9 +2052,11 @@ pub(crate) fn parallel_worker_evidence(
     // paths since it was written, for exactly this reason. Committing is
     // off-contract for a worker, which is why this defends against it rather
     // than trusting it not to happen.
-    paths.extend(run::committed_paths_since_baseline(wt, run_dir)?);
-    paths.sort();
-    paths.dedup();
+    //
+    // Collected up front but unioned at the END, so a committed path is never
+    // eligible for overlay attribution — the serial rule is that a path the
+    // worker committed loses that provenance and stays attributed to it.
+    let committed = run::committed_paths_since_baseline(wt, run_dir)?;
     let seed_root = run_dir.join(run::HARNESS_SEED_DIR);
     let mut core_input_overlays = Vec::new();
     if seed_root.is_dir() {
@@ -2126,17 +2128,31 @@ pub(crate) fn parallel_worker_evidence(
         else {
             return true;
         };
-        if !run::dependency_input_overlay_matches(wt, overlay) {
+        if committed.contains(path) || !run::dependency_input_overlay_matches(wt, overlay) {
             return true;
         }
         dependency_input_overlays.push(overlay.clone());
         false
     });
+    // Status-derived paths keep the harness-allowlist filter: a parallel
+    // worktree also carries Yardlet's OWN seeded copies of canonical state, and
+    // without a pre-worker snapshot to subtract them by content this filter is
+    // what stops them being attributed to the worker.
+    //
+    // Committed paths do NOT get that filter. Yardlet never commits its seeds,
+    // so a commit is unambiguously the worker's — and applying the allowlist to
+    // it silently removed exactly the canonical-state set `forbidden_in` exists
+    // to catch, leaving `.agents/yardlet.yaml` invisible to the gate while the
+    // merge carried it into the workspace (issue #83).
+    let mut paths = paths
+        .into_iter()
+        .filter(|path| evaluator::is_integratable_path(path))
+        .collect::<Vec<_>>();
+    paths.extend(committed);
+    paths.sort();
+    paths.dedup();
     Ok(ParallelWorkerEvidence {
-        paths: paths
-            .into_iter()
-            .filter(|path| evaluator::is_integratable_path(path))
-            .collect(),
+        paths,
         core_input_overlays,
         dependency_input_overlays,
     })
@@ -2777,6 +2793,80 @@ mod tests {
             evidence.paths.iter().any(|path| path == ".env"),
             "committed paths must reach the evidence the forbidden-path gate reads: {:?}",
             evidence.paths
+        );
+
+        // Canonical state is the class the gate cares about most, and the one an
+        // `is_integratable_path` filter on the evidence silently removed: it
+        // rejects everything under `.agents/` outside the harness roots, which
+        // is precisely what `forbidden_in` is looking for.
+        std::fs::create_dir_all(worktree.join(".agents")).unwrap();
+        std::fs::write(worktree.join(".agents/yardlet.yaml"), "pwned: true\n").unwrap();
+        sh_git(&worktree, &["add", "-f", ".agents/yardlet.yaml"]);
+        sh_git(&worktree, &["commit", "-q", "-m", "canonical state"]);
+        let evidence = parallel_worker_evidence(&root, &worktree, &run_dir).unwrap();
+        assert!(
+            evidence
+                .paths
+                .iter()
+                .any(|path| path == ".agents/yardlet.yaml"),
+            "a committed canonical-state file must reach the gate: {:?}",
+            evidence.paths
+        );
+        assert!(
+            !crate::evaluator::forbidden_paths(evidence.paths.iter()).is_empty(),
+            "and the gate must actually call it forbidden"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Git's default rename detection reports only a rename's DESTINATION, so
+    /// moving a forbidden path out of the way would hide the source from the
+    /// gate entirely. The serial enumeration has always passed `--no-renames`.
+    #[test]
+    fn a_committed_rename_still_reports_the_forbidden_source() {
+        let root = temp_repo("committed-rename");
+        // The file has to exist at the baseline: a path created AND renamed
+        // inside the range collapses legitimately, because nothing by that name
+        // ever reaches the merge.
+        std::fs::create_dir_all(root.join("config")).unwrap();
+        std::fs::write(root.join("config/secret.pem"), "key\n").unwrap();
+        sh_git(&root, &["add", "config/secret.pem"]);
+        sh_git(&root, &["commit", "-q", "-m", "add key"]);
+
+        let run_id = "run-committed-rename";
+        let worktree = root.join(".agents/worktrees").join(run_id);
+        let branch = format!("yard/rename/{run_id}");
+        create_worktree(&root, &worktree, &branch).unwrap();
+        let baseline = sh_git(&worktree, &["rev-parse", "HEAD"]).trim().to_string();
+        let run_dir = root.join(".agents/runs").join(run_id);
+        std::fs::create_dir_all(&run_dir).unwrap();
+        crate::state::write_str(
+            &run_dir.join("run.yaml"),
+            &format!(
+                "schema_version: 1\nrun_id: {run_id}\ntask_id: YARD-001\nintent_id: intent-test\n\
+                 worker: fixture\nstate: running\nstarted_at: \"2026-07-27T00:00:00+00:00\"\n\
+                 worktree: {}\nworktree_branch: {branch}\nbaseline_oid: {baseline}\n",
+                worktree.display()
+            ),
+        )
+        .unwrap();
+
+        sh_git(&worktree, &["mv", "config/secret.pem", "config/plain.txt"]);
+        sh_git(&worktree, &["commit", "-q", "-m", "rename away"]);
+
+        let evidence = parallel_worker_evidence(&root, &worktree, &run_dir).unwrap();
+        assert!(
+            evidence
+                .paths
+                .iter()
+                .any(|path| path == "config/secret.pem"),
+            "the renamed-away source must still reach the gate: {:?}",
+            evidence.paths
+        );
+        assert!(
+            !crate::evaluator::forbidden_paths(evidence.paths.iter()).is_empty(),
+            "and the gate must call it forbidden"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -2065,6 +2065,10 @@ pub(crate) fn parallel_worker_evidence(
         let unchanged = paths
             .iter()
             .filter(|path| seeded.contains(*path) && !modified.contains(*path))
+            // Serial's rule, applied on this side too: a path the worker
+            // committed loses its dispatcher provenance and stays attributed to
+            // the worker, so it must not also be recorded as a core overlay.
+            .filter(|path| !committed.contains(*path))
             .cloned()
             .collect::<Vec<_>>();
         paths.retain(|path| !seeded.contains(path) || modified.contains(path));
@@ -2743,6 +2747,10 @@ mod tests {
         sh_git(&root, &["init", "-q"]);
         sh_git(&root, &["config", "user.name", "Local User"]);
         sh_git(&root, &["config", "user.email", "local@example.test"]);
+        // Pin rename detection ON. With `diff.renames = false` in an ambient
+        // global config, a range diff already reports both sides of a rename,
+        // so the `--no-renames` regression guard would pass without the fix.
+        sh_git(&root, &["config", "diff.renames", "true"]);
         std::fs::write(root.join("base.txt"), "base\n").unwrap();
         sh_git(&root, &["add", "base.txt"]);
         sh_git(&root, &["commit", "-q", "-m", "init"]);
@@ -2815,6 +2823,118 @@ mod tests {
         assert!(
             !crate::evaluator::forbidden_paths(evidence.paths.iter()).is_empty(),
             "and the gate must actually call it forbidden"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// The guarantee #83 is actually about: not that the path appears in a
+    /// vector, but that the gate STOPS it. A worker that commits canonical
+    /// state must not have that commit merged into the workspace.
+    #[test]
+    fn a_committed_canonical_state_file_blocks_the_run_and_never_merges() {
+        let root = temp_repo("committed-canonical-blocks");
+        std::fs::create_dir_all(root.join(".agents")).unwrap();
+        let worker = write_test_worker(
+            &root,
+            "canonical-committer.sh",
+            r##"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "fixture 1.0"
+  exit 0
+fi
+run_dir="$1"
+task_id="$2"
+run_id=$(basename "$run_dir")
+cat >/dev/null
+printf "feature\n" > feature.txt
+mkdir -p .agents
+printf "pwned: true\n" > .agents/yardlet.yaml
+git add -f feature.txt .agents/yardlet.yaml
+git -c user.name=w -c user.email=w@e.t commit -q -m "worker commit"
+cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "$task_id",
+  "status": "done",
+  "intent_adherence": { "drift_detected": false, "notes": "" },
+  "changes": { "files_modified": [], "files_created": ["feature.txt"], "files_deleted": [] },
+  "validation": { "commands_run": [], "passed": true, "failures": [] },
+  "question_for_user": null,
+  "compact_summary": "committed canonical state",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+printf "# worker handoff\n" > "$run_dir/handoff.md"
+"##,
+        );
+        let worker_yaml = format!(
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", YARD-PAR-CANON]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            yaml_string(&worker)
+        );
+        let mut offender = task("YARD-PAR-CANON", TaskState::Queued, 10, vec![]);
+        offender.kind = "implementation".into();
+        let ws = setup_workspace(&root, &worker_yaml, vec![offender]);
+        let mut q = ws.load_queue().unwrap();
+        q.intent_id = "intent-test".into();
+        ws.save_queue(&q).unwrap();
+        let canonical_before = std::fs::read_to_string(ws.config_path()).unwrap();
+        let head_before = sh_git(&root, &["rev-parse", "HEAD"]).trim().to_string();
+
+        let mut events = Vec::new();
+        let states = run_batch(&ws, &[0], false, |line| events.push(line.to_string())).unwrap();
+
+        assert_ne!(
+            states.first().map(|(_, state)| *state),
+            Some(TaskState::Done),
+            "a run that committed canonical state must not land Done: {events:?}"
+        );
+        // Assert the FORBIDDEN-PATH gate is what stopped it. Without this the
+        // test passes on any unrelated failure — the run is refused for other
+        // reasons too, so "not Done" alone proves nothing about #83.
+        let run_dir = std::fs::read_dir(ws.runs_dir())
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .find(|path| path.join("evaluation.json").is_file())
+            .expect("the run wrote an evaluation");
+        let evaluation: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(run_dir.join("evaluation.json")).unwrap(),
+        )
+        .unwrap();
+        let gate = evaluation["checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|check| check["name"] == "forbidden_paths_untouched")
+            .expect("the evaluator still runs the forbidden-path gate");
+        assert_eq!(
+            gate["passed"], false,
+            "the forbidden-path gate must be what refuses this run: {gate}"
+        );
+        assert!(
+            gate["note"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(".agents/yardlet.yaml"),
+            "and it must name the committed path: {gate}"
+        );
+        assert_eq!(
+            sh_git(&root, &["rev-parse", "HEAD"]).trim(),
+            head_before,
+            "the worker's commit must not have been merged: {events:?}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(ws.config_path()).unwrap(),
+            canonical_before,
+            "the workspace's canonical state must be untouched"
+        );
+        assert!(
+            !root.join("feature.txt").exists(),
+            "nothing from a blocked run may reach the workspace"
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -2044,6 +2044,17 @@ pub(crate) fn parallel_worker_evidence(
 ) -> Result<ParallelWorkerEvidence> {
     let mut paths = evaluator::changed_paths(wt)
         .ok_or_else(|| anyhow!("could not enumerate parallel worktree changes"))?;
+    // Working-tree status alone is not the run's diff. A worker that commits
+    // its own work leaves a clean status, so status-only evidence is EMPTY for
+    // everything it committed — and an empty `Some(vec![])` is not the `None`
+    // the evaluator fails closed on, so `forbidden_paths_untouched` certifies a
+    // diff it never saw (issue #83). The serial path has unioned committed
+    // paths since it was written, for exactly this reason. Committing is
+    // off-contract for a worker, which is why this defends against it rather
+    // than trusting it not to happen.
+    paths.extend(run::committed_paths_since_baseline(wt, run_dir)?);
+    paths.sort();
+    paths.dedup();
     let seed_root = run_dir.join(run::HARNESS_SEED_DIR);
     let mut core_input_overlays = Vec::new();
     if seed_root.is_dir() {
@@ -2720,6 +2731,55 @@ mod tests {
         sh_git(&root, &["add", "base.txt"]);
         sh_git(&root, &["commit", "-q", "-m", "init"]);
         root
+    }
+
+    /// A worker that COMMITS its work leaves a clean `git status`, so
+    /// status-only evidence is empty for everything it committed. Empty is not
+    /// `None`, so the evaluator's fail-closed branch never fires and
+    /// `forbidden_paths_untouched` certifies a diff it never saw (issue #83).
+    /// Committing is off-contract for a worker; the serial path has defended
+    /// against it since it was written.
+    #[test]
+    fn parallel_evidence_includes_what_the_worker_committed() {
+        let root = temp_repo("committed-evidence");
+        let run_id = "run-committed-evidence";
+        let worktree = root.join(".agents/worktrees").join(run_id);
+        let branch = format!("yard/committed/{run_id}");
+        create_worktree(&root, &worktree, &branch).unwrap();
+        let baseline = sh_git(&worktree, &["rev-parse", "HEAD"]).trim().to_string();
+
+        let run_dir = root.join(".agents/runs").join(run_id);
+        std::fs::create_dir_all(&run_dir).unwrap();
+        crate::state::write_str(
+            &run_dir.join("run.yaml"),
+            &format!(
+                "schema_version: 1\nrun_id: {run_id}\ntask_id: YARD-001\nintent_id: intent-test\n\
+                 worker: fixture\nstate: running\nstarted_at: \"2026-07-27T00:00:00+00:00\"\n\
+                 worktree: {}\nworktree_branch: {branch}\nbaseline_oid: {baseline}\n",
+                worktree.display()
+            ),
+        )
+        .unwrap();
+
+        // The worker writes a secret, commits it, and leaves a clean tree.
+        std::fs::write(worktree.join(".env"), "SECRET=1\n").unwrap();
+        sh_git(&worktree, &["add", ".env"]);
+        sh_git(&worktree, &["commit", "-q", "-m", "worker commit"]);
+        assert!(
+            crate::evaluator::changed_paths(&worktree)
+                .unwrap()
+                .is_empty(),
+            "the fixture must leave a clean status, or it is not reproducing the bug"
+        );
+
+        let evidence = parallel_worker_evidence(&root, &worktree, &run_dir).unwrap();
+        assert!(
+            evidence.paths.iter().any(|path| path == ".env"),
+            "committed paths must reach the evidence the forbidden-path gate reads: {:?}",
+            evidence.paths
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[cfg(unix)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -720,7 +720,11 @@ fn committed_paths_since(worktree: &std::path::Path, range: &str) -> Option<Vec<
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(worktree)
-        .args(["diff", "--name-only", "-z", range])
+        // `--no-renames` or a committed rename reports only its DESTINATION,
+        // so moving `config/secret.pem` to `config/plain.txt` would hide the
+        // forbidden source from the gate entirely. The serial enumeration has
+        // always passed it.
+        .args(["diff", "--name-only", "--no-renames", "-z", range])
         .env("LC_ALL", "C")
         .env("LANG", "C")
         .output()

--- a/src/run.rs
+++ b/src/run.rs
@@ -292,6 +292,43 @@ fn serial_committed_paths(
     })
 }
 
+/// Paths committed on a run-owned worktree branch since its pinned baseline.
+///
+/// Shared by both evidence paths: a worker that commits its work leaves a clean
+/// `git status`, so status alone would report no changes at all for it. The
+/// serial path has always unioned these; the parallel path did not, which left
+/// the forbidden-path gate certifying a diff it never saw (issue #83).
+///
+/// A missing or baseline-less run record yields no committed paths rather than
+/// an error: legacy runs predate the pinned baseline, and their status-only
+/// evidence is what they have always been evaluated on.
+pub(crate) fn committed_paths_since_baseline(
+    worktree: &std::path::Path,
+    run_dir: &std::path::Path,
+) -> Result<Vec<String>> {
+    let Ok(record) = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml")) else {
+        return Ok(Vec::new());
+    };
+    if record.baseline_oid.is_empty() {
+        return Ok(Vec::new());
+    }
+    let merge_target = if record.worktree_branch.is_empty() {
+        "HEAD^{commit}".to_string()
+    } else {
+        format!("refs/heads/{}^{{commit}}", record.worktree_branch)
+    };
+    let tip = git_stdout(worktree, &["rev-parse", "--verify", &merge_target])
+        .with_context(|| format!("resolving {merge_target} for committed change evidence"))?
+        .trim()
+        .to_string();
+    committed_paths_since(worktree, &format!("{}..{tip}", record.baseline_oid)).ok_or_else(|| {
+        anyhow!(
+            "could not enumerate committed changes in {}",
+            worktree.display()
+        )
+    })
+}
+
 /// Actual serial-worktree changes with only Yardlet's unchanged canonical seed
 /// copies removed. The main run owns an exact pre-worker snapshot, so a worker
 /// create, edit, delete, or symlink replacement stays in the evidence and is
@@ -660,7 +697,9 @@ pub(crate) fn detectable_repository_outputs(
     }
     if let Ok(record) = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml")) {
         if !record.baseline_oid.is_empty() {
-            if let Some(committed) = committed_paths_since(worktree, &record.baseline_oid) {
+            if let Some(committed) =
+                committed_paths_since(worktree, &format!("{}..HEAD", record.baseline_oid))
+            {
                 evidence = true;
                 paths.extend(committed);
             }
@@ -677,11 +716,11 @@ pub(crate) fn detectable_repository_outputs(
     )
 }
 
-fn committed_paths_since(worktree: &std::path::Path, baseline: &str) -> Option<Vec<String>> {
+fn committed_paths_since(worktree: &std::path::Path, range: &str) -> Option<Vec<String>> {
     let output = std::process::Command::new("git")
         .arg("-C")
         .arg(worktree)
-        .args(["diff", "--name-only", "-z", &format!("{baseline}..HEAD")])
+        .args(["diff", "--name-only", "-z", range])
         .env("LC_ALL", "C")
         .env("LANG", "C")
         .output()


### PR DESCRIPTION
Closes #83. Found while fixing #55.

## The bypass

`parallel_worker_evidence` built the run's change evidence from `evaluator::changed_paths` — `git status` — alone.

A worker that **commits** its work leaves a clean status. So for everything it committed, the evidence was empty. And an empty `Some(vec![])` is not the `None` that makes `forbidden_paths_untouched` fail closed:

```rust
match actual_changes {
    Some(actual) => { /* forbidden_in(actual) — nothing to find */ }
    None => { /* fail closed: "cannot certify forbidden paths untouched" */ }
}
```

So the gate that certifies no secret, no out-of-workspace path and no Yardlet-owned canonical-state file was touched **passed on a diff it never saw**. Integration then merges the commit normally: `integrate_worktree_after_staged` handles committed work via `ahead > 0` -> `git merge --no-ff`.

The serial path has defended against this since it was written, and says why in a comment: *"Status alone is not enough: a worker may commit its own changes and detach HEAD, so paths committed on the exact run-owned branch tip after the pinned baseline are unioned."* The parallel path never got the same treatment.

Committing is off-contract — the packet tells workers not to reshape version-control state — which is exactly why the serial path defends against it rather than trusting it not to happen.

## The change

Extract the serial union as `run::committed_paths_since_baseline(worktree, run_dir)` and use it on both sides. It resolves the run-owned **branch tip** rather than `HEAD`, because a worker that commits may also detach HEAD; a run record with no pinned baseline (legacy) yields no committed paths rather than an error, preserving how those runs have always been evaluated.

`committed_paths_since` now takes the range instead of appending `..HEAD` itself.

## Test

`parallel_evidence_includes_what_the_worker_committed` — a worker writes `.env`, commits it, and leaves a clean tree. The test asserts the clean status first (otherwise it is not reproducing the bug), then that `.env` reaches the evidence.

RED verified: without the union, the evidence is `[]`.

## Verification

- `cargo test` — 25 targets, 797 tests, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean