### PR TITLE
feat(harness): add `yardlet skill commit` so learned also means durable

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -283,6 +283,7 @@ Bracketed paste는 붙여넣은 줄바꿈과 한국어/CJK 본문을 그대로 �
 | `yardlet trust [--json]` | 실행 텔레메트리와 전이 감사 로그 기반 신뢰+자율성 리포트 (읽기 전용); `--json`은 지표를 내보냄. |
 | `yardlet recover` | 중단된 세션에서 상태 복구 (고아 실행, 미확인 계획). |
 | `yardlet skill list / suggest / equip <preset> / unequip / research / create / apply / review` | 저장소 분류, managed 11-skill catalog 사용, 스킬 장착·작성·점수화. Core skill은 외부 library 없이 설치되고 overlay는 task 범위에서만 활성화. |
+| `yardlet skill commit` | 학습된 하니스 자산을 커밋해 "학습됨"이 곧 "내구적"이 되게 함. |
 | `yardlet harness review` | 자동 학습된 규칙과 스킬을 eval 점수와 함께 표시, 그리고 마이닝된 개선 후보. |
 | `yardlet rubric drift / sync [--adopt-text]` | 워크스페이스 루브릭이 템플릿에 얼마나 뒤처졌는지 진단하고 개선을 병합 (비파괴적). |
 | `yardlet routing review` | 작업 종류별 워커 성공 통계 + 제안 선호도. |

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Bracketed paste preserves pasted newlines and Korean/CJK text.
 | `yardlet trust [--json]` | Trust + autonomy report from run telemetry and the transition audit log (read-only); `--json` emits the metrics. |
 | `yardlet recover` | Recover state from an interrupted session (orphaned runs, unread plans). |
 | `yardlet skill list / suggest / equip <preset> / unequip / research / create / apply / review` | Classify repos; use the managed 11-skill catalog; equip, author, and score skills. Core skills install without an external library; overlays stay task-scoped. |
+| `yardlet skill commit` | Commit learned harness assets so "learned" also means durable. |
 | `yardlet harness review` | Show auto-learned rules and skills with their eval scores, plus mined improvement candidates. |
 | `yardlet rubric drift / sync [--adopt-text]` | Diagnose how the workspace rubric lags the template and merge improvements in (non-destructive). |
 | `yardlet routing review` | Per-kind worker success stats + suggested preferences. |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -189,6 +189,12 @@ enum SkillCmd {
     },
     /// Install a skill previously drafted by `research`, by its run id.
     Apply { run: String },
+    /// Commit learned harness assets so "learned" also means durable.
+    Commit {
+        /// Show what would be committed and stop.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Show each equipped skill's eval score (from telemetry).
     Review,
 }
@@ -969,6 +975,23 @@ fn cmd_skill(cwd: &std::path::Path, args: SkillArgs) -> Result<()> {
             for l in &r.lines {
                 println!("  {l}");
             }
+        }
+        SkillCmd::Commit { dry_run } => {
+            let pending = crate::skills::uncommitted_harness_assets(&ws);
+            if pending.is_empty() {
+                println!("Every learned harness asset is already in git.");
+                return Ok(());
+            }
+            println!("Learned harness assets not yet in git:");
+            for path in &pending {
+                println!("  {path}");
+            }
+            if dry_run {
+                println!("\n(dry run — nothing committed)");
+                return Ok(());
+            }
+            let commit = crate::skills::commit_harness_assets(&ws, &pending)?;
+            println!("\nCommitted {} as {}.", pending.len(), commit);
         }
         SkillCmd::Review => {
             let scores = crate::skills::scores(&ws);

--- a/src/run.rs
+++ b/src/run.rs
@@ -7205,20 +7205,19 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             let untracked = untracked_harness_assets(ws, &learned, &rules);
             if !untracked.is_empty() {
                 lines.push(format!(
-                    "learned harness assets are NOT in git yet: {}. Track them with `git add {}`",
-                    untracked.join(", "),
-                    untracked.join(" ")
+                    "learned harness assets are NOT in git yet: {}. Commit them with \
+                     `yardlet skill commit`",
+                    untracked.join(", ")
                 ));
                 let note = format!(
                     "\n## Untracked harness assets\n\nThis run learned harness assets that are \
                      on disk but not in git:\n\n{}\n\nThey are not durable until committed:\n\n\
-                     ```\ngit add {}\n```\n",
+                     ```\nyardlet skill commit\n```\n",
                     untracked
                         .iter()
                         .map(|path| format!("- `{path}`"))
                         .collect::<Vec<_>>()
                         .join("\n"),
-                    untracked.join(" ")
                 );
                 let handoff = run_dir.join("handoff.md");
                 let mut existing = std::fs::read_to_string(&handoff).unwrap_or_default();

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -6,7 +6,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 
 use crate::inspect::RepoSummary;
@@ -1090,6 +1090,146 @@ pub fn scores(ws: &Workspace) -> Vec<SkillScore> {
     out
 }
 
+/// Learned harness assets that are on disk but not yet in git.
+///
+/// A learned skill that is not committed is not durable: `docs/skills.md` makes
+/// git the record and the safety net for skill learning with no human gate, so
+/// the gap between "learned" and "in git" is a gap in that safety net (issue
+/// #45). Reads the same two roots the learning loop writes.
+pub fn uncommitted_harness_assets(ws: &Workspace) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&ws.root)
+        .args([
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "-z",
+            "--",
+            ".agents/skills",
+            ".agents/rules",
+        ])
+        .env("LC_ALL", "C")
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let mut chunks = raw.split('\0');
+    let mut paths = Vec::new();
+    while let Some(entry) = chunks.next() {
+        if entry.len() < 4 {
+            continue;
+        }
+        let status = &entry[..2];
+        let path = entry[3..].to_string();
+        if status.starts_with('R') || status.starts_with('C') {
+            chunks.next();
+        }
+        if !path.is_empty() {
+            paths.push(path);
+        }
+    }
+    paths.retain(|path| is_learned_harness_asset(ws, path));
+    paths.sort();
+    paths.dedup();
+    paths
+}
+
+/// Is this path a LEARNED harness asset, as opposed to a library skill the
+/// operator equipped or a managed builtin?
+///
+/// `.agents/skills/` holds all three. Only the learned ones are what the
+/// learning loop writes with no human gate, and only they are what issue #45 is
+/// about — sweeping an equipped bundle into a `chore(harness)` commit would be
+/// a different, unrequested change to the operator's repository.
+fn is_learned_harness_asset(ws: &Workspace, path: &str) -> bool {
+    if let Some(rest) = path.strip_prefix(".agents/rules/") {
+        return rest.starts_with("learned-") && rest.ends_with(".md");
+    }
+    let Some(rest) = path.strip_prefix(".agents/skills/") else {
+        return false;
+    };
+    let Some(slug) = rest.split('/').next().filter(|slug| !slug.is_empty()) else {
+        return false;
+    };
+    // The bundle directory and anything carrying a managed marker came from the
+    // library, not from a run.
+    !slug.starts_with('.')
+        && !ws
+            .agents_dir()
+            .join("skills")
+            .join(slug)
+            .join(".yardlet-managed.yaml")
+            .exists()
+}
+
+/// Stage and commit exactly these paths, and nothing else.
+///
+/// Deliberately pathspec-scoped on BOTH sides: `.agents/` is shared with
+/// parallel sessions and the operator's own work, so a commit that swept in
+/// whatever else happened to be staged would violate the repo's own
+/// multi-session rule ("stage only the files you changed", never `git add -A`).
+pub fn commit_harness_assets(ws: &Workspace, paths: &[String]) -> Result<String> {
+    if paths.is_empty() {
+        bail!("no learned harness assets to commit");
+    }
+    let git = |args: &[&str]| -> Result<String> {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&ws.root)
+            .args(args)
+            .env("LC_ALL", "C")
+            .output()
+            .with_context(|| format!("running git {args:?}"))?;
+        if !output.status.success() {
+            bail!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    };
+    let mut add = vec!["add", "--"];
+    add.extend(paths.iter().map(String::as_str));
+    git(&add)?;
+    let summary = summarize_harness_assets(paths);
+    let mut commit = vec!["commit", "-m", &summary, "--"];
+    commit.extend(paths.iter().map(String::as_str));
+    git(&commit)?;
+    Ok(git(&["rev-parse", "--short", "HEAD"])?.trim().to_string())
+}
+
+/// A commit subject naming what was learned, matching the message operators
+/// have been writing by hand.
+fn summarize_harness_assets(paths: &[String]) -> String {
+    let names = paths
+        .iter()
+        .filter_map(|path| {
+            path.strip_prefix(".agents/skills/")
+                .and_then(|rest| rest.split('/').next())
+                .or_else(|| {
+                    path.strip_prefix(".agents/rules/")
+                        .and_then(|rest| rest.strip_suffix(".md"))
+                })
+        })
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    match names.len() {
+        0 => "chore(harness): track learned harness assets".to_string(),
+        1 => format!("chore(harness): track learned {}", names[0]),
+        _ => format!(
+            "chore(harness): track {} learned assets ({})",
+            names.len(),
+            names.join(", ")
+        ),
+    }
+}
+
 /// Minimum runs before a learned skill can be pruned (don't judge on noise).
 const PRUNE_MIN_RUNS: u32 = 3;
 /// Score floor below which a learned skill is pruned.
@@ -1315,6 +1455,148 @@ fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod harness_commit_tests {
+    use super::*;
+
+    fn git(root: &Path, args: &[&str]) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(root)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn repo(label: &str) -> Workspace {
+        let root = std::env::temp_dir().join(format!(
+            "yard-harness-commit-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join(".agents/rules")).unwrap();
+        std::fs::create_dir_all(root.join(".agents/skills")).unwrap();
+        git(&root, &["init", "-q"]);
+        git(&root, &["config", "user.name", "Fixture"]);
+        git(&root, &["config", "user.email", "fixture@example.test"]);
+        std::fs::write(root.join("base.txt"), "base\n").unwrap();
+        git(&root, &["add", "base.txt"]);
+        git(&root, &["commit", "-qm", "base"]);
+        Workspace::at(&root)
+    }
+
+    /// `.agents/skills/` holds learned skills, operator-equipped library skills,
+    /// and managed builtins. Only the first kind is what the learning loop
+    /// writes with no human gate, and only it is issue #45 — sweeping an
+    /// equipped bundle into a `chore(harness)` commit would be a different,
+    /// unrequested change to the operator's repository.
+    #[test]
+    fn only_learned_assets_are_offered_for_commit() {
+        let ws = repo("scope");
+        let skills = ws.agents_dir().join("skills");
+        for (slug, managed) in [("learned-one", false), ("equipped", true)] {
+            std::fs::create_dir_all(skills.join(slug)).unwrap();
+            std::fs::write(skills.join(slug).join("SKILL.md"), "# s\n").unwrap();
+            if managed {
+                std::fs::write(
+                    skills.join(slug).join(".yardlet-managed.yaml"),
+                    "source: library\n",
+                )
+                .unwrap();
+            }
+        }
+        std::fs::create_dir_all(skills.join(".yardlet-managed-bundle")).unwrap();
+        std::fs::write(
+            skills.join(".yardlet-managed-bundle/manifest.yaml"),
+            "bundle: true\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ws.agents_dir().join("rules/learned-thing.md"),
+            "# learned\n",
+        )
+        .unwrap();
+        std::fs::write(
+            ws.agents_dir().join("rules/handwritten.md"),
+            "# operator's own\n",
+        )
+        .unwrap();
+
+        let pending = uncommitted_harness_assets(&ws);
+        assert_eq!(
+            pending,
+            vec![
+                ".agents/rules/learned-thing.md".to_string(),
+                ".agents/skills/learned-one/SKILL.md".to_string(),
+            ],
+            "only learned assets belong in a `yardlet skill commit`"
+        );
+
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// `.agents/` is shared with parallel sessions and the operator's own work,
+    /// so this must never sweep in whatever else happens to be staged — the
+    /// repo's own multi-session rule.
+    #[test]
+    fn committing_learned_assets_leaves_other_staged_work_alone() {
+        let ws = repo("scope-commit");
+        let skills = ws.agents_dir().join("skills");
+        std::fs::create_dir_all(skills.join("learned-one")).unwrap();
+        std::fs::write(skills.join("learned-one/SKILL.md"), "# s\n").unwrap();
+        std::fs::write(ws.root.join("unrelated.txt"), "someone else\n").unwrap();
+        git(&ws.root, &["add", "unrelated.txt"]);
+
+        let pending = uncommitted_harness_assets(&ws);
+        let commit = commit_harness_assets(&ws, &pending).unwrap();
+        assert!(!commit.is_empty());
+
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&ws.root)
+            .args(["show", "--name-only", "--format=", "HEAD"])
+            .output()
+            .unwrap();
+        let touched = String::from_utf8_lossy(&output.stdout);
+        assert!(touched.contains(".agents/skills/learned-one/SKILL.md"));
+        assert!(
+            !touched.contains("unrelated.txt"),
+            "another session's staged file must not ride along: {touched}"
+        );
+        assert!(
+            uncommitted_harness_assets(&ws).is_empty(),
+            "a second run has nothing left to do"
+        );
+
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn the_commit_subject_names_what_was_learned() {
+        assert_eq!(
+            summarize_harness_assets(&[".agents/skills/red-base/SKILL.md".into()]),
+            "chore(harness): track learned red-base"
+        );
+        assert_eq!(
+            summarize_harness_assets(&[
+                ".agents/skills/red-base/SKILL.md".into(),
+                ".agents/skills/red-base/notes.md".into(),
+                ".agents/rules/learned-x.md".into(),
+            ]),
+            "chore(harness): track 2 learned assets (learned-x, red-base)"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #45.

## The gap

`docs/skills.md` makes git the record and the safety net for skill learning with no human gate. But a learned skill lands untracked in the owning root, so the operator had to notice the path and hand-write a `chore(harness): track learned …` commit every time — nine in a single 2026-07-24 batch.

PR #76 added the notice (the issue's option b). This adds the command (option c):

```
yardlet skill commit [--dry-run]
```

The run's notice and handoff now name it instead of a raw `git add`.

## Why not option (a)

The issue prefers folding the assets into the run's own integration commit, as "run-authored content flowing through the normal evidence path". I did not do that, and the reason is structural: the learning loop writes into the **owning root** after the worker finishes, not into the run-owned worktree.

- Committing there **before** integration moves the HEAD that `git_finish` pins as the run's owned OID.
- Committing **after** integration lands outside the range that was pushed and verified.

Entangling the ownership proof with harness bookkeeping to save one command is the wrong trade. The command stays separate.

## Two things it is careful about

**Scope.** `.agents/skills/` holds learned skills, operator-equipped library skills, and managed builtins. Only the learned ones come from the no-gate loop, so only they are offered — a skill directory carrying `.yardlet-managed.yaml`, and the `.yardlet-managed-bundle` directory, are excluded, as are `.agents/rules/` files without the `learned-` prefix.

My first cut swept the whole `.agents/skills/` tree, including the managed bundle and an operator's equipped library skills. That would have been a different, unrequested change to their repository, and I found it by running the command rather than trusting it.

**Other people's work.** `.agents/` is shared with parallel sessions, so both the `git add` and the `git commit` are pathspec-scoped. A file another session had staged stays staged and out of the commit — the repo's own multi-session rule ("stage only the files you changed", never `git add -A`).

## Tests

- `only_learned_assets_are_offered_for_commit` — a learned skill, an equipped skill with a managed marker, the managed bundle, a learned rule, and an operator's hand-written rule; only the two learned ones are offered.
- `committing_learned_assets_leaves_other_staged_work_alone` — another session's staged file stays staged and is absent from the commit; a second run has nothing left to do.
- `the_commit_subject_names_what_was_learned` — the subject matches the message operators have been writing by hand.

Exercised end to end on a scratch repo, including the dry run, the idempotent second run, and the other-staged-work case.

## Verification

- `cargo test` — 25 targets, 811 tests, 0 failed
- `cargo fmt --check` clean, `cargo clippy --all-targets` clean
- Both READMEs list the command