### PR TITLE
chore(ci): keep clap_lex on 1.0 while the MSRV is 1.82

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
       - dependency-name: clap
         update-types:
           - version-update:semver-minor
+      # clap_lex 1.1 ships an edition-2024 manifest, which Cargo 1.82 cannot
+      # even parse. Keep receiving 1.0 patches while the MSRV is 1.82.
+      - dependency-name: clap_lex
+        update-types:
+          - version-update:semver-minor
       # Ratatui 0.30 requires Rust 1.88. Keep receiving 0.29 patches and
       # security updates until Yardlet deliberately raises its MSRV.
       - dependency-name: ratatui


### PR DESCRIPTION
Dependabot's #78 (clap_lex 1.0.1 -> 1.1.0) fails the MSRV (1.82.0) job, and not because of Yardlet's code: clap_lex 1.1.0 ships an edition-2024 manifest, so cargo 1.82 refuses to parse it before compiling anything.

```
error: failed to parse manifest at `.../clap_lex-1.1.0/Cargo.toml`
Caused by:
  feature `edition2024` is required
```

That is the same wall the `clap` 4.6 entry already documents, so this adds the matching `clap_lex` entry: 1.0 patches and security updates keep flowing, minor bumps stop until the MSRV is deliberately raised.

#78 is closed as not-mergeable-under-1.82 rather than left failing.