### PR TITLE
chore(harness): track learned yardlet-binary-crate-focused-tests

### DIFF
--- a/.agents/skills/yardlet-binary-crate-focused-tests/SKILL.md
+++ b/.agents/skills/yardlet-binary-crate-focused-tests/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: yardlet-binary-crate-focused-tests
+description: yardlet-binary-crate-focused-tests
+source: learned
+---
+yardlet은 lib 타깃이 없는 binary crate다. 모듈 내 #[cfg(test)] 유닛 테스트를 좁혀 실행할 땐 `cargo test --bin yardlet <필터>`를 쓴다 — `cargo test --lib`는 'no library targets found'로 실패한다. 전체 스위트는 그냥 `cargo test`.


### PR DESCRIPTION
The PR #97 review run learned a skill, and #97's own notice is what produced this commit: `yardlet skill commit` staged and committed exactly the one learned asset, pathspec-scoped, with the subject operators had been writing by hand.

First real use of the command on the repository that ships it. The dry run offered only the learned skill, not the marker-less `planning-gate` scaffold or any equipped library skill, and a second run reported nothing left to do.