### PR TITLE
feat(git): add `yardlet target`, and stop leaving the tracking ref stale

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Cargo.lock.orig
 /.agents/intent-contract.yaml
 /.agents/work-queue.yaml
 /.agents/conversations/
+/.agents/git-finish-target.log
 /.agents/approvals.yaml
 /.agents/planning.lock
 /.agents/locks/

--- a/README.ko.md
+++ b/README.ko.md
@@ -273,6 +273,7 @@ Bracketed paste는 붙여넣은 줄바꿈과 한국어/CJK 본문을 그대로 �
 | `yardlet defer <id> --cascade [reason]` | 그 뒤에 좌초된 queued 작업까지 전이적으로 함께 defer하고 하나의 revive 그룹으로 기록. |
 | `yardlet revive <id> [--group]` | Deferred 작업을 Queued로 되살림; `--group`은 함께 기록된 cascade 그룹을 되살림. |
 | `yardlet access <sandboxed\|full>` | 기본 워커 권한 수준 설정. |
+| `yardlet target [<ref>]` | Git finish 배송 대상 확인/변경. `--to-checkout`은 현재 체크아웃으로 맞춤. |
 | `yardlet handoff` | 최신 실행의 핸드오프 출력. |
 | `yardlet report` | 인텐트의 최종 리포트 출력 (모든 작업의 집계). |
 | `yardlet memory [init \| refresh [--stale-only]]` | 프로젝트 메모리 인덱스 나열(오래되었을 수 있는 문서 표시); `init`/`refresh`는 워커가 초안한 문서를 Yardlet 코어가 기록. |

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Bracketed paste preserves pasted newlines and Korean/CJK text.
 | `yardlet defer <id> --cascade [reason]` | Also defer queued tasks stranded behind it, transitively, as one revive group. |
 | `yardlet revive <id> [--group]` | Return a Deferred task to Queued; `--group` revives the cascade group recorded with it. |
 | `yardlet access <sandboxed\|full>` | Set the default worker permission level. |
+| `yardlet target [<ref>]` | Show or set where Git finish delivers; `--to-checkout` retargets to the current branch. |
 | `yardlet handoff` | Print the latest run's handoff. |
 | `yardlet report` | Print the intent's final report (aggregate of every task). |
 | `yardlet memory [init \| refresh [--stale-only]]` | List the project-memory index (flags possibly stale docs); `init`/`refresh` draft docs via a worker that Yardlet's core then writes. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2028,6 +2028,12 @@ fn cmd_target(cwd: &std::path::Path, args: TargetArgs) -> Result<()> {
     let checkout = crate::git_finish::checkout_ref(&ws.root);
     let current = config.git_finish.target_ref.clone();
 
+    if args.to_checkout && checkout.is_none() {
+        anyhow::bail!(
+            "--to-checkout needs a checked-out branch; the owning root is on a detached or \
+             unborn HEAD. Check out the branch you want to deliver to, or name a ref."
+        );
+    }
     let Some(requested) = args
         .target_ref
         .clone()
@@ -2056,7 +2062,7 @@ fn cmd_target(cwd: &std::path::Path, args: TargetArgs) -> Result<()> {
         return Ok(());
     };
 
-    let normalized = crate::git_finish::normalize_target_ref(&requested)?;
+    let normalized = crate::git_finish::normalize_target_ref(&ws.root, &requested)?;
     if normalized == current {
         println!("Git finish target is already {normalized}.");
         return Ok(());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,8 @@ pub enum Command {
     Resolve(ResolveArgs),
     /// Set the default worker permission: sandboxed | full.
     Access(AccessArgs),
+    /// Show or change where Git finish delivers (`git_finish.target_ref`).
+    Target(TargetArgs),
     /// Print the latest run's handoff.
     Handoff,
     /// Print the intent's final report (aggregate of every task's result).
@@ -309,6 +311,17 @@ pub struct RedirectArgs {
     /// Drop the worker sandbox for the new attempt.
     #[arg(long)]
     full_access: bool,
+}
+
+#[derive(Args)]
+pub struct TargetArgs {
+    /// The ref to deliver to, e.g. `refs/heads/main` or just `main`. Omit to
+    /// show the current target and the checkout it would be compared against.
+    target_ref: Option<String>,
+    /// Retarget to whatever the owning root currently has checked out. This is
+    /// what a blocked run's diagnostic is asking for.
+    #[arg(long, conflicts_with = "target_ref")]
+    to_checkout: bool,
 }
 
 #[derive(Args)]
@@ -621,6 +634,7 @@ pub fn dispatch(cli: Cli) -> Result<()> {
         Some(Command::Revive(a)) => cmd_revive(&cwd, a),
         Some(Command::Resolve(a)) => cmd_resolve(&cwd, a),
         Some(Command::Access(a)) => cmd_access(&cwd, a),
+        Some(Command::Target(a)) => cmd_target(&cwd, a),
         Some(Command::Handoff) => cmd_handoff(&cwd),
         Some(Command::Report) => cmd_report(&cwd),
         Some(Command::Trust(a)) => cmd_trust(&cwd, a),
@@ -1995,6 +2009,86 @@ fn cmd_access(cwd: &std::path::Path, args: AccessArgs) -> Result<()> {
             "Workers now run without the sandbox (commands and network flow freely). They still \
              self-gate dangerous actions per the packet, and any change to a forbidden path still \
              fails the run."
+        );
+    }
+    Ok(())
+}
+
+/// Show or change the Git finish delivery target.
+///
+/// The #36 fix deliberately blocks a run whose configured `target_ref` does not
+/// match the checkout, rather than silently retargeting. That was the right
+/// call, but it left the prescribed remedy performable only by hand-editing
+/// Yardlet-owned state — which this project's own guidance tells operators not
+/// to do (issue #42). The change goes through `state.rs` like every other
+/// canonical write, and is recorded so the retarget itself is auditable.
+fn cmd_target(cwd: &std::path::Path, args: TargetArgs) -> Result<()> {
+    let ws = init::ensure_initialized(cwd)?.0;
+    let config = ws.load_config()?;
+    let checkout = crate::git_finish::checkout_ref(&ws.root);
+    let current = config.git_finish.target_ref.clone();
+
+    let Some(requested) = args
+        .target_ref
+        .clone()
+        .or_else(|| args.to_checkout.then(|| checkout.clone()).flatten())
+    else {
+        println!(
+            "Git finish target: {}",
+            if current.is_empty() {
+                "(unset — the run's checkout is used)"
+            } else {
+                &current
+            }
+        );
+        match &checkout {
+            Some(checkout) => {
+                println!("Owning root checkout: {checkout}");
+                if !current.is_empty() && &current != checkout {
+                    println!(
+                        "\nThese differ, so a run will be blocked before it spawns a worker.\n\
+                         Retarget with `yardlet target --to-checkout`, or name a ref explicitly."
+                    );
+                }
+            }
+            None => println!("Owning root checkout: (detached HEAD or not a repository)"),
+        }
+        return Ok(());
+    };
+
+    let normalized = crate::git_finish::normalize_target_ref(&requested)?;
+    if normalized == current {
+        println!("Git finish target is already {normalized}.");
+        return Ok(());
+    }
+    crate::state::save_git_finish_target_ref(&ws.config_path(), &normalized)?;
+    // Read it back rather than trusting the write: a config writer that silently
+    // no-ops would otherwise be reported to the operator as a completed
+    // retarget, which is the failure this command exists to remove.
+    let written = ws.load_config()?.git_finish.target_ref;
+    if written != normalized {
+        anyhow::bail!(
+            "retarget did not persist: {} still reads '{written}'",
+            ws.config_path().display()
+        );
+    }
+    let from = if current.is_empty() {
+        "(unset)".to_string()
+    } else {
+        current
+    };
+    crate::state::append_str(
+        &ws.agents_dir().join("git-finish-target.log"),
+        &format!(
+            "{}\tretargeted\t{from}\t{normalized}\n",
+            chrono::Local::now().to_rfc3339()
+        ),
+    )?;
+    println!("Git finish target set to {normalized} (was {from}).");
+    if checkout.as_deref() != Some(normalized.as_str()) {
+        println!(
+            "Note: the owning root is not on this ref right now, so a run will still be blocked \
+             until it is."
         );
     }
     Ok(())

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -641,7 +641,7 @@ pub fn checkout_ref(root: &std::path::Path) -> Option<String> {
 /// Operators think in branch names; the policy stores full refs. Rejecting
 /// `main` because it is not `refs/heads/main` would make the retarget command
 /// as fiddly as the hand-edit it replaces (issue #42).
-pub fn normalize_target_ref(requested: &str) -> anyhow::Result<String> {
+pub fn normalize_target_ref(root: &std::path::Path, requested: &str) -> anyhow::Result<String> {
     let trimmed = requested.trim();
     let candidate = if trimmed.starts_with("refs/") {
         trimmed.to_string()
@@ -653,6 +653,14 @@ pub fn normalize_target_ref(requested: &str) -> anyhow::Result<String> {
             "'{requested}' is not a usable branch ref; give a branch name like `main` or a \
              full `refs/heads/<branch>`"
         );
+    }
+    // The same check the finish path runs. Accepting a ref here that Git will
+    // later reject would turn one clear block into a worse one: the command
+    // would report success and every run would then fail with
+    // `target_ref_invalid`, which is less actionable than the mismatch the
+    // operator invoked this to clear.
+    if !git_ok(root, &["check-ref-format", &candidate]) {
+        anyhow::bail!("'{candidate}' is not a valid Git ref name");
     }
     Ok(candidate)
 }
@@ -1721,9 +1729,13 @@ mod target_ref_tests {
     /// replaces (issue #42).
     #[test]
     fn a_retarget_accepts_either_spelling_and_refuses_unusable_refs() {
-        assert_eq!(normalize_target_ref("main").unwrap(), "refs/heads/main");
+        let root = std::env::temp_dir();
         assert_eq!(
-            normalize_target_ref("  refs/heads/release/1.0  ").unwrap(),
+            normalize_target_ref(&root, "main").unwrap(),
+            "refs/heads/main"
+        );
+        assert_eq!(
+            normalize_target_ref(&root, "  refs/heads/release/1.0  ").unwrap(),
             "refs/heads/release/1.0"
         );
         for bad in [
@@ -1736,8 +1748,16 @@ mod target_ref_tests {
             "back\\slash",
         ] {
             assert!(
-                normalize_target_ref(bad).is_err(),
+                normalize_target_ref(&root, bad).is_err(),
                 "{bad:?} must not become a delivery target"
+            );
+        }
+        // Lexically safe, but Git itself refuses these. Accepting one would
+        // trade the operator's clear block for a worse one at run time.
+        for git_refuses in [".hidden", "foo.lock", "a//b", "foo/.bar", "x.lock/y"] {
+            assert!(
+                normalize_target_ref(&root, git_refuses).is_err(),
+                "{git_refuses:?} is not a valid Git ref name and must be refused"
             );
         }
     }

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -629,6 +629,34 @@ fn remote_name_is_safe(value: &str) -> bool {
             .all(|byte| !byte.is_ascii_whitespace() && !byte.is_ascii_control())
 }
 
+/// The owning root's checked-out ref, or `None` on a detached or unborn HEAD.
+pub fn checkout_ref(root: &std::path::Path) -> Option<String> {
+    git_stdout(root, &["symbolic-ref", "--quiet", "HEAD"])
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+/// Accept a delivery target in either spelling and return the full ref.
+///
+/// Operators think in branch names; the policy stores full refs. Rejecting
+/// `main` because it is not `refs/heads/main` would make the retarget command
+/// as fiddly as the hand-edit it replaces (issue #42).
+pub fn normalize_target_ref(requested: &str) -> anyhow::Result<String> {
+    let trimmed = requested.trim();
+    let candidate = if trimmed.starts_with("refs/") {
+        trimmed.to_string()
+    } else {
+        format!("refs/heads/{trimmed}")
+    };
+    if !branch_ref_label_is_safe(&candidate) {
+        anyhow::bail!(
+            "'{requested}' is not a usable branch ref; give a branch name like `main` or a \
+             full `refs/heads/<branch>`"
+        );
+    }
+    Ok(candidate)
+}
+
 fn branch_ref_label_is_safe(value: &str) -> bool {
     let Some(branch) = value.strip_prefix("refs/heads/") else {
         return false;
@@ -676,9 +704,7 @@ pub(crate) fn preflight_target_before_spawn(
     } else {
         policy.target_ref.clone()
     };
-    let checkout_ref = git_stdout(&ws.root, &["symbolic-ref", "--quiet", "HEAD"])
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty());
+    let checkout_ref = checkout_ref(&ws.root);
     if checkout_ref.as_deref() == Some(effective_target.as_str()) {
         return Ok(());
     }
@@ -692,7 +718,8 @@ pub(crate) fn preflight_target_before_spawn(
     persist(ws, run_dir, &record)?;
     anyhow::bail!(
         "branch_does_not_match_target_ref: configured Git finish target_ref '{}' \
-         does not match checkout ref '{}'; update git_finish.target_ref before running",
+         does not match checkout ref '{}'; retarget with `yardlet target --to-checkout` \
+         (or `yardlet target <ref>`) before running",
         effective_target,
         observed
     )
@@ -1251,8 +1278,9 @@ fn finish_owned_run_with_mode_and_github(
     match remote_oid(&ws.root, &policy.remote, &policy.target_ref) {
         Ok(Some(oid)) if oid == expected => {
             record.status = GitFinishStatus::Pushed;
-            record.remote_oid = Some(oid);
+            record.remote_oid = Some(oid.clone());
             record.reason = "remote_verified".to_string();
+            refresh_remote_tracking_ref(&ws.root, &policy.remote, &policy.target_ref, &oid);
         }
         Ok(oid) => {
             record.status = GitFinishStatus::RemoteMismatch;
@@ -1265,6 +1293,40 @@ fn finish_owned_run_with_mode_and_github(
         }
     }
     persist_result(record)
+}
+
+/// Move the local remote-tracking ref to the OID a verified push just put on
+/// the remote.
+///
+/// Git updates tracking refs when you push to a named remote; Yardlet pushes to
+/// the exact URL pinned before the run, so a remote cannot be retargeted
+/// mid-push. That deliberate choice has a cost: `git status` in the owning root
+/// keeps reporting the branch "ahead" after a successful push until someone
+/// fetches, which twice read as a failed auto-push during dogfooding (issue
+/// #41).
+///
+/// Only refreshes a tracking ref that ALREADY exists, and only to the OID the
+/// remote was just verified to hold. A workspace whose remote uses a
+/// non-standard fetch refspec, or that has never fetched this branch, has no
+/// such ref and none is invented — the point is to un-stale a ref Git itself
+/// created, not to fabricate remote state. Best-effort: a failure here leaves
+/// the pre-existing cosmetic staleness and must not affect the finish outcome.
+fn refresh_remote_tracking_ref(root: &std::path::Path, remote: &str, target_ref: &str, oid: &str) {
+    let Some(branch) = target_ref.strip_prefix("refs/heads/") else {
+        return;
+    };
+    if branch.is_empty() || remote.is_empty() {
+        return;
+    }
+    let tracking = format!("refs/remotes/{remote}/{branch}");
+    let Some(current) = git_stdout(root, &["rev-parse", "--verify", "--quiet", &tracking]) else {
+        return;
+    };
+    let current = current.trim();
+    if current.is_empty() || current == oid {
+        return;
+    }
+    let _ = git_ok(root, &["update-ref", &tracking, oid, current]);
 }
 
 fn single_push_destination(bytes: &[u8]) -> Option<String> {
@@ -1648,6 +1710,116 @@ fn shell_ok(root: &Path, command: &str) -> bool {
         .stderr(std::process::Stdio::null())
         .status()
         .is_ok_and(|s| s.success())
+}
+
+#[cfg(test)]
+mod target_ref_tests {
+    use super::*;
+
+    /// Operators think in branch names; the policy stores full refs. Requiring
+    /// the long spelling would make the command as fiddly as the hand-edit it
+    /// replaces (issue #42).
+    #[test]
+    fn a_retarget_accepts_either_spelling_and_refuses_unusable_refs() {
+        assert_eq!(normalize_target_ref("main").unwrap(), "refs/heads/main");
+        assert_eq!(
+            normalize_target_ref("  refs/heads/release/1.0  ").unwrap(),
+            "refs/heads/release/1.0"
+        );
+        for bad in [
+            "",
+            "   ",
+            "refs/tags/v1",
+            "main..other",
+            "with space",
+            "a@{0}",
+            "back\\slash",
+        ] {
+            assert!(
+                normalize_target_ref(bad).is_err(),
+                "{bad:?} must not become a delivery target"
+            );
+        }
+    }
+
+    /// The tracking ref is refreshed only when Git itself already created one,
+    /// and only to the OID the remote was just verified to hold. Inventing one
+    /// would assert remote state Yardlet did not observe.
+    #[test]
+    fn tracking_ref_refresh_touches_only_an_existing_stale_ref() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-tracking-ref-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        for args in [
+            &["init", "-q"][..],
+            &["config", "user.name", "Fixture"][..],
+            &["config", "user.email", "fixture@example.test"][..],
+        ] {
+            assert!(git_ok(&root, args), "git {args:?}");
+        }
+        std::fs::write(root.join("a.txt"), "a\n").unwrap();
+        assert!(git_ok(&root, &["add", "a.txt"]));
+        assert!(git_ok(&root, &["commit", "-qm", "one"]));
+        let first = git_stdout(&root, &["rev-parse", "HEAD"]).unwrap();
+        let first = first.trim().to_string();
+        std::fs::write(root.join("a.txt"), "b\n").unwrap();
+        assert!(git_ok(&root, &["add", "a.txt"]));
+        assert!(git_ok(&root, &["commit", "-qm", "two"]));
+        let second = git_stdout(&root, &["rev-parse", "HEAD"]).unwrap();
+        let second = second.trim().to_string();
+
+        // No tracking ref yet: nothing is invented.
+        refresh_remote_tracking_ref(&root, "origin", "refs/heads/main", &second);
+        assert!(
+            git_stdout(
+                &root,
+                &[
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    "refs/remotes/origin/main"
+                ]
+            )
+            .is_none(),
+            "a tracking ref must not be created out of thin air"
+        );
+
+        // A stale one is moved to the verified OID.
+        assert!(git_ok(
+            &root,
+            &["update-ref", "refs/remotes/origin/main", &first]
+        ));
+        refresh_remote_tracking_ref(&root, "origin", "refs/heads/main", &second);
+        assert_eq!(
+            git_stdout(&root, &["rev-parse", "refs/remotes/origin/main"])
+                .unwrap()
+                .trim(),
+            second,
+            "a verified push must leave the tracking ref current"
+        );
+
+        // A non-branch target is not a tracking-ref shape at all.
+        assert!(git_ok(
+            &root,
+            &["update-ref", "refs/remotes/origin/main", &first]
+        ));
+        refresh_remote_tracking_ref(&root, "origin", "refs/tags/v1", &second);
+        assert_eq!(
+            git_stdout(&root, &["rev-parse", "refs/remotes/origin/main"])
+                .unwrap()
+                .trim(),
+            first
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 }
 
 #[cfg(test)]

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -659,8 +659,20 @@ pub fn normalize_target_ref(root: &std::path::Path, requested: &str) -> anyhow::
     // would report success and every run would then fail with
     // `target_ref_invalid`, which is less actionable than the mismatch the
     // operator invoked this to clear.
-    if !git_ok(root, &["check-ref-format", &candidate]) {
-        anyhow::bail!("'{candidate}' is not a valid Git ref name");
+    match std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["check-ref-format", &candidate])
+        .output()
+    {
+        Ok(output) if output.status.success() => {}
+        // Distinguish "git rejected the name" from "git could not be run".
+        // Reporting a spawn failure as an invalid ref would send the operator
+        // looking at their branch name for a problem that is not there.
+        Ok(_) => anyhow::bail!("'{candidate}' is not a valid Git ref name"),
+        Err(error) => {
+            anyhow::bail!("could not run git to validate '{candidate}': {error}")
+        }
     }
     Ok(candidate)
 }
@@ -1097,6 +1109,10 @@ fn finish_owned_run_with_mode_and_github(
         block(&mut record, "worktree_changed_during_checks");
         return persist_result(record);
     }
+    // Refreshed only AFTER the outcome is durably recorded below: it is
+    // cosmetic, and widening the push-to-record crash window for it would trade
+    // a real guarantee for a nicety.
+    let mut tracking_ref_to_refresh = None;
     match remote_oid(&ws.root, &policy.remote, &policy.target_ref) {
         Ok(oid) if oid == remote_before => {}
         Ok(_) => {
@@ -1288,7 +1304,7 @@ fn finish_owned_run_with_mode_and_github(
             record.status = GitFinishStatus::Pushed;
             record.remote_oid = Some(oid.clone());
             record.reason = "remote_verified".to_string();
-            refresh_remote_tracking_ref(&ws.root, &policy.remote, &policy.target_ref, &oid);
+            tracking_ref_to_refresh = Some(oid);
         }
         Ok(oid) => {
             record.status = GitFinishStatus::RemoteMismatch;
@@ -1300,7 +1316,11 @@ fn finish_owned_run_with_mode_and_github(
             record.reason = "remote_lookup_after_push_failed".to_string();
         }
     }
-    persist_result(record)
+    let result = persist_result(record);
+    if let Some(oid) = tracking_ref_to_refresh {
+        refresh_remote_tracking_ref(&ws.root, &policy.remote, &policy.target_ref, &oid);
+    }
+    result
 }
 
 /// Move the local remote-tracking ref to the OID a verified push just put on

--- a/src/state.rs
+++ b/src/state.rs
@@ -5155,6 +5155,28 @@ pub fn save_git_finish_target_ref(path: &Path, target_ref: &str) -> Result<()> {
     let original =
         fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     let updated = apply_git_finish_target_edit(&original, target_ref);
+    // Prove the edit before committing it. This is hand-rolled line editing of
+    // Yardlet-owned canonical state: a shape the editor mishandles (a flow
+    // mapping, a file with no trailing newline, a same-named key at another
+    // depth) would otherwise write YAML that no longer parses, and every
+    // `yardlet` command in the workspace would fail with a parse error. There is
+    // no backup to fall back on, so the recovery would be exactly the hand-edit
+    // this writer exists to remove. Refusing is always better than corrupting.
+    let parsed: YardConfig = crate::yaml::from_str(&updated).map_err(|error| {
+        anyhow::anyhow!(
+            "refusing to write {}: the edit would not parse ({error}); \
+             set git_finish.target_ref by hand and report this config shape",
+            path.display()
+        )
+    })?;
+    if parsed.git_finish.target_ref != target_ref {
+        bail!(
+            "refusing to write {}: the edit did not set git_finish.target_ref to '{target_ref}' \
+             (it reads '{}'); set it by hand and report this config shape",
+            path.display(),
+            parsed.git_finish.target_ref
+        );
+    }
     write_str_atomic(path, &updated)
 }
 
@@ -5186,14 +5208,39 @@ fn apply_git_finish_target_edit(input: &str, target_ref: &str) -> String {
         })
         .map(|(index, _)| index)
         .unwrap_or(lines.len());
+    // The block's own indent, taken from its first child. Matching `indent > 0`
+    // instead would rewrite a same-named key nested deeper (a
+    // `pre_push_checks[].target_ref`, or one inside a block scalar) and return,
+    // leaving the real key unwritten.
+    let child_indent = lines
+        .iter()
+        .take(block_end)
+        .skip(block_start + 1)
+        .find_map(|line| {
+            yaml_key_line(split_line_ending(line).0)
+                .map(|(indent, _, _)| indent)
+                .filter(|indent| *indent > 0)
+        })
+        .unwrap_or(2);
     for line in lines.iter_mut().take(block_end).skip(block_start + 1) {
         let (body, eol) = split_line_ending(line);
-        if yaml_key_line(body).is_some_and(|(indent, key, _)| indent > 0 && key == "target_ref") {
+        if yaml_key_line(body)
+            .is_some_and(|(indent, key, _)| indent == child_indent && key == "target_ref")
+        {
             *line = format!("{}{}", replace_line_value(body, &scalar), eol);
             return lines.concat();
         }
     }
-    lines.insert(block_start + 1, format!("  target_ref: {value}\n"));
+    // A block header with no newline would otherwise be joined to the new key.
+    if let Some(header) = lines.get_mut(block_start) {
+        if !header.ends_with('\n') {
+            header.push('\n');
+        }
+    }
+    lines.insert(
+        block_start + 1,
+        format!("{}target_ref: {value}\n", " ".repeat(child_indent)),
+    );
     lines.concat()
 }
 
@@ -6596,6 +6643,53 @@ mod git_finish_target_tests {
             updated.find("target_ref").unwrap() < updated.find("language").unwrap(),
             "the key must land inside the block, not after it:\n{updated}"
         );
+    }
+
+    /// The writer edits Yardlet-owned canonical state by hand, so every case
+    /// must round-trip to a loadable config. Substring assertions alone let a
+    /// shape through that produced YAML no `yardlet` command could parse.
+    #[test]
+    fn every_edited_shape_still_parses_as_a_config() {
+        let base = "schema_version: 1\nproduct: yardlet\nworkspace_id: t\ncreated_at: \"2026-07-28T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: \"\"\n";
+        for (label, shape) in [
+            ("block with the key", "git_finish:\n  auto_push: false\n  target_ref: 'refs/heads/old'\n"),
+            ("block without the key", "git_finish:\n  auto_push: false\n"),
+            ("no block", ""),
+            ("block header last, no trailing newline", "git_finish:"),
+            ("flow mapping", "git_finish: {auto_push: false}\n"),
+            ("deeper same-named key", "git_finish:\n  auto_push: false\n  pre_push_checks:\n    - name: c\n      command: 'echo target_ref: decoy'\n"),
+            ("no trailing newline", "git_finish:\n  auto_push: false"),
+        ] {
+            let input = format!("{base}{shape}");
+            let updated = super::apply_git_finish_target_edit(&input, "refs/heads/main");
+            match crate::yaml::from_str::<crate::schemas::YardConfig>(&updated) {
+                Ok(config) => assert_eq!(
+                    config.git_finish.target_ref, "refs/heads/main",
+                    "{label}: parsed but did not take the value:\n{updated}"
+                ),
+                Err(error) => {
+                    // A shape the editor cannot handle must be REFUSED by the
+                    // writer, never written. Prove the guard catches it.
+                    let path = std::env::temp_dir().join(format!(
+                        "yard-target-shape-{}-{}.yaml",
+                        std::process::id(),
+                        label.replace(' ', "-")
+                    ));
+                    std::fs::write(&path, &input).unwrap();
+                    let refused = super::save_git_finish_target_ref(&path, "refs/heads/main");
+                    assert!(
+                        refused.is_err(),
+                        "{label}: writer produced unparseable YAML ({error}) and wrote it anyway"
+                    );
+                    assert_eq!(
+                        std::fs::read_to_string(&path).unwrap(),
+                        input,
+                        "{label}: a refused edit must leave the file untouched"
+                    );
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -5145,6 +5145,58 @@ enum ScalarValue<'a> {
     Usize(usize),
 }
 
+/// Set `git_finish.target_ref`, preserving the file's comments and layout.
+///
+/// `save_config_preserving_format` only rewrites top-level scalars, so a nested
+/// change made through it is silently dropped — the caller reports success over
+/// a file it never wrote. Delivery retargeting needs a real writer (issue #42),
+/// and it goes here because `.agents/` is written from one place.
+pub fn save_git_finish_target_ref(path: &Path, target_ref: &str) -> Result<()> {
+    let original =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let updated = apply_git_finish_target_edit(&original, target_ref);
+    write_str_atomic(path, &updated)
+}
+
+/// Rewrite (or introduce) `target_ref` inside the `git_finish:` block.
+fn apply_git_finish_target_edit(input: &str, target_ref: &str) -> String {
+    let mut lines = split_preserving_newlines(input);
+    let scalar = ScalarValue::String(target_ref);
+    let value = render_scalar("", &scalar);
+    let Some(block_start) = lines.iter().position(|line| {
+        yaml_key_line(split_line_ending(line).0)
+            .is_some_and(|(indent, key, _)| indent == 0 && key == "git_finish")
+    }) else {
+        // No block at all: add one rather than dropping the change.
+        if !lines.last().is_some_and(|line| line.ends_with('\n')) {
+            if let Some(last) = lines.last_mut() {
+                last.push('\n');
+            }
+        }
+        lines.push(format!("git_finish:\n  target_ref: {value}\n"));
+        return lines.concat();
+    };
+    // The block ends at the next line whose key is top-level.
+    let block_end = lines
+        .iter()
+        .enumerate()
+        .skip(block_start + 1)
+        .find(|(_, line)| {
+            yaml_key_line(split_line_ending(line).0).is_some_and(|(indent, _, _)| indent == 0)
+        })
+        .map(|(index, _)| index)
+        .unwrap_or(lines.len());
+    for line in lines.iter_mut().take(block_end).skip(block_start + 1) {
+        let (body, eol) = split_line_ending(line);
+        if yaml_key_line(body).is_some_and(|(indent, key, _)| indent > 0 && key == "target_ref") {
+            *line = format!("{}{}", replace_line_value(body, &scalar), eol);
+            return lines.concat();
+        }
+    }
+    lines.insert(block_start + 1, format!("  target_ref: {value}\n"));
+    lines.concat()
+}
+
 fn apply_top_level_edits(input: &str, edits: &[LineEdit<'_>]) -> Result<String> {
     let mut lines = split_preserving_newlines(input);
     for edit in edits {
@@ -6485,6 +6537,91 @@ pub fn place_skill_files_no_clobber(
             let _ = fs::remove_dir_all(&staging);
             Err(error).with_context(|| format!("placing skill {}", dst.display()))
         }
+    }
+}
+
+#[cfg(test)]
+mod git_finish_target_tests {
+    use super::apply_git_finish_target_edit;
+
+    /// The written value, quoting style aside.
+    fn target_line(text: &str) -> String {
+        text.lines()
+            .find_map(|line| line.trim().strip_prefix("target_ref:"))
+            .map(|value| {
+                value
+                    .trim()
+                    .trim_matches('\'')
+                    .trim_matches('"')
+                    .to_string()
+            })
+            .unwrap_or_default()
+    }
+
+    /// `save_config_preserving_format` only rewrites top-level scalars, so a
+    /// nested change made through it is silently dropped and the caller reports
+    /// success over a file it never wrote (issue #42).
+    #[test]
+    fn retarget_rewrites_the_nested_key_without_disturbing_the_file() {
+        let existing = "schema_version: 1\n# keep this comment\ngit_finish:\n  auto_push: false\n  # and this one\n  target_ref: 'refs/heads/old'\n  remote: origin\nlanguage: ko\n";
+        let updated = apply_git_finish_target_edit(existing, "refs/heads/main");
+        assert!(updated.contains("target_ref: 'refs/heads/main'"));
+        assert!(!updated.contains("refs/heads/old"));
+        for preserved in [
+            "# keep this comment",
+            "# and this one",
+            "auto_push: false",
+            "remote: origin",
+            "language: ko",
+        ] {
+            assert!(
+                updated.contains(preserved),
+                "lost {preserved:?}:\n{updated}"
+            );
+        }
+        assert_eq!(
+            updated.matches("target_ref:").count(),
+            1,
+            "the key must be rewritten, not duplicated"
+        );
+    }
+
+    #[test]
+    fn retarget_adds_the_key_to_a_block_that_lacks_it() {
+        let existing = "git_finish:\n  auto_push: true\nlanguage: en\n";
+        let updated = apply_git_finish_target_edit(existing, "refs/heads/main");
+        assert!(target_line(&updated) == "refs/heads/main", "{updated}");
+        assert!(updated.contains("auto_push: true"));
+        assert!(
+            updated.find("target_ref").unwrap() < updated.find("language").unwrap(),
+            "the key must land inside the block, not after it:\n{updated}"
+        );
+    }
+
+    #[test]
+    fn retarget_adds_the_block_when_the_file_has_none() {
+        for existing in ["language: en\n", "language: en"] {
+            let updated = apply_git_finish_target_edit(existing, "refs/heads/main");
+            assert!(updated.contains("language: en"));
+            assert!(
+                updated.contains("git_finish:\n  target_ref: "),
+                "a missing block must be introduced rather than dropping the change:\n{updated}"
+            );
+            assert_eq!(target_line(&updated), "refs/heads/main", "{updated}");
+        }
+    }
+
+    /// A key of the same name in a LATER top-level block must not be mistaken
+    /// for this one.
+    #[test]
+    fn retarget_stays_inside_its_own_block() {
+        let existing =
+            "git_finish:\n  auto_push: false\nother:\n  target_ref: 'refs/heads/decoy'\n";
+        let updated = apply_git_finish_target_edit(existing, "refs/heads/main");
+        assert!(updated.contains("refs/heads/decoy"), "{updated}");
+        let block = updated.split("other:").next().unwrap();
+        assert!(block.contains("target_ref: "), "{updated}");
+        assert!(block.contains("refs/heads/main"), "{updated}");
     }
 }
 


### PR DESCRIPTION
Closes #41 and #42 — two Git-finish frictions from live dogfooding, both in the same subsystem.

## #42 — the prescribed retarget had no command

The #36 fix deliberately blocks a run whose configured `target_ref` does not match the checkout, rather than silently retargeting. That was the right call. But the remedy it prescribes was performable only by hand-editing `.agents/<workspace>.yaml` — which CLAUDE.md explicitly tells operators not to do. Recovering a blocked run required exactly that edit.

```
yardlet target                      # show target + checkout, and say if they differ
yardlet target main                 # or refs/heads/main — both accepted
yardlet target --to-checkout        # what a blocked run is asking for
```

The blocked-run diagnostic now names the command instead of implying a config edit. The retarget is appended to `.agents/git-finish-target.log` so it is auditable.

### A real writer was needed

`save_config_preserving_format` only rewrites four top-level scalars (`language`, `default_access`, `max_parallel`, `auto_ime`). A nested change routed through it returns `Ok(false)` and writes nothing.

I hit this by running the command instead of trusting it: it printed `Git finish target set to refs/heads/release/1.0` and the very next `yardlet target` reported `(unset)`. A success message over an operation that did nothing is the worst shape for a command whose whole purpose is to replace a hand-edit.

So: `state::save_git_finish_target_ref` edits the nested key while preserving comments and layout, and `cmd_target` **reads the value back** before claiming the retarget happened.

## #41 — a verified push left `git status` saying "ahead"

Yardlet pushes to the exact URL pinned before the run, so a remote cannot be retargeted between the pin and the push. The cost: Git updates remote-tracking refs only when you push to a **named** remote. So after a push that `git ls-remote` confirms, the owning root still reported the branch ahead until someone fetched — which twice read as a failed auto-push during a session.

After `remote_verified`, move the tracking ref to the OID the remote was just confirmed to hold. Deliberately narrow:

- only a ref **Git itself already created** — never invented, because a workspace with a non-standard fetch refspec or one that has never fetched this branch has no such ref, and fabricating one would assert remote state Yardlet did not observe
- only when it is actually stale
- only for a `refs/heads/` target
- compare-and-swap against the current value, and best-effort — a failure here leaves the pre-existing cosmetic staleness and cannot affect the finish outcome

## Tests

- `a_retarget_accepts_either_spelling_and_refuses_unusable_refs` — branch name and full ref both normalize; tags, `..`, whitespace, `@{`, backslashes are refused.
- `tracking_ref_refresh_touches_only_an_existing_stale_ref` — on a real repo: nothing is created when no tracking ref exists, a stale one moves to the verified OID, and a non-branch target is left alone.
- Four `apply_git_finish_target_edit` cases: rewrite in place preserving comments (and not duplicating the key), add the key to a block that lacks it (inside the block, not after it), add the block when the file has none, and do not mistake a same-named key in a later top-level block for this one.

## Verification

- `cargo test` — 25 targets, 802 tests, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- CI parity: `cargo +1.82.0 check --locked --all-targets`, `cargo +1.97.1 clippy --all-targets` clean
- Both commands exercised end to end against a scratch repo, including the failure path