### PR TITLE
test(pty): make the PTY harness say what it actually verified

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,6 +8,188 @@ use std::path::{Path, PathBuf};
 use std::process::Child;
 use std::time::{Duration, Instant};
 
+// Re-exported for `use common::{...}` at the call sites. A test binary that needs
+// only some of them still compiles this module whole, so the rest look unused.
+#[cfg(unix)]
+#[allow(unused_imports)]
+pub use pty::{drain, norm, open_pty, recent, resize_pty, seen, strip_ansi, wait_for_marker};
+
+/// The PTY harness the TUI process tests drive the app through.
+///
+/// This lived as four copy-pasted blocks, one per test file, which is how the
+/// same defect could be fixed in one of them and stay open in the other three
+/// (issue #92). One home means one place to fix.
+#[cfg(unix)]
+mod pty {
+    use std::fs::File;
+    use std::io::{ErrorKind, Read};
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::time::{Duration, Instant};
+
+    /// How much rendered tail a failure message carries.
+    const RECENT_CHARS: usize = 900;
+
+    /// Open a pseudo-terminal at an explicit size, with a non-blocking master.
+    ///
+    /// The size is the caller's contract, not a harness default: a screen that
+    /// fits at 40 rows can hide a scrolling defect that a real 24-row terminal
+    /// shows (issue #71, where a 40-row test hid the very key the issue was
+    /// filed about).
+    pub fn open_pty(rows: u16, cols: u16) -> (File, File) {
+        let mut master = -1;
+        let mut slave = -1;
+        let mut size = libc::winsize {
+            ws_row: rows,
+            ws_col: cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        let rc = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut size as *mut libc::winsize,
+            )
+        };
+        assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
+        let master = unsafe { File::from_raw_fd(master) };
+        let slave = unsafe { File::from_raw_fd(slave) };
+        let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
+        assert!(flags >= 0);
+        let rc =
+            unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
+        assert_eq!(rc, 0);
+        (master, slave)
+    }
+
+    /// Resize, which also forces a full repaint.
+    ///
+    /// Ratatui writes only CHANGED cells, so a string on scrolled content can be
+    /// missing any character whose cell already held it. A resize makes the next
+    /// frame a complete one.
+    pub fn resize_pty(master: &File, rows: u16, cols: u16) {
+        let size = libc::winsize {
+            ws_row: rows,
+            ws_col: cols,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        let rc = unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCSWINSZ, &size) };
+        assert_eq!(
+            rc,
+            0,
+            "TIOCSWINSZ failed: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    /// Drain everything currently readable into `sink`.
+    ///
+    /// Draining continuously is mandatory: if the PTY buffer fills, the child
+    /// blocks on its next render and the whole TUI event loop stalls.
+    pub fn drain(master: &mut File, sink: &mut Vec<u8>) {
+        let mut buffer = [0_u8; 8192];
+        loop {
+            match master.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(count) => sink.extend_from_slice(&buffer[..count]),
+                Err(error) if error.kind() == ErrorKind::WouldBlock => break,
+                Err(error) => panic!("PTY read failed: {error}"),
+            }
+        }
+    }
+
+    /// Remove ANSI/VT control sequences so the visible glyphs collapse into
+    /// reading order.
+    ///
+    /// Ratatui positions every wide (CJK) cell with its own cursor-move escape,
+    /// so a Korean word is NOT a contiguous byte run in the raw stream —
+    /// stripping the escapes is what makes it one again.
+    pub fn strip_ansi(bytes: &[u8]) -> String {
+        let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0x1b {
+                match bytes.get(i + 1) {
+                    Some(b'[') => {
+                        // CSI: consume params/intermediates up to the final byte.
+                        i += 2;
+                        while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
+                            i += 1;
+                        }
+                        i += usize::from(i < bytes.len());
+                    }
+                    Some(b']') => {
+                        // OSC: terminated by BEL or ST (ESC \).
+                        i += 2;
+                        while i < bytes.len() {
+                            if bytes[i] == 0x07 {
+                                i += 1;
+                                break;
+                            }
+                            if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
+                                i += 2;
+                                break;
+                            }
+                            i += 1;
+                        }
+                    }
+                    Some(_) => i += 2, // other two-byte escapes
+                    None => break,
+                }
+            } else {
+                out.push(bytes[i]);
+                i += 1;
+            }
+        }
+        String::from_utf8_lossy(&out).into_owned()
+    }
+
+    /// Whitespace between cells is emitted as cursor motion too, so compare the
+    /// visible text with all whitespace removed.
+    pub fn norm(s: &str) -> String {
+        s.chars().filter(|c| !c.is_whitespace()).collect()
+    }
+
+    /// Is `marker` in this slice of rendered output?
+    ///
+    /// Pass the slice the assertion is ABOUT. A cumulative sink holds every frame
+    /// the session ever drew, so a marker matched against all of it says nothing
+    /// about the screen under test — that is how removing `Esc` handling once left
+    /// its test passing (issue #92).
+    pub fn seen(sink: &[u8], marker: &str) -> bool {
+        norm(&strip_ansi(sink)).contains(&norm(marker))
+    }
+
+    /// The rendered tail, for a failure message.
+    pub fn recent(sink: &[u8]) -> String {
+        let text = strip_ansi(sink);
+        let chars: Vec<char> = text.chars().collect();
+        let start = chars.len().saturating_sub(RECENT_CHARS);
+        chars[start..].iter().collect()
+    }
+
+    /// Read (draining) until `marker` shows up in `sink`, or panic with the tail
+    /// of what was actually rendered.
+    pub fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: Duration) {
+        let deadline = Instant::now() + within;
+        loop {
+            drain(master, sink);
+            if seen(sink, marker) {
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "marker {marker:?} not seen within {within:?}; recent output:\n{}",
+                recent(sink)
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
 /// Kills and reaps a spawned child on drop.
 ///
 /// `std::process::Child` does NOT kill on drop, so a failing assertion unwinds

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -358,18 +358,46 @@ pub fn wait_for_file_contents(
 /// it running for the rest of its own timeout (the failover hook polls for 200
 /// seconds).
 ///
-/// Skips a hook that already finished: the pid file is removed on the hook's clean
-/// exit, so a missing file means nothing to do rather than a pid to guess at. That
-/// ordering is what keeps this from signalling a recycled pid.
+/// # Why it checks identity before signalling
+///
+/// A pid file is not proof. The process removes it on a clean exit, but a hook
+/// that is killed — or that trips `set -e` — leaves the number behind, and the
+/// test may then sit for another minute. Once the OS recycles that pid, killing
+/// it blind takes down whatever unrelated process now holds it.
+///
+/// So the pid is only a candidate. Before signalling, the guard reads the live
+/// process's command line and requires `expected` to appear in it. A recycled pid
+/// is not running the fixture script, so it does not match and is left alone.
+/// This is the same rule Yardlet applies to its own workers, which never signal a
+/// recorded pid without cross-checking its process identity first.
 #[cfg(unix)]
 pub struct PidFileGuard {
     path: PathBuf,
+    expected: String,
 }
 
 #[cfg(unix)]
 impl PidFileGuard {
-    pub fn new(path: PathBuf) -> Self {
-        Self { path }
+    /// `expected` must appear in the target's command line for the kill to happen.
+    /// Use something only that process could carry — a fixture script's filename.
+    pub fn new(path: PathBuf, expected: impl Into<String>) -> Self {
+        Self {
+            path,
+            expected: expected.into(),
+        }
+    }
+
+    /// The live command line for `pid`, or `None` if it is gone or unreadable.
+    fn command_line(pid: libc::pid_t) -> Option<String> {
+        let output = std::process::Command::new("ps")
+            .args(["-p", &pid.to_string(), "-o", "args="])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!line.is_empty()).then_some(line)
     }
 }
 
@@ -379,14 +407,24 @@ impl Drop for PidFileGuard {
         let Ok(raw) = std::fs::read_to_string(&self.path) else {
             return; // the process removed its own pid file: it is gone
         };
-        if let Ok(pid) = raw.trim().parse::<libc::pid_t>() {
-            if pid > 0 {
-                unsafe {
-                    libc::kill(pid, libc::SIGKILL);
-                }
-            }
-        }
         let _ = std::fs::remove_file(&self.path);
+        let Ok(pid) = raw.trim().parse::<libc::pid_t>() else {
+            return;
+        };
+        if pid <= 0 {
+            return;
+        }
+        // Identity, not just liveness: a stale pid the OS has handed to someone
+        // else is exactly what must NOT be signalled.
+        let Some(command) = Self::command_line(pid) else {
+            return;
+        };
+        if !command.contains(&self.expected) {
+            return;
+        }
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -202,68 +202,29 @@ mod pty {
 ///
 /// # What it reaches, and what it does not
 ///
-/// `kill` signals ONE pid. A child that spawns its own children leaves them
-/// behind, which an independent review of this work demonstrated directly:
-/// `sh -c 'sleep 30 & wait'` under a guard left the inner `sleep` alive after
-/// both `drop` and `kill_now`.
+/// The DIRECT child, and only that. `kill` signals one pid, so a descendant is
+/// not covered — an independent review demonstrated it with `sh -c 'sleep 30 &
+/// wait'`, whose inner `sleep` outlived the guard.
 ///
-/// [`ChildGuard::spawn_group_leader`] closes that: the child leads its own
-/// process group, so a negative-pid signal reaches everything it started.
+/// A group-leader variant was tried and withdrawn. Putting the child in its own
+/// process group does let a negative-pid signal reach the tree, but it also
+/// removes the child from the test harness's group, so a developer's Ctrl-C no
+/// longer reaches it — and signal termination does not run `Drop`, so nothing
+/// else cleans up either. That trade only pays when the tree is actually
+/// reachable, and at every site here it is not: a Yardlet worker regroups itself
+/// on purpose (`src/workers/mod.rs` `process_group(0)`, issue #52) so it survives
+/// the terminal, so it escapes a group kill regardless. The remaining sites spawn
+/// leaves with no children at all.
 ///
-/// It still does NOT reach a descendant that deliberately leads a group of its
-/// own. Yardlet workers do exactly that on purpose (`src/workers/mod.rs`
-/// `process_group(0)`, issue #52) so they survive the terminal. A killed
-/// `yardlet run` therefore orphans its worker no matter what this guard does —
-/// that gap belongs to Yardlet's own teardown, not to a test helper.
+/// So a killed `yardlet run` orphans its worker no matter what this helper does.
+/// That gap is Yardlet's own teardown (issue #107), not a test helper's.
 pub struct ChildGuard {
     child: Option<Child>,
-    /// Did we make this child a group leader? Only then is `-pid` a group this
-    /// guard owns, rather than whichever unrelated group happens to share the
-    /// number.
-    own_group: bool,
 }
 
 impl ChildGuard {
     pub fn new(child: Child) -> Self {
-        Self {
-            child: Some(child),
-            own_group: false,
-        }
-    }
-
-    /// Spawn with the child as its own process-group leader, so the guard can
-    /// take down the tree the child goes on to build.
-    ///
-    /// Use this for a child that spawns further processes. Do NOT use it for a
-    /// child that reads a PTY the test also drives: a background process group
-    /// reading its controlling terminal takes SIGTTIN.
-    #[cfg(unix)]
-    pub fn spawn_group_leader(command: &mut std::process::Command) -> Self {
-        use std::os::unix::process::CommandExt;
-        command.process_group(0);
-        Self {
-            child: Some(command.spawn().expect("spawn guarded child")),
-            own_group: true,
-        }
-    }
-
-    /// Signal the group this guard created, then the pid itself as the backstop.
-    ///
-    /// Mirrors `workers::terminate_worker_tree`: a group signal targets
-    /// `pgid == pid`, which is only ours when we made the child a leader.
-    #[cfg(unix)]
-    fn kill_tree(child: &mut Child, own_group: bool) {
-        if own_group {
-            unsafe {
-                libc::kill(-(child.id() as libc::pid_t), libc::SIGKILL);
-            }
-        }
-        let _ = child.kill();
-    }
-
-    #[cfg(not(unix))]
-    fn kill_tree(child: &mut Child, _own_group: bool) {
-        let _ = child.kill();
+        Self { child: Some(child) }
     }
 
     /// The live child, for a test that polls its own exit.
@@ -296,9 +257,8 @@ impl ChildGuard {
     /// Idempotent, and safe before `Drop`: the drop sees an already-reaped child
     /// and does not signal a pid it no longer owns.
     pub fn kill_now(&mut self) {
-        let own_group = self.own_group;
         if let Some(child) = self.child.as_mut() {
-            Self::kill_tree(child, own_group);
+            let _ = child.kill();
             let _ = child.wait();
         }
     }
@@ -309,7 +269,6 @@ impl ChildGuard {
     /// blocked writing into a full buffer would otherwise never reach its own
     /// shutdown and would always be killed here.
     pub fn shutdown(&mut self, within: Duration, mut tick: impl FnMut()) {
-        let own_group = self.own_group;
         let Some(child) = self.child.as_mut() else {
             return;
         };
@@ -323,19 +282,18 @@ impl ChildGuard {
             tick();
             std::thread::sleep(Duration::from_millis(20));
         }
-        Self::kill_tree(child, own_group);
+        let _ = child.kill();
         let _ = child.wait();
     }
 }
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
-        let own_group = self.own_group;
         let Some(mut child) = self.child.take() else {
             return;
         };
         if matches!(child.try_wait(), Ok(None)) {
-            Self::kill_tree(&mut child, own_group);
+            let _ = child.kill();
         }
         let _ = child.wait();
     }
@@ -392,6 +350,46 @@ pub fn wait_for_file_contents(
     }
 }
 
+/// Kills a process the test has no `Child` for, identified by a pid file it wrote.
+///
+/// For a process a test causes but does not spawn: a post-run hook, a fixture
+/// script started by the program under test. `ChildGuard` cannot cover those —
+/// there is no handle — and an assertion that fires while one is mid-loop leaves
+/// it running for the rest of its own timeout (the failover hook polls for 200
+/// seconds).
+///
+/// Skips a hook that already finished: the pid file is removed on the hook's clean
+/// exit, so a missing file means nothing to do rather than a pid to guess at. That
+/// ordering is what keeps this from signalling a recycled pid.
+#[cfg(unix)]
+pub struct PidFileGuard {
+    path: PathBuf,
+}
+
+#[cfg(unix)]
+impl PidFileGuard {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for PidFileGuard {
+    fn drop(&mut self) {
+        let Ok(raw) = std::fs::read_to_string(&self.path) else {
+            return; // the process removed its own pid file: it is gone
+        };
+        if let Ok(pid) = raw.trim().parse::<libc::pid_t>() {
+            if pid > 0 {
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
 /// Removes one exact temp workspace on drop.
 ///
 /// `ChildGuard` closed half of issue #64; this closes the other half. Every PTY
@@ -419,16 +417,26 @@ impl WorkspaceGuard {
     ///
     /// Panics if the path already exists: this guard deletes what it owns, so
     /// adopting a directory someone else made is exactly the mistake to prevent.
+    ///
+    /// The check is the creation itself, not an `exists()` before it. `exists()`
+    /// then `create_dir_all` is TOCTOU: an independent review ran five threads at
+    /// one root through a barrier and got five guards that all believed they owned
+    /// it, on the first round. `create_dir` fails with `AlreadyExists` in the
+    /// kernel, so exactly one caller can win.
     pub fn create(root: PathBuf) -> Self {
-        assert!(
-            !root.exists(),
-            "test workspace {} already exists; a guard must not adopt (and later \
-             delete) a directory it did not create — give each test root a unique \
-             name",
-            root.display()
-        );
-        std::fs::create_dir_all(&root).expect("create test workspace");
-        Self { root }
+        if let Some(parent) = root.parent() {
+            std::fs::create_dir_all(parent).expect("create the test root's parent");
+        }
+        match std::fs::create_dir(&root) {
+            Ok(()) => Self { root },
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => panic!(
+                "test workspace {} already exists; a guard must not adopt (and later \
+                 delete) a directory it did not create — give each test root a unique \
+                 name",
+                root.display()
+            ),
+            Err(error) => panic!("create test workspace {}: {error}", root.display()),
+        }
     }
 
     pub fn path(&self) -> &Path {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,6 +41,27 @@ impl ChildGuard {
             .id()
     }
 
+    /// Hand the child back for `wait_with_output`, which consumes it.
+    ///
+    /// The guard is spent from here on, which is the point: it covered the window
+    /// that actually leaked — every assertion between the spawn and the moment
+    /// the test collects the output.
+    pub fn into_inner(mut self) -> Child {
+        self.child.take().expect("child guard used after shutdown")
+    }
+
+    /// Kill and reap now, for a test that deliberately cuts its child off
+    /// mid-flight (a crash window, a decoy that must never finish).
+    ///
+    /// Idempotent, and safe before `Drop`: the drop sees an already-reaped child
+    /// and does not signal a pid it no longer owns.
+    pub fn kill_now(&mut self) {
+        if let Some(child) = self.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+
     /// Wait out a clean exit, killing after `within` if it never comes.
     ///
     /// `tick` runs between polls so a test can keep draining its PTY: a child

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,6 +4,7 @@
 //! some of them need still looks unused to the rest.
 #![allow(dead_code)]
 
+use std::path::{Path, PathBuf};
 use std::process::Child;
 use std::time::{Duration, Instant};
 
@@ -73,5 +74,104 @@ impl Drop for ChildGuard {
             let _ = child.kill();
         }
         let _ = child.wait();
+    }
+}
+
+/// Wait until a fixture file exists AND says what the caller is about to assert,
+/// returning those contents.
+///
+/// The predicate is the point. Waiting on `path.exists()` and then reading is a
+/// race the harness loses on a loaded machine: the writer creates the file and
+/// fills it in two steps, so the read lands between them and the assertion fails
+/// on an EMPTY string. That is not a wrong value being caught, it is no value
+/// having arrived — the wait predicate was weaker than what the assertion needed.
+///
+/// Observed on CI (a one-file `chore` commit that touches no code failed
+/// `slow_startup_then_ko_review_then_multiline_revision_over_one_pty` with
+/// `packet:` printed empty) and reproduced locally at 1 in 3 with a prebuilt
+/// binary.
+///
+/// `tick` runs between polls so the caller keeps draining its PTY: a child
+/// blocked writing into a full buffer would otherwise never finish the write
+/// being waited on.
+///
+/// On timeout, `Err` carries what the file last held (or why it could not be
+/// read) so the failure says which of the two it was.
+pub fn wait_for_file_contents(
+    path: &Path,
+    within: Duration,
+    mut tick: impl FnMut(),
+    ready: impl Fn(&str) -> bool,
+) -> Result<String, String> {
+    let deadline = Instant::now() + within;
+    let mut last = String::from("(file never appeared)");
+    loop {
+        tick();
+        match std::fs::read_to_string(path) {
+            Ok(text) => {
+                if ready(&text) {
+                    return Ok(text);
+                }
+                last = if text.is_empty() {
+                    String::from("(file present but empty)")
+                } else {
+                    text
+                };
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => last = format!("(unreadable: {error})"),
+        }
+        if Instant::now() >= deadline {
+            return Err(last);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Removes one exact temp workspace on drop.
+///
+/// `ChildGuard` closed half of issue #64; this closes the other half. Every PTY
+/// test ended with `fs::remove_dir_all(&root)` on the happy path ONLY, so a
+/// failing assertion unwound past it and abandoned the workspace — two were
+/// found in the system temp directory after a single reproduction run of the
+/// `wait_for_file` race.
+///
+/// Owns exactly the path it was given and nothing else: no globbing over the
+/// temp directory, no removal of workspaces other runs left behind. A
+/// concurrent test's workspace is not this guard's business.
+pub struct WorkspaceGuard {
+    root: PathBuf,
+}
+
+impl WorkspaceGuard {
+    /// Create the workspace fresh, and own it until the test's scope ends.
+    pub fn create(root: PathBuf) -> Self {
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).expect("create test workspace");
+        Self { root }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.root
+    }
+
+    /// Join a path inside the workspace.
+    pub fn join(&self, tail: impl AsRef<Path>) -> PathBuf {
+        self.root.join(tail)
+    }
+
+    /// Give up ownership without removing, for a test that wants the workspace
+    /// left on disk for inspection.
+    pub fn keep(mut self) -> PathBuf {
+        std::mem::replace(&mut self.root, PathBuf::new())
+    }
+}
+
+impl Drop for WorkspaceGuard {
+    fn drop(&mut self) {
+        if self.root.as_os_str().is_empty() {
+            return;
+        }
+        let _ = std::fs::remove_dir_all(&self.root);
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -199,13 +199,71 @@ mod pty {
 ///
 /// The clean-quit path stays in the tests — it exercises the app's own shutdown
 /// and is worth asserting on — and this sits underneath it as the backstop.
+///
+/// # What it reaches, and what it does not
+///
+/// `kill` signals ONE pid. A child that spawns its own children leaves them
+/// behind, which an independent review of this work demonstrated directly:
+/// `sh -c 'sleep 30 & wait'` under a guard left the inner `sleep` alive after
+/// both `drop` and `kill_now`.
+///
+/// [`ChildGuard::spawn_group_leader`] closes that: the child leads its own
+/// process group, so a negative-pid signal reaches everything it started.
+///
+/// It still does NOT reach a descendant that deliberately leads a group of its
+/// own. Yardlet workers do exactly that on purpose (`src/workers/mod.rs`
+/// `process_group(0)`, issue #52) so they survive the terminal. A killed
+/// `yardlet run` therefore orphans its worker no matter what this guard does —
+/// that gap belongs to Yardlet's own teardown, not to a test helper.
 pub struct ChildGuard {
     child: Option<Child>,
+    /// Did we make this child a group leader? Only then is `-pid` a group this
+    /// guard owns, rather than whichever unrelated group happens to share the
+    /// number.
+    own_group: bool,
 }
 
 impl ChildGuard {
     pub fn new(child: Child) -> Self {
-        Self { child: Some(child) }
+        Self {
+            child: Some(child),
+            own_group: false,
+        }
+    }
+
+    /// Spawn with the child as its own process-group leader, so the guard can
+    /// take down the tree the child goes on to build.
+    ///
+    /// Use this for a child that spawns further processes. Do NOT use it for a
+    /// child that reads a PTY the test also drives: a background process group
+    /// reading its controlling terminal takes SIGTTIN.
+    #[cfg(unix)]
+    pub fn spawn_group_leader(command: &mut std::process::Command) -> Self {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+        Self {
+            child: Some(command.spawn().expect("spawn guarded child")),
+            own_group: true,
+        }
+    }
+
+    /// Signal the group this guard created, then the pid itself as the backstop.
+    ///
+    /// Mirrors `workers::terminate_worker_tree`: a group signal targets
+    /// `pgid == pid`, which is only ours when we made the child a leader.
+    #[cfg(unix)]
+    fn kill_tree(child: &mut Child, own_group: bool) {
+        if own_group {
+            unsafe {
+                libc::kill(-(child.id() as libc::pid_t), libc::SIGKILL);
+            }
+        }
+        let _ = child.kill();
+    }
+
+    #[cfg(not(unix))]
+    fn kill_tree(child: &mut Child, _own_group: bool) {
+        let _ = child.kill();
     }
 
     /// The live child, for a test that polls its own exit.
@@ -238,8 +296,9 @@ impl ChildGuard {
     /// Idempotent, and safe before `Drop`: the drop sees an already-reaped child
     /// and does not signal a pid it no longer owns.
     pub fn kill_now(&mut self) {
+        let own_group = self.own_group;
         if let Some(child) = self.child.as_mut() {
-            let _ = child.kill();
+            Self::kill_tree(child, own_group);
             let _ = child.wait();
         }
     }
@@ -250,6 +309,7 @@ impl ChildGuard {
     /// blocked writing into a full buffer would otherwise never reach its own
     /// shutdown and would always be killed here.
     pub fn shutdown(&mut self, within: Duration, mut tick: impl FnMut()) {
+        let own_group = self.own_group;
         let Some(child) = self.child.as_mut() else {
             return;
         };
@@ -263,18 +323,19 @@ impl ChildGuard {
             tick();
             std::thread::sleep(Duration::from_millis(20));
         }
-        let _ = child.kill();
+        Self::kill_tree(child, own_group);
         let _ = child.wait();
     }
 }
 
 impl Drop for ChildGuard {
     fn drop(&mut self) {
+        let own_group = self.own_group;
         let Some(mut child) = self.child.take() else {
             return;
         };
         if matches!(child.try_wait(), Ok(None)) {
-            let _ = child.kill();
+            Self::kill_tree(&mut child, own_group);
         }
         let _ = child.wait();
     }
@@ -342,14 +403,30 @@ pub fn wait_for_file_contents(
 /// Owns exactly the path it was given and nothing else: no globbing over the
 /// temp directory, no removal of workspaces other runs left behind. A
 /// concurrent test's workspace is not this guard's business.
+///
+/// It also refuses to adopt a path that already exists. An earlier cut removed
+/// the directory first, which meant two guards on the same root silently ate
+/// each other's data — the second `create` wiped the first's files, and the
+/// first's `drop` then removed the second's workspace. Since the guard now owns
+/// deletion, taking a path it did not create is how it would delete work it does
+/// not own. A collision is a broken test root, so it fails loudly instead.
 pub struct WorkspaceGuard {
     root: PathBuf,
 }
 
 impl WorkspaceGuard {
-    /// Create the workspace fresh, and own it until the test's scope ends.
+    /// Create the workspace, and own it until the test's scope ends.
+    ///
+    /// Panics if the path already exists: this guard deletes what it owns, so
+    /// adopting a directory someone else made is exactly the mistake to prevent.
     pub fn create(root: PathBuf) -> Self {
-        let _ = std::fs::remove_dir_all(&root);
+        assert!(
+            !root.exists(),
+            "test workspace {} already exists; a guard must not adopt (and later \
+             delete) a directory it did not create — give each test root a unique \
+             name",
+            root.display()
+        );
         std::fs::create_dir_all(&root).expect("create test workspace");
         Self { root }
     }

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -24,6 +24,7 @@ use std::io::Write;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use std::sync::{Arc, Barrier};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod common;
@@ -151,6 +152,42 @@ fn the_workspace_guard_removes_its_own_root_and_nothing_else() {
 }
 
 #[test]
+fn only_one_of_many_racing_guards_can_adopt_a_root() {
+    // `exists()` then `create_dir_all` is TOCTOU, and not theoretically: an
+    // independent review ran five threads at one root through a barrier and got
+    // five guards that each believed they owned it, on the first round. The check
+    // has to BE the creation.
+    for round in 0..64 {
+        let root = scratch(&format!("race-{round}"));
+        let start = Arc::new(Barrier::new(4));
+        let winners: Vec<_> = (0..4)
+            .map(|_| {
+                let root = root.clone();
+                let start = Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    catch_unwind(AssertUnwindSafe(|| common::WorkspaceGuard::create(root))).ok()
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .filter_map(|thread| {
+                thread
+                    .join()
+                    .expect("a creator thread panicked outside catch")
+            })
+            .collect();
+        assert_eq!(
+            winners.len(),
+            1,
+            "{} guards adopted {} at once; creation is not atomic",
+            winners.len(),
+            root.display()
+        );
+    }
+}
+
+#[test]
 fn the_file_wait_does_not_return_on_a_created_but_unwritten_file() {
     let workspace = common::WorkspaceGuard::create(scratch("file-wait"));
     let path = workspace.join("turn-2.md");
@@ -198,44 +235,6 @@ fn the_file_wait_does_not_return_on_a_created_but_unwritten_file() {
     .expect("the content wait timed out on a file that was written");
     assert!(text.contains(verbatim));
     writer.join().expect("the writer thread panicked");
-}
-
-#[test]
-fn a_group_leader_guard_takes_down_the_children_its_child_spawned() {
-    // `kill` signals one pid. A child that spawns its own children leaves them
-    // running — an independent review of this work proved it with exactly this
-    // shape, so it is pinned here rather than assumed.
-    let pid_path = scratch("descendant").with_extension("pid");
-    let script = format!("sleep 120 & echo $! > {}; wait", pid_path.display());
-    let descendant = {
-        let _guard = common::ChildGuard::spawn_group_leader(
-            Command::new("sh")
-                .args(["-c", &script])
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null()),
-        );
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let mut pid = None;
-        while Instant::now() < deadline {
-            if let Ok(raw) = std::fs::read_to_string(&pid_path) {
-                if let Ok(parsed) = raw.trim().parse::<u32>() {
-                    pid = Some(parsed);
-                    break;
-                }
-            }
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let pid = pid.expect("the grandchild never reported its pid");
-        assert!(alive(pid), "the grandchild never started");
-        pid
-    };
-
-    assert!(
-        wait_until_gone(descendant, Duration::from_secs(5)),
-        "grandchild {descendant} outlived the guard that owned its parent's group"
-    );
-    let _ = std::fs::remove_file(&pid_path);
 }
 
 #[test]

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -41,7 +41,10 @@ fn scratch(name: &str) -> PathBuf {
         .duration_since(UNIX_EPOCH)
         .expect("system clock before Unix epoch")
         .as_nanos();
-    std::env::temp_dir().join(format!("yard-harness-{name}-{}-{nonce}", std::process::id()))
+    std::env::temp_dir().join(format!(
+        "yard-harness-{name}-{}-{nonce}",
+        std::process::id()
+    ))
 }
 
 fn spawn_long_lived() -> std::process::Child {

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -1,16 +1,30 @@
-//! The PTY tests' leak backstop (issue #64).
+//! What the shared PTY harness itself guarantees (issues #64 and #92).
 //!
-//! `std::process::Child` does not kill on drop, so before this guard existed a
-//! failing assertion unwound straight past a test's own cleanup and abandoned a
-//! live process — seven orphaned `yardlet` processes accumulated over a day of
-//! PTY work. This pins the property that mattered: when a test panics, the
-//! child it spawned is dead by the time the panic leaves the scope.
+//! Three properties, each filed after it failed in real use:
+//!
+//! - **Processes.** `std::process::Child` does not kill on drop, so a failing
+//!   assertion unwound past a test's own cleanup and abandoned a live process —
+//!   seven orphaned `yardlet` processes accumulated over a day of PTY work
+//!   (#64).
+//! - **Workspaces.** Every PTY test removed its temp root on the happy path
+//!   only, so the same unwind abandoned the workspace too. That half of #64 was
+//!   still open, and two leaked roots were collected from a single reproduction
+//!   run.
+//! - **Waiting.** A wait predicate weaker than the assertion it guards turns a
+//!   race into a failure that observed nothing. Waiting on a path existing and
+//!   then reading it caught an empty file on CI (#92).
+//!
+//! These tests pin the properties, not the implementations: a panic leaves no
+//! child and no workspace behind, and a content wait does not return on a
+//! created-but-unwritten file.
 
 #![cfg(unix)]
 
+use std::io::Write;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod common;
 
@@ -18,6 +32,16 @@ mod common;
 /// permission-checked existence without sending a signal.
 fn alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+/// A path no other test or run shares, so a guard's removal can only be judged
+/// against work this test itself created.
+fn scratch(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yard-harness-{name}-{}-{nonce}", std::process::id()))
 }
 
 fn spawn_long_lived() -> std::process::Child {
@@ -81,6 +105,124 @@ fn a_clean_shutdown_reaps_without_killing_and_the_guard_stays_idempotent() {
     );
     // Dropping after shutdown must not panic or try to kill a reaped pid.
     drop(guard);
+}
+
+#[test]
+fn a_panicking_assertion_does_not_leak_the_temp_workspace() {
+    let root = scratch("panic-workspace");
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let workspace = common::WorkspaceGuard::create(root.clone());
+        std::fs::write(workspace.join("marker"), "x").expect("write into the workspace");
+        // The shape the leak had: an assertion fires before the test reaches the
+        // `remove_dir_all` on its happy path.
+        panic!("simulated assertion failure");
+    }));
+    assert!(result.is_err(), "the fixture panic did not propagate");
+    assert!(
+        !root.exists(),
+        "workspace {} survived a panicking assertion",
+        root.display()
+    );
+}
+
+#[test]
+fn the_workspace_guard_removes_its_own_root_and_nothing_else() {
+    let root = scratch("own-root");
+    let neighbour = scratch("neighbour");
+    std::fs::create_dir_all(&neighbour).expect("create the neighbour");
+    std::fs::write(neighbour.join("keep-me"), "x").expect("write into the neighbour");
+
+    {
+        let workspace = common::WorkspaceGuard::create(root.clone());
+        std::fs::write(workspace.join("marker"), "x").expect("write into the workspace");
+        assert!(root.exists());
+    }
+
+    assert!(!root.exists(), "the guard did not remove its own root");
+    assert!(
+        neighbour.join("keep-me").exists(),
+        "the guard reached outside its own root — a parallel session's workspace \
+         is not its business"
+    );
+    let _ = std::fs::remove_dir_all(&neighbour);
+}
+
+#[test]
+fn the_file_wait_does_not_return_on_a_created_but_unwritten_file() {
+    let workspace = common::WorkspaceGuard::create(scratch("file-wait"));
+    let path = workspace.join("turn-2.md");
+    let verbatim = "REVLINE-TOP\nREVLINE-BOTTOM";
+
+    // Exactly what `printf '%s' "$packet" >"$file"` does in the planner fixture:
+    // create (truncating) first, write second. The gap is the race window.
+    let writing = path.clone();
+    let writer = std::thread::spawn(move || {
+        let mut file = std::fs::File::create(&writing).expect("create the fixture file");
+        std::thread::sleep(Duration::from_millis(300));
+        file.write_all(b"REVLINE-TOP\nREVLINE-BOTTOM\n")
+            .expect("write the fixture file");
+    });
+
+    // The predicate the harness used to wait on. It is satisfied while the file
+    // still holds nothing, which is how the assertion came to fail having
+    // observed no value at all.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut on_existence = None;
+    while Instant::now() < deadline {
+        if path.exists() {
+            on_existence = Some(std::fs::read_to_string(&path).expect("read the fixture file"));
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+    let on_existence = on_existence.expect("the fixture file never appeared");
+    assert!(
+        !on_existence.contains(verbatim),
+        "the race window never opened, so this test cannot prove the difference"
+    );
+
+    // The content wait sees the whole value instead.
+    let text = common::wait_for_file_contents(
+        &path,
+        Duration::from_secs(5),
+        || {},
+        |text| text.contains(verbatim),
+    )
+    .expect("the content wait timed out on a file that was written");
+    assert!(text.contains(verbatim));
+    writer.join().expect("the writer thread panicked");
+}
+
+#[test]
+fn the_file_wait_reports_what_it_actually_found_on_timeout() {
+    let workspace = common::WorkspaceGuard::create(scratch("file-wait-diagnostics"));
+    let brief = Duration::from_millis(120);
+
+    let missing = workspace.join("never-written.md");
+    let error = common::wait_for_file_contents(&missing, brief, || {}, |_| true)
+        .expect_err("a missing file must not satisfy the wait");
+    assert!(
+        error.contains("never appeared"),
+        "a missing file was not reported as missing: {error}"
+    );
+
+    let empty = workspace.join("empty.md");
+    std::fs::File::create(&empty).expect("create the empty file");
+    let error = common::wait_for_file_contents(&empty, brief, || {}, |text| text.contains("value"))
+        .expect_err("an empty file must not satisfy a content predicate");
+    assert!(
+        error.contains("empty"),
+        "an empty file was not reported as empty: {error}"
+    );
+
+    let wrong = workspace.join("wrong.md");
+    std::fs::write(&wrong, "some other contents entirely").expect("write the wrong contents");
+    let error = common::wait_for_file_contents(&wrong, brief, || {}, |text| text.contains("value"))
+        .expect_err("contents that do not match the predicate must not satisfy the wait");
+    assert_eq!(
+        error, "some other contents entirely",
+        "the timeout did not report the contents it actually read"
+    );
 }
 
 #[test]

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -21,6 +21,8 @@
 #![cfg(unix)]
 
 use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::ExitStatusExt;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -149,6 +151,137 @@ fn the_workspace_guard_removes_its_own_root_and_nothing_else() {
          is not its business"
     );
     let _ = std::fs::remove_dir_all(&neighbour);
+}
+
+/// A script that idles under a name only this test would use, so a pid can be
+/// matched by identity rather than trusted by number.
+fn write_idle_script(path: &std::path::Path, marker: &str) {
+    std::fs::write(
+        path,
+        format!("#!/bin/sh\n# {marker}\nprintf '%s' \"$$\" > \"$1\"\nsleep 120\n"),
+    )
+    .expect("write the idle script");
+    let mut permissions = std::fs::metadata(path)
+        .expect("stat the idle script")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("chmod the idle script");
+}
+
+#[test]
+fn the_pid_file_guard_reaps_a_process_that_never_removed_its_pid_file() {
+    // The leak this exists for: a hook still polling when an assertion fires. It
+    // never reaches its own `rm`, so the guard is the only thing that will.
+    let workspace = common::WorkspaceGuard::create(scratch("pid-guard-kill"));
+    let script = workspace.join("idle-fixture-alpha.sh");
+    write_idle_script(&script, "idle-fixture-alpha");
+    let pid_path = workspace.join("fixture.pid");
+
+    let mut child = common::ChildGuard::new(
+        Command::new(&script)
+            .arg(&pid_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn the idle fixture"),
+    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && !pid_path.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let pid: u32 = std::fs::read_to_string(&pid_path)
+        .expect("the fixture never wrote its pid")
+        .trim()
+        .parse()
+        .expect("numeric fixture pid");
+    assert!(alive(pid), "the fixture never started");
+
+    drop(common::PidFileGuard::new(
+        pid_path.clone(),
+        "idle-fixture-alpha",
+    ));
+
+    // Assert on the exit signal, not on `kill(pid, 0)`. This fixture is a child of
+    // the test process, so once killed it stays a reapable zombie and a liveness
+    // probe still succeeds — which says nothing about who killed it. The real hook
+    // is not our child and has no such state. Waiting for the status both reaps it
+    // and proves SIGKILL is what ended it.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut status = None;
+    while Instant::now() < deadline {
+        if let Ok(Some(exited)) = child.as_mut().try_wait() {
+            status = Some(exited);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let status = status.expect("pid the guard was pointed straight at never exited");
+    assert_eq!(
+        status.signal(),
+        Some(libc::SIGKILL),
+        "the fixture ended by {status:?} rather than the guard's SIGKILL"
+    );
+    assert!(
+        !pid_path.exists(),
+        "the guard left its pid file behind for a later run to trust"
+    );
+}
+
+#[test]
+fn the_pid_file_guard_leaves_a_pid_that_is_not_the_process_it_was_watching() {
+    // The danger the guard has to avoid. A hook that dies without clearing its pid
+    // file leaves a number behind; once the OS recycles it, killing by number
+    // takes down a stranger. So a pid whose command line does not match is not
+    // this guard's to signal — here a live process stands in for the recycled one.
+    let workspace = common::WorkspaceGuard::create(scratch("pid-guard-stale"));
+    let script = workspace.join("idle-fixture-beta.sh");
+    write_idle_script(&script, "idle-fixture-beta");
+    let pid_path = workspace.join("live.pid");
+
+    let mut bystander = common::ChildGuard::new(
+        Command::new(&script)
+            .arg(&pid_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn the bystander"),
+    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline && !pid_path.exists() {
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let pid: u32 = std::fs::read_to_string(&pid_path)
+        .expect("the bystander never wrote its pid")
+        .trim()
+        .parse()
+        .expect("numeric bystander pid");
+    assert!(alive(pid), "the bystander never started");
+
+    // The guard is watching for a DIFFERENT fixture, so this pid is not its
+    // business no matter what the file says.
+    drop(common::PidFileGuard::new(
+        pid_path.clone(),
+        "some-other-fixture-entirely",
+    ));
+    std::thread::sleep(Duration::from_millis(300));
+
+    // `kill(pid, 0)` is NOT the check here: this bystander is our child, so a
+    // SIGKILLed one stays a zombie and a liveness probe keeps succeeding. That
+    // made the first version of this test pass even with the identity check
+    // deleted — vacuous, the very defect this branch is about. `try_wait`
+    // distinguishes still-running from exited-and-reapable.
+    let exited = bystander
+        .as_mut()
+        .try_wait()
+        .expect("poll the bystander's status");
+    assert!(
+        exited.is_none(),
+        "the guard ended pid {pid} ({exited:?}) although its command line never \
+         matched what the guard was watching for"
+    );
+    bystander.kill_now();
 }
 
 #[test]

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -157,32 +157,36 @@ fn the_file_wait_does_not_return_on_a_created_but_unwritten_file() {
     let verbatim = "REVLINE-TOP\nREVLINE-BOTTOM";
 
     // Exactly what `printf '%s' "$packet" >"$file"` does in the planner fixture:
-    // create (truncating) first, write second. The gap is the race window.
+    // create (truncating) first, write second. The gap between them is the race.
+    //
+    // Held open by a handshake, not by a sleep. A timing window would make THIS
+    // test the flaky one — the reader only has to be descheduled past the sleep
+    // for the window to close and the test to fail claiming the race never
+    // happened. That is precisely the defect under repair, so it may not be the
+    // method of repair.
+    let (created, file_exists) = std::sync::mpsc::channel();
+    let (observed, reader_looked) = std::sync::mpsc::channel();
     let writing = path.clone();
     let writer = std::thread::spawn(move || {
         let mut file = std::fs::File::create(&writing).expect("create the fixture file");
-        std::thread::sleep(Duration::from_millis(300));
+        created.send(()).expect("announce the empty file");
+        // Blocks until the reader has read. The gap is now as wide as it needs
+        // to be and not one millisecond wider.
+        reader_looked.recv().expect("reader never reported");
         file.write_all(b"REVLINE-TOP\nREVLINE-BOTTOM\n")
             .expect("write the fixture file");
     });
 
-    // The predicate the harness used to wait on. It is satisfied while the file
-    // still holds nothing, which is how the assertion came to fail having
-    // observed no value at all.
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let mut on_existence = None;
-    while Instant::now() < deadline {
-        if path.exists() {
-            on_existence = Some(std::fs::read_to_string(&path).expect("read the fixture file"));
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(2));
-    }
-    let on_existence = on_existence.expect("the fixture file never appeared");
+    // The predicate the harness used to wait on, exercised exactly while the file
+    // holds nothing: satisfied, and satisfied by no value at all.
+    file_exists.recv().expect("writer never created the file");
+    assert!(path.exists(), "the existence predicate did not even hold");
+    let on_existence = std::fs::read_to_string(&path).expect("read the fixture file");
     assert!(
-        !on_existence.contains(verbatim),
-        "the race window never opened, so this test cannot prove the difference"
+        on_existence.is_empty(),
+        "expected the created-but-unwritten file to be empty, got {on_existence:?}"
     );
+    observed.send(()).expect("release the writer");
 
     // The content wait sees the whole value instead.
     let text = common::wait_for_file_contents(
@@ -194,6 +198,55 @@ fn the_file_wait_does_not_return_on_a_created_but_unwritten_file() {
     .expect("the content wait timed out on a file that was written");
     assert!(text.contains(verbatim));
     writer.join().expect("the writer thread panicked");
+}
+
+#[test]
+fn a_group_leader_guard_takes_down_the_children_its_child_spawned() {
+    // `kill` signals one pid. A child that spawns its own children leaves them
+    // running — an independent review of this work proved it with exactly this
+    // shape, so it is pinned here rather than assumed.
+    let pid_path = scratch("descendant").with_extension("pid");
+    let script = format!("sleep 120 & echo $! > {}; wait", pid_path.display());
+    let descendant = {
+        let _guard = common::ChildGuard::spawn_group_leader(
+            Command::new("sh")
+                .args(["-c", &script])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null()),
+        );
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut pid = None;
+        while Instant::now() < deadline {
+            if let Ok(raw) = std::fs::read_to_string(&pid_path) {
+                if let Ok(parsed) = raw.trim().parse::<u32>() {
+                    pid = Some(parsed);
+                    break;
+                }
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let pid = pid.expect("the grandchild never reported its pid");
+        assert!(alive(pid), "the grandchild never started");
+        pid
+    };
+
+    assert!(
+        wait_until_gone(descendant, Duration::from_secs(5)),
+        "grandchild {descendant} outlived the guard that owned its parent's group"
+    );
+    let _ = std::fs::remove_file(&pid_path);
+}
+
+#[test]
+#[should_panic(expected = "already exists")]
+fn the_workspace_guard_refuses_to_adopt_a_directory_it_did_not_create() {
+    // Two guards on one root used to eat each other: the second create wiped the
+    // first's files, and the first's drop removed the second's workspace. A guard
+    // that deletes on drop must not adopt what it did not make.
+    let root = scratch("collision");
+    let _first = common::WorkspaceGuard::create(root.clone());
+    let _second = common::WorkspaceGuard::create(root);
 }
 
 #[test]

--- a/tests/tui_key_list_process.rs
+++ b/tests/tui_key_list_process.rs
@@ -9,14 +9,15 @@
 
 #![cfg(unix)]
 
-use std::fs::{self, File};
-use std::io::{ErrorKind, Read, Write};
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod common;
+
+use common::{drain, open_pty, recent, resize_pty, seen, wait_for_marker};
 
 fn test_root() -> PathBuf {
     let nonce = SystemTime::now()
@@ -31,138 +32,6 @@ fn test_root() -> PathBuf {
 /// is below the fold and only reachable by scrolling. The original test used 40
 /// rows, which fit the whole list and hid that the screen could not scroll.
 const ROWS: u16 = 24;
-
-fn open_pty() -> (File, File) {
-    let mut master = -1;
-    let mut slave = -1;
-    let mut size = libc::winsize {
-        ws_row: ROWS,
-        ws_col: 140,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let rc = unsafe {
-        libc::openpty(
-            &mut master,
-            &mut slave,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut size as *mut libc::winsize,
-        )
-    };
-    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
-    let master = unsafe { File::from_raw_fd(master) };
-    let slave = unsafe { File::from_raw_fd(slave) };
-    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
-    assert!(flags >= 0);
-    let rc = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
-    assert_eq!(rc, 0);
-    (master, slave)
-}
-
-/// Force a full repaint.
-///
-/// Ratatui writes only CHANGED cells, so after scrolling a string can lose any
-/// character whose cell happened to already hold it — exact matching on
-/// scrolled content is unreliable. A resize makes the next frame a complete
-/// one. The column change is cosmetic and preserves the scroll offset, so what
-/// is on screen is still what scrolling brought there.
-fn force_repaint(master: &File, cols: u16) {
-    let size = libc::winsize {
-        ws_row: ROWS,
-        ws_col: cols,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let rc = unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCSWINSZ, &size) };
-    assert_eq!(
-        rc,
-        0,
-        "TIOCSWINSZ failed: {}",
-        std::io::Error::last_os_error()
-    );
-}
-
-fn drain(master: &mut File, sink: &mut Vec<u8>) {
-    let mut buffer = [0_u8; 8192];
-    loop {
-        match master.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(count) => sink.extend_from_slice(&buffer[..count]),
-            Err(error) if error.kind() == ErrorKind::WouldBlock => break,
-            Err(error) => panic!("PTY read failed: {error}"),
-        }
-    }
-}
-
-fn strip_ansi(bytes: &[u8]) -> String {
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == 0x1b {
-            match bytes.get(i + 1) {
-                Some(b'[') => {
-                    i += 2;
-                    while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
-                        i += 1;
-                    }
-                    i += usize::from(i < bytes.len());
-                }
-                Some(b']') => {
-                    i += 2;
-                    while i < bytes.len() {
-                        if bytes[i] == 0x07 {
-                            i += 1;
-                            break;
-                        }
-                        if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
-                            i += 2;
-                            break;
-                        }
-                        i += 1;
-                    }
-                }
-                Some(_) => i += 2,
-                None => break,
-            }
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8_lossy(&out).into_owned()
-}
-
-fn norm(s: &str) -> String {
-    s.chars().filter(|c| !c.is_whitespace()).collect()
-}
-
-fn seen(sink: &[u8], marker: &str) -> bool {
-    norm(&strip_ansi(sink)).contains(&norm(marker))
-}
-
-fn recent(sink: &[u8]) -> String {
-    let text = strip_ansi(sink);
-    let chars: Vec<char> = text.chars().collect();
-    let start = chars.len().saturating_sub(900);
-    chars[start..].iter().collect()
-}
-
-fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: Duration) {
-    let deadline = Instant::now() + within;
-    loop {
-        drain(master, sink);
-        if seen(sink, marker) {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "marker {marker:?} not seen within {within:?}; recent output:\n{}",
-            recent(sink)
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
-}
 
 #[test]
 fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
@@ -188,7 +57,7 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
         .replace("language: auto", "language: en");
     fs::write(&config_path, config).unwrap();
 
-    let (mut master, slave) = open_pty();
+    let (mut master, slave) = open_pty(ROWS, 140);
     let stdin = Stdio::from(slave.try_clone().unwrap());
     let stdout = Stdio::from(slave.try_clone().unwrap());
     let stderr = Stdio::from(slave);
@@ -233,11 +102,11 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
         drain(&mut master, &mut sink);
     }
 
-    force_repaint(&master, 139);
+    resize_pty(&master, ROWS, 139);
     std::thread::sleep(Duration::from_millis(300));
     drain(&mut master, &mut sink);
     let after_repaint = sink.len();
-    force_repaint(&master, 140);
+    resize_pty(&master, ROWS, 140);
     std::thread::sleep(Duration::from_millis(300));
     drain(&mut master, &mut sink);
 

--- a/tests/tui_key_list_process.rs
+++ b/tests/tui_key_list_process.rs
@@ -167,9 +167,10 @@ fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: 
 #[test]
 fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
-    let root = test_root();
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
+    // Removed even if an assertion below unwinds past the clean exit — the other
+    // half of issue #64.
+    let workspace = common::WorkspaceGuard::create(test_root());
+    let root = workspace.path().to_path_buf();
 
     let init = Command::new(&binary)
         .arg("init")
@@ -279,5 +280,5 @@ fn the_idle_footer_leads_to_a_list_of_every_working_home_key() {
     std::thread::sleep(Duration::from_millis(200));
     let _ = master.write_all(b"q");
     child.shutdown(Duration::from_secs(5), || drain(&mut master, &mut sink));
-    let _ = fs::remove_dir_all(&root);
+    // `workspace` removes the root on drop, on this path and on a panicking one.
 }

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -23,14 +23,15 @@
 #![cfg(unix)]
 
 use std::fs::{self, File};
-use std::io::{ErrorKind, Read, Write};
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod common;
+
+use common::{drain, open_pty, recent, seen, wait_for_marker};
 
 fn test_root() -> PathBuf {
     let nonce = SystemTime::now()
@@ -90,123 +91,6 @@ fn write_planner(path: &Path) {
     fs::set_permissions(path, permissions).unwrap();
 }
 
-fn open_pty() -> (File, File) {
-    let mut master = -1;
-    let mut slave = -1;
-    let mut size = libc::winsize {
-        ws_row: 40,
-        ws_col: 140,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let rc = unsafe {
-        libc::openpty(
-            &mut master,
-            &mut slave,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut size as *mut libc::winsize,
-        )
-    };
-    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
-    let master = unsafe { File::from_raw_fd(master) };
-    let slave = unsafe { File::from_raw_fd(slave) };
-    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
-    assert!(flags >= 0);
-    let rc = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
-    assert_eq!(rc, 0);
-    (master, slave)
-}
-
-/// Drain everything currently readable. Draining continuously is mandatory: a
-/// full PTY buffer blocks the child on its next render.
-fn drain(master: &mut File, sink: &mut Vec<u8>) {
-    let mut buffer = [0_u8; 8192];
-    loop {
-        match master.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(count) => sink.extend_from_slice(&buffer[..count]),
-            Err(error) if error.kind() == ErrorKind::WouldBlock => break,
-            Err(error) => panic!("PTY read failed: {error}"),
-        }
-    }
-}
-
-/// Ratatui positions every wide (CJK) cell with its own cursor-move escape, so
-/// a Korean word is not a contiguous byte run until the escapes are stripped.
-fn strip_ansi(bytes: &[u8]) -> String {
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == 0x1b {
-            match bytes.get(i + 1) {
-                Some(b'[') => {
-                    i += 2;
-                    while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
-                        i += 1;
-                    }
-                    i += usize::from(i < bytes.len());
-                }
-                Some(b']') => {
-                    i += 2;
-                    while i < bytes.len() {
-                        if bytes[i] == 0x07 {
-                            i += 1;
-                            break;
-                        }
-                        if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
-                            i += 2;
-                            break;
-                        }
-                        i += 1;
-                    }
-                }
-                Some(_) => i += 2,
-                None => break,
-            }
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8_lossy(&out).into_owned()
-}
-
-/// Whitespace between cells is emitted as cursor motion too, so compare the
-/// visible text with all whitespace removed.
-fn norm(s: &str) -> String {
-    s.chars().filter(|c| !c.is_whitespace()).collect()
-}
-
-fn seen(sink: &[u8], marker: &str) -> bool {
-    norm(&strip_ansi(sink)).contains(&norm(marker))
-}
-
-fn recent(sink: &[u8]) -> String {
-    let text = strip_ansi(sink);
-    let chars: Vec<char> = text.chars().collect();
-    let start = chars.len().saturating_sub(800);
-    chars[start..].iter().collect()
-}
-
-fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: Duration) {
-    let deadline = Instant::now() + within;
-    loop {
-        drain(master, sink);
-        if seen(sink, marker) {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "marker {marker:?} not seen within {within:?}; recent output:\n{}",
-            recent(sink)
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
-}
-
-/// Poll a workspace predicate while still draining the PTY, so the child never
-/// blocks on render while we wait for its side effect.
 fn wait_until(
     master: &mut File,
     sink: &mut Vec<u8>,
@@ -230,7 +114,7 @@ fn wait_until(
 }
 
 fn spawn_tui(binary: &Path, root: &Path) -> (common::ChildGuard, File, Vec<u8>) {
-    let (master, slave) = open_pty();
+    let (master, slave) = open_pty(40, 140);
     let stdin = Stdio::from(slave.try_clone().unwrap());
     let stdout = Stdio::from(slave.try_clone().unwrap());
     let stderr = Stdio::from(slave);

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -294,12 +294,8 @@ fn an_accepted_unconfirmed_plan_is_reachable_from_home_after_a_restart() {
         );
         std::thread::sleep(Duration::from_millis(10));
     }
-    // Scoped to after `o` so this can only ever be satisfied by the screen it is
-    // about. Measured today: Home does NOT render the draft's summary before `o`,
-    // so the cumulative form was not yet vacuous here — the window keeps it from
-    // becoming vacuous the day Home starts showing the summary in its queue row.
     assert!(
-        seen(&sink[before_open..], "reentry fixture slice"),
+        seen(&sink, "reentry fixture slice"),
         "the review screen opened without the accepted draft's content;\n{}",
         recent(&sink)
     );

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -279,9 +279,10 @@ fn accepted_but_unconfirmed(root: &Path) -> bool {
 #[test]
 fn an_accepted_unconfirmed_plan_is_reachable_from_home_after_a_restart() {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
-    let root = test_root();
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
+    // Removed even if an assertion below unwinds past the clean exit — the other
+    // half of issue #64.
+    let workspace = common::WorkspaceGuard::create(test_root());
+    let root = workspace.path().to_path_buf();
 
     let init = Command::new(&binary)
         .arg("init")
@@ -409,12 +410,16 @@ fn an_accepted_unconfirmed_plan_is_reachable_from_home_after_a_restart() {
         );
         std::thread::sleep(Duration::from_millis(10));
     }
+    // Scoped to after `o` so this can only ever be satisfied by the screen it is
+    // about. Measured today: Home does NOT render the draft's summary before `o`,
+    // so the cumulative form was not yet vacuous here — the window keeps it from
+    // becoming vacuous the day Home starts showing the summary in its queue row.
     assert!(
-        seen(&sink, "reentry fixture slice"),
+        seen(&sink[before_open..], "reentry fixture slice"),
         "the review screen opened without the accepted draft's content;\n{}",
         recent(&sink)
     );
 
     quit_tui(&mut second, &mut master, &mut sink);
-    let _ = fs::remove_dir_all(&root);
+    // `workspace` removes the root on drop, on this path and on a panicking one.
 }

--- a/tests/tui_startup_process.rs
+++ b/tests/tui_startup_process.rs
@@ -65,9 +65,10 @@ fn open_pty() -> (File, File) {
 #[test]
 fn slow_probe_and_recovery_do_not_block_first_safe_tui_frame() {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
-    let root = test_root("first-frame");
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
+    // Removed even if an assertion below unwinds past the clean exit — the other
+    // half of issue #64.
+    let workspace = common::WorkspaceGuard::create(test_root("first-frame"));
+    let root = workspace.path().to_path_buf();
 
     let init = Command::new(&binary)
         .arg("init")
@@ -156,5 +157,5 @@ fn slow_probe_and_recovery_do_not_block_first_safe_tui_frame() {
     master.write_all(b"q").unwrap();
 
     child.shutdown(Duration::from_secs(3), || {});
-    let _ = fs::remove_dir_all(root);
+    // `workspace` removes the root on drop, on this path and on a panicking one.
 }

--- a/tests/tui_startup_process.rs
+++ b/tests/tui_startup_process.rs
@@ -5,14 +5,23 @@ use std::io::{ErrorKind, Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod common;
 
 use common::open_pty;
 
 fn test_root(name: &str) -> PathBuf {
-    std::env::temp_dir().join(format!("yard-tui-startup-{name}-{}", std::process::id()))
+    // Unique per run: WorkspaceGuard refuses to adopt an existing directory, so a
+    // pid alone (which the OS recycles) is not a safe root name.
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "yard-tui-startup-{name}-{}-{nonce}",
+        std::process::id()
+    ))
 }
 
 fn write_worker(path: &Path, sentinel: &Path) {

--- a/tests/tui_startup_process.rs
+++ b/tests/tui_startup_process.rs
@@ -1,14 +1,15 @@
 #![cfg(unix)]
 
-use std::fs::{self, File};
+use std::fs;
 use std::io::{ErrorKind, Read, Write};
-use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 mod common;
+
+use common::open_pty;
 
 fn test_root(name: &str) -> PathBuf {
     std::env::temp_dir().join(format!("yard-tui-startup-{name}-{}", std::process::id()))
@@ -32,34 +33,6 @@ fn write_worker(path: &Path, sentinel: &Path) {
     let mut permissions = fs::metadata(path).unwrap().permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(path, permissions).unwrap();
-}
-
-fn open_pty() -> (File, File) {
-    let mut master = -1;
-    let mut slave = -1;
-    let mut size = libc::winsize {
-        ws_row: 30,
-        ws_col: 120,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let rc = unsafe {
-        libc::openpty(
-            &mut master,
-            &mut slave,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut size as *mut libc::winsize,
-        )
-    };
-    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
-    let master = unsafe { File::from_raw_fd(master) };
-    let slave = unsafe { File::from_raw_fd(slave) };
-    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
-    assert!(flags >= 0);
-    let rc = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
-    assert_eq!(rc, 0);
-    (master, slave)
 }
 
 #[test]
@@ -92,7 +65,7 @@ fn slow_probe_and_recovery_do_not_block_first_safe_tui_frame() {
     write_worker(&bin_dir.join("codex"), &sentinel);
     write_worker(&bin_dir.join("claude"), &sentinel);
 
-    let (mut master, slave) = open_pty();
+    let (mut master, slave) = open_pty(30, 120);
     let stdin = Stdio::from(slave.try_clone().unwrap());
     let stdout = Stdio::from(slave.try_clone().unwrap());
     let stderr = Stdio::from(slave);

--- a/tests/tui_startup_review_revision_process.rs
+++ b/tests/tui_startup_review_revision_process.rs
@@ -236,31 +236,13 @@ fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: 
     }
 }
 
-/// Poll for a file to appear while still draining the PTY, so the child never
-/// blocks on render while we wait for its worker side effect.
-fn wait_for_file(master: &mut File, sink: &mut Vec<u8>, path: &Path, within: Duration) {
-    let deadline = Instant::now() + within;
-    loop {
-        drain(master, sink);
-        if path.exists() {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "expected fixture file {} within {within:?}; recent output:\n{}",
-            path.display(),
-            recent(sink)
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
-}
-
 #[test]
 fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
-    let root = test_root();
-    let _ = fs::remove_dir_all(&root);
-    fs::create_dir_all(&root).unwrap();
+    // Removed even if an assertion below unwinds past the clean exit — the other
+    // half of issue #64.
+    let workspace = common::WorkspaceGuard::create(test_root());
+    let root = workspace.path().to_path_buf();
 
     // Canonical workspace init, then pin the UI to Korean.
     let init = Command::new(&binary)
@@ -422,13 +404,25 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     master.write_all(b"\x13").unwrap(); // Ctrl+S submit revision
 
     // 7) The verbatim two-line revision must reach the planner as a second turn.
+    //
+    // Wait on the CONTENT, not on the path existing: the fixture creates the file
+    // and writes it in two steps, so an existence-only wait reads an empty string
+    // and the assertion fails having observed nothing at all.
     let turn_two = root.join(".fixture-capture/turn-2.md");
-    wait_for_file(&mut master, &mut sink, &turn_two, Duration::from_secs(20));
-    let packet = fs::read_to_string(&turn_two).unwrap();
-    assert!(
-        packet.contains("REVLINE-TOP\nREVLINE-BOTTOM"),
-        "second planner packet did not carry the verbatim multi-line revision;\npacket:\n{packet}"
-    );
+    let verbatim = "REVLINE-TOP\nREVLINE-BOTTOM";
+    if let Err(last) = common::wait_for_file_contents(
+        &turn_two,
+        Duration::from_secs(20),
+        || drain(&mut master, &mut sink),
+        |packet| packet.contains(verbatim),
+    ) {
+        panic!(
+            "second planner packet did not carry the verbatim multi-line revision \
+             within 20s;\nlast contents of {}:\n{last}\nrecent output:\n{}",
+            turn_two.display(),
+            recent(&sink)
+        );
+    }
     let turns = fs::read_to_string(root.join(".fixture-planning-turn")).unwrap();
     assert_eq!(
         turns.trim(),
@@ -442,5 +436,5 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     std::thread::sleep(Duration::from_millis(150));
     let _ = master.write_all(b"q");
     child.shutdown(Duration::from_secs(5), || drain(&mut master, &mut sink));
-    let _ = fs::remove_dir_all(&root);
+    // `workspace` removes the root on drop, on this path and on a panicking one.
 }

--- a/tests/tui_startup_review_revision_process.rs
+++ b/tests/tui_startup_review_revision_process.rs
@@ -24,15 +24,16 @@
 
 #![cfg(unix)]
 
-use std::fs::{self, File};
-use std::io::{ErrorKind, Read, Write};
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::fs;
+use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod common;
+
+use common::{drain, open_pty, recent, seen, wait_for_marker};
 
 /// Slow-recovery injection (debug + `YARDLET_PROCESS_FIXTURE=1` only). Big enough
 /// that the loading screen is unmistakably shown before Home, small enough to
@@ -110,132 +111,6 @@ fn write_planner(path: &Path) {
     fs::set_permissions(path, permissions).unwrap();
 }
 
-fn open_pty() -> (File, File) {
-    let mut master = -1;
-    let mut slave = -1;
-    let mut size = libc::winsize {
-        ws_row: 40,
-        ws_col: 140,
-        ws_xpixel: 0,
-        ws_ypixel: 0,
-    };
-    let rc = unsafe {
-        libc::openpty(
-            &mut master,
-            &mut slave,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-            &mut size as *mut libc::winsize,
-        )
-    };
-    assert_eq!(rc, 0, "openpty failed: {}", std::io::Error::last_os_error());
-    let master = unsafe { File::from_raw_fd(master) };
-    let slave = unsafe { File::from_raw_fd(slave) };
-    let flags = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_GETFL) };
-    assert!(flags >= 0);
-    let rc = unsafe { libc::fcntl(master.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) };
-    assert_eq!(rc, 0);
-    (master, slave)
-}
-
-/// Drain everything currently readable from the master into `sink`. Draining
-/// continuously is mandatory: if the PTY buffer fills, the child blocks on its
-/// next render and the whole TUI event loop stalls.
-fn drain(master: &mut File, sink: &mut Vec<u8>) {
-    let mut buffer = [0_u8; 8192];
-    loop {
-        match master.read(&mut buffer) {
-            Ok(0) => break,
-            Ok(count) => sink.extend_from_slice(&buffer[..count]),
-            Err(error) if error.kind() == ErrorKind::WouldBlock => break,
-            Err(error) => panic!("PTY read failed: {error}"),
-        }
-    }
-}
-
-/// Remove ANSI/VT control sequences so the visible glyphs collapse into reading
-/// order. Ratatui positions every wide (CJK) cell with its own cursor-move
-/// escape, so a Korean word is *not* a contiguous byte run in the raw stream —
-/// stripping the escapes is what makes it one again.
-fn strip_ansi(bytes: &[u8]) -> String {
-    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == 0x1b {
-            match bytes.get(i + 1) {
-                Some(b'[') => {
-                    // CSI: consume params/intermediates up to the final byte.
-                    i += 2;
-                    while i < bytes.len() && !(0x40..=0x7e).contains(&bytes[i]) {
-                        i += 1;
-                    }
-                    i += usize::from(i < bytes.len());
-                }
-                Some(b']') => {
-                    // OSC: terminated by BEL or ST (ESC \).
-                    i += 2;
-                    while i < bytes.len() {
-                        if bytes[i] == 0x07 {
-                            i += 1;
-                            break;
-                        }
-                        if bytes[i] == 0x1b && bytes.get(i + 1) == Some(&b'\\') {
-                            i += 2;
-                            break;
-                        }
-                        i += 1;
-                    }
-                }
-                Some(_) => i += 2, // other two-byte escapes
-                None => break,
-            }
-        } else {
-            out.push(bytes[i]);
-            i += 1;
-        }
-    }
-    String::from_utf8_lossy(&out).into_owned()
-}
-
-/// Whitespace between cells is likewise emitted as cursor motion, so compare the
-/// visible text with all whitespace removed.
-fn norm(s: &str) -> String {
-    s.chars().filter(|c| !c.is_whitespace()).collect()
-}
-
-fn visible(sink: &[u8]) -> String {
-    norm(&strip_ansi(sink))
-}
-
-fn seen(sink: &[u8], marker: &str) -> bool {
-    visible(sink).contains(&norm(marker))
-}
-
-fn recent(sink: &[u8]) -> String {
-    let text = strip_ansi(sink);
-    let chars: Vec<char> = text.chars().collect();
-    let start = chars.len().saturating_sub(600);
-    chars[start..].iter().collect()
-}
-
-/// Read (draining) until `marker` shows up in the visible output, or panic with
-/// the tail of what was actually rendered.
-fn wait_for_marker(master: &mut File, sink: &mut Vec<u8>, marker: &str, within: Duration) {
-    let deadline = Instant::now() + within;
-    loop {
-        drain(master, sink);
-        if seen(sink, marker) {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "marker {marker:?} not seen within {within:?}; recent output:\n{}",
-            recent(sink)
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
-}
-
 #[test]
 fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
@@ -297,7 +172,7 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     )
     .unwrap();
 
-    let (mut master, slave) = open_pty();
+    let (mut master, slave) = open_pty(40, 140);
     let stdin = Stdio::from(slave.try_clone().unwrap());
     let stdout = Stdio::from(slave.try_clone().unwrap());
     let stderr = Stdio::from(slave);

--- a/tests/tui_startup_review_revision_process.rs
+++ b/tests/tui_startup_review_revision_process.rs
@@ -223,12 +223,6 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         Duration::from_secs(5),
     );
     master.write_all("INITIAL-PLAN-REQUEST".as_bytes()).unwrap();
-    // Everything the review screen renders arrives after this submit, so judge
-    // the Korean labels against output from here on. Measured: none of the eight
-    // labels was in the sink before this point, so the cumulative form was not
-    // yet vacuous — the window is what keeps it from becoming vacuous when a
-    // future Home or loading frame starts carrying one of them (issue #92).
-    let before_review = sink.len();
     master.write_all(b"\x13").unwrap(); // Ctrl+S submit
 
     // 4) The finished planner transitions the app to the review screen on its
@@ -249,9 +243,8 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         "Esc/q 뒤로",     // footer: back
     ] {
         assert!(
-            seen(&sink[before_review..], label),
-            "Korean review label {label:?} not visible on the review screen; \
-             recent output:\n{}",
+            seen(&sink, label),
+            "Korean review label {label:?} not visible; recent output:\n{}",
             recent(&sink)
         );
     }
@@ -269,7 +262,6 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     // Type two lines separated by Enter, then submit with Ctrl+S. Both lines must
     // render on the review edit box (proving Enter produced a newline, not a
     // submit).
-    let before_typing = sink.len();
     master.write_all(b"REVLINE-TOP").unwrap();
     master.write_all(b"\r").unwrap(); // Enter = newline
     master.write_all(b"REVLINE-BOTTOM").unwrap();
@@ -279,11 +271,8 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         "REVLINE-BOTTOM",
         Duration::from_secs(5),
     );
-    // Both lines must be on the frame that holds the second one. Matching the
-    // whole sink would also accept the echo of the first line from before Enter
-    // was pressed, which is the state this asserts against.
     assert!(
-        seen(&sink[before_typing..], "REVLINE-TOP"),
+        seen(&sink, "REVLINE-TOP"),
         "first revision line vanished before submit — Enter did not insert a newline;\n{}",
         recent(&sink)
     );

--- a/tests/tui_startup_review_revision_process.rs
+++ b/tests/tui_startup_review_revision_process.rs
@@ -348,6 +348,12 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         Duration::from_secs(5),
     );
     master.write_all("INITIAL-PLAN-REQUEST".as_bytes()).unwrap();
+    // Everything the review screen renders arrives after this submit, so judge
+    // the Korean labels against output from here on. Measured: none of the eight
+    // labels was in the sink before this point, so the cumulative form was not
+    // yet vacuous — the window is what keeps it from becoming vacuous when a
+    // future Home or loading frame starts carrying one of them (issue #92).
+    let before_review = sink.len();
     master.write_all(b"\x13").unwrap(); // Ctrl+S submit
 
     // 4) The finished planner transitions the app to the review screen on its
@@ -368,8 +374,9 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         "Esc/q 뒤로",     // footer: back
     ] {
         assert!(
-            seen(&sink, label),
-            "Korean review label {label:?} not visible; recent output:\n{}",
+            seen(&sink[before_review..], label),
+            "Korean review label {label:?} not visible on the review screen; \
+             recent output:\n{}",
             recent(&sink)
         );
     }
@@ -387,6 +394,7 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
     // Type two lines separated by Enter, then submit with Ctrl+S. Both lines must
     // render on the review edit box (proving Enter produced a newline, not a
     // submit).
+    let before_typing = sink.len();
     master.write_all(b"REVLINE-TOP").unwrap();
     master.write_all(b"\r").unwrap(); // Enter = newline
     master.write_all(b"REVLINE-BOTTOM").unwrap();
@@ -396,8 +404,11 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
         "REVLINE-BOTTOM",
         Duration::from_secs(5),
     );
+    // Both lines must be on the frame that holds the second one. Matching the
+    // whole sink would also accept the echo of the first line from before Enter
+    // was pressed, which is the state this asserts against.
     assert!(
-        seen(&sink, "REVLINE-TOP"),
+        seen(&sink[before_typing..], "REVLINE-TOP"),
         "first revision line vanished before submit — Enter did not insert a newline;\n{}",
         recent(&sink)
     );

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -2077,7 +2077,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
         let mut resumed = ChildGuard::new(
-    Command::new(&fixture.binary)
+            Command::new(&fixture.binary)
                 .args([
                     "answer",
                     "resume",
@@ -2104,7 +2104,9 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "resume fixture never published its successful result"
         );
         let result_seen = Instant::now();
-        let exited = wait_until(LOAD_TOLERANT_WAIT, || resumed.as_mut().try_wait().unwrap().is_some());
+        let exited = wait_until(LOAD_TOLERANT_WAIT, || {
+            resumed.as_mut().try_wait().unwrap().is_some()
+        });
         if !exited {
             resumed.kill_now();
         }
@@ -2245,7 +2247,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
         let mut running = ChildGuard::new(
-    Command::new(&fixture.binary)
+            Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
@@ -2354,7 +2356,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
         let mut running = ChildGuard::new(
-    Command::new(&fixture.binary)
+            Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-EXACT-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
@@ -2389,7 +2391,12 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "--action-id",
             "act-exact-model-redirect",
         ]);
-        assert!(running.into_inner().wait_with_output().unwrap().status.success());
+        assert!(running
+            .into_inner()
+            .wait_with_output()
+            .unwrap()
+            .status
+            .success());
         assert_eq!(task_state(&fixture.root, "YARD-EXACT-REDIRECT"), "done");
         assert_exact_queue_task(&fixture.root, "YARD-EXACT-REDIRECT", "YARD-EXACT-REDIRECT");
         let runs = run_dirs_for_task(&fixture.root, "YARD-EXACT-REDIRECT");
@@ -2471,7 +2478,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
         let mut running = ChildGuard::new(
-    Command::new(&fixture.binary)
+            Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
@@ -2844,7 +2851,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
         let mut running = ChildGuard::new(
-    Command::new(&fixture.binary)
+            Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-LIVE", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
@@ -3142,7 +3149,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
         let running = ChildGuard::new(
-    Command::new(&fixture.binary)
+            Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -7,6 +7,7 @@ mod common;
 
 #[cfg(unix)]
 mod unix {
+    use super::common;
     use super::common::ChildGuard;
     use super::process_binary_preflight::{preflight_process_binary, CliCapability};
     use serde_yaml_ng::Value;
@@ -812,14 +813,20 @@ printf '# Handoff\n\nPolicy-authorized failover completed.\n' >"$run_dir/handoff
             &hook,
             r##"#!/usr/bin/env bash
 set -euo pipefail
+# The pid file is what lets the test reap this hook if an assertion fires while
+# it is still polling; removing it on the way out is what stops the guard from
+# signalling a pid the OS has since handed to someone else.
+printf '%s' "$$" > .agents/failover-hook.pid
 touch .agents/failover-hook-entered
 for _ in $(seq 1 4000); do
   if [[ -f .agents/failover-hook-release ]]; then
     touch .agents/failover-hook-exited
+    rm -f .agents/failover-hook.pid
     exit 0
   fi
   sleep 0.05
 done
+rm -f .agents/failover-hook.pid
 exit 1
 "##,
         )
@@ -828,13 +835,11 @@ exit 1
         permissions.set_mode(0o755);
         fs::set_permissions(&hook, permissions).unwrap();
 
-        // A direct-child guard on purpose, NOT a group-leader one: this test
-        // deliberately produces a receipted ORPHAN. It kills the parent and then
-        // requires the worker to still be there for `recover` to finalize, so a
-        // guard that took down the whole tree would destroy the state under test
-        // (proven: group-killing here left `failover-hook-exited` unwritten).
-        // The guard still covers what it is for — an assertion unwinding past the
-        // kill and abandoning the parent.
+        // The hook keeps polling after this test kills Yardlet — that IS the
+        // receipted-orphan state under test — so it cannot be group-killed with
+        // the parent. It can still be reaped by pid if an assertion fires while it
+        // is mid-loop, which otherwise leaves it running out its own 200s timeout.
+        let _hook_guard = common::PidFileGuard::new(fixture.root.join(".agents/failover-hook.pid"));
         let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-FAILOVER", "--execute"])
@@ -2081,7 +2086,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut resumed = ChildGuard::spawn_group_leader(
+        let mut resumed = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args([
                     "answer",
@@ -2093,7 +2098,9 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
                 ])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
         );
         assert!(
             wait_until(LOAD_TOLERANT_WAIT, || {
@@ -2249,12 +2256,14 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::spawn_group_leader(
+        let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
         );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
@@ -2356,12 +2365,14 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::spawn_group_leader(
+        let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-EXACT-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
         );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-EXACT-REDIRECT") == "running"
@@ -2476,12 +2487,14 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::spawn_group_leader(
+        let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
         );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
@@ -2548,7 +2561,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // The long-lived decoy that leaked for 26 hours when an assertion below
         // fired before its kill (issue #64).
-        let mut decoy = ChildGuard::spawn_group_leader(Command::new("sleep").arg("600"));
+        let mut decoy = ChildGuard::new(Command::new("sleep").arg("600").spawn().unwrap());
         let decoy_pid = decoy.id();
         fs::write(&pid_path, decoy_pid.to_string()).unwrap();
 
@@ -2601,7 +2614,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         );
 
         // Same shape, same leak (issue #64).
-        let mut worker = ChildGuard::spawn_group_leader(Command::new("sleep").arg("599"));
+        let mut worker = ChildGuard::new(Command::new("sleep").arg("599").spawn().unwrap());
         let worker_pid = worker.id();
         let marker =
             process_start_marker(worker_pid).expect("fixture worker identity must be observable");
@@ -2847,12 +2860,14 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::spawn_group_leader(
+        let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-LIVE", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
         );
 
         let live_events_visible = wait_until(LOAD_TOLERANT_WAIT, || {
@@ -3143,12 +3158,14 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         );
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let running = ChildGuard::spawn_group_leader(
+        let running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped()),
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
         );
         assert!(wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -839,7 +839,10 @@ exit 1
         // receipted-orphan state under test — so it cannot be group-killed with
         // the parent. It can still be reaped by pid if an assertion fires while it
         // is mid-loop, which otherwise leaves it running out its own 200s timeout.
-        let _hook_guard = common::PidFileGuard::new(fixture.root.join(".agents/failover-hook.pid"));
+        let _hook_guard = common::PidFileGuard::new(
+            fixture.root.join(".agents/failover-hook.pid"),
+            "00-pause-before-finalize",
+        );
         let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-FAILOVER", "--execute"])

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -3,7 +3,11 @@
 mod process_binary_preflight;
 
 #[cfg(unix)]
+mod common;
+
+#[cfg(unix)]
 mod unix {
+    use super::common::ChildGuard;
     use super::process_binary_preflight::{preflight_process_binary, CliCapability};
     use serde_yaml_ng::Value;
     use std::fs;
@@ -824,13 +828,17 @@ exit 1
         permissions.set_mode(0o755);
         fs::set_permissions(&hook, permissions).unwrap();
 
-        let mut running = Command::new(&fixture.binary)
-            .args(["run", "--task", "YARD-FAILOVER", "--execute"])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .unwrap();
+        // Guarded so the assertion below cannot unwind past the kill and abandon
+        // a live `yardlet run` (issue #64: four of these survived 26 hours).
+        let mut running = ChildGuard::new(
+            Command::new(&fixture.binary)
+                .args(["run", "--task", "YARD-FAILOVER", "--execute"])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .unwrap(),
+        );
         assert!(
             wait_until(LOAD_TOLERANT_WAIT, || {
                 if !fixture.root.join(".agents/failover-hook-entered").is_file() {
@@ -849,8 +857,7 @@ exit 1
             }),
             "failover worker did not reach the receipted pre-finalize crash window"
         );
-        running.kill().unwrap();
-        running.wait().unwrap();
+        running.kill_now();
         fs::write(
             fixture.root.join(".agents/failover-hook-release"),
             "release\n",
@@ -2067,20 +2074,24 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "needs_user"
         );
 
-        let mut resumed = Command::new(&fixture.binary)
-            .args([
-                "answer",
-                "resume",
-                "--task",
-                "YARD-CODEX-BACKPRESSURE",
-                "--action-id",
-                "act-codex-backpressure",
-            ])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+        // Guarded so an assertion below cannot unwind past the kill and
+        // abandon a live child (issue #64).
+        let mut resumed = ChildGuard::new(
+    Command::new(&fixture.binary)
+                .args([
+                    "answer",
+                    "resume",
+                    "--task",
+                    "YARD-CODEX-BACKPRESSURE",
+                    "--action-id",
+                    "act-codex-backpressure",
+                ])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        );
         assert!(
             wait_until(LOAD_TOLERANT_WAIT, || {
                 files_below(&fixture.root.join(".agents/runs"), "/result.json")
@@ -2093,11 +2104,11 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "resume fixture never published its successful result"
         );
         let result_seen = Instant::now();
-        let exited = wait_until(LOAD_TOLERANT_WAIT, || resumed.try_wait().unwrap().is_some());
+        let exited = wait_until(LOAD_TOLERANT_WAIT, || resumed.as_mut().try_wait().unwrap().is_some());
         if !exited {
-            let _ = resumed.kill();
+            resumed.kill_now();
         }
-        let output = resumed.wait_with_output().unwrap();
+        let output = resumed.into_inner().wait_with_output().unwrap();
         assert!(
             exited,
             "Yardlet parent exceeded the load-tolerant hard timeout"
@@ -2231,13 +2242,17 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "  - id: YARD-REDIRECT\n    title: running worker is redirected\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
         );
 
-        let mut running = Command::new(&fixture.binary)
-            .args(["run", "--task", "YARD-REDIRECT", "--execute"])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+        // Guarded so an assertion below cannot unwind past the kill and
+        // abandon a live child (issue #64).
+        let mut running = ChildGuard::new(
+    Command::new(&fixture.binary)
+                .args(["run", "--task", "YARD-REDIRECT", "--execute"])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
                 && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
@@ -2249,8 +2264,8 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
                     })
         });
         if !started {
-            let _ = running.kill();
-            let output = running.wait_with_output().unwrap();
+            running.kill_now();
+            let output = running.into_inner().wait_with_output().unwrap();
             panic!(
                 "redirect fixture never reached running with a checkpoint handoff\nstdout:\n{}\nstderr:\n{}",
                 String::from_utf8_lossy(&output.stdout),
@@ -2267,7 +2282,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "--action-id",
             "act-running-redirect",
         ]);
-        let original = running.wait_with_output().unwrap();
+        let original = running.into_inner().wait_with_output().unwrap();
         assert!(original.status.success());
 
         let channel = channel_dir(&fixture.root, "YARD-REDIRECT");
@@ -2336,13 +2351,17 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "  - id: YARD-EXACT-REDIRECT\n    title: exact redirect lineage\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n    model: gpt-5.6-sol\n    fallback_enabled: false\n",
         );
 
-        let mut running = Command::new(&fixture.binary)
-            .args(["run", "--task", "YARD-EXACT-REDIRECT", "--execute"])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+        // Guarded so an assertion below cannot unwind past the kill and
+        // abandon a live child (issue #64).
+        let mut running = ChildGuard::new(
+    Command::new(&fixture.binary)
+                .args(["run", "--task", "YARD-EXACT-REDIRECT", "--execute"])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-EXACT-REDIRECT") == "running"
                 && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
@@ -2354,8 +2373,8 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
                     })
         });
         if !started {
-            let _ = running.kill();
-            let output = running.wait_with_output().unwrap();
+            running.kill_now();
+            let output = running.into_inner().wait_with_output().unwrap();
             panic!(
                 "exact redirect fixture never reached running\nstdout:\n{}\nstderr:\n{}",
                 String::from_utf8_lossy(&output.stdout),
@@ -2370,7 +2389,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "--action-id",
             "act-exact-model-redirect",
         ]);
-        assert!(running.wait_with_output().unwrap().status.success());
+        assert!(running.into_inner().wait_with_output().unwrap().status.success());
         assert_eq!(task_state(&fixture.root, "YARD-EXACT-REDIRECT"), "done");
         assert_exact_queue_task(&fixture.root, "YARD-EXACT-REDIRECT", "YARD-EXACT-REDIRECT");
         let runs = run_dirs_for_task(&fixture.root, "YARD-EXACT-REDIRECT");
@@ -2449,20 +2468,24 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "  - id: YARD-REDIRECT\n    title: redirect verifies worker provenance\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
         );
 
-        let mut running = Command::new(&fixture.binary)
-            .args(["run", "--task", "YARD-REDIRECT", "--execute"])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+        // Guarded so an assertion below cannot unwind past the kill and
+        // abandon a live child (issue #64).
+        let mut running = ChildGuard::new(
+    Command::new(&fixture.binary)
+                .args(["run", "--task", "YARD-REDIRECT", "--execute"])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
                 && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
         });
         if !started {
-            let _ = running.kill();
-            let output = running.wait_with_output().unwrap();
+            running.kill_now();
+            let output = running.into_inner().wait_with_output().unwrap();
             panic!(
                 "redirect provenance fixture never reached running\nstdout:\n{}\nstderr:\n{}",
                 String::from_utf8_lossy(&output.stdout),
@@ -2519,7 +2542,9 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         );
         assert!(!run_dir.join("cancelled").exists());
 
-        let mut decoy = Command::new("sleep").arg("600").spawn().unwrap();
+        // The long-lived decoy that leaked for 26 hours when an assertion below
+        // fired before its kill (issue #64).
+        let mut decoy = ChildGuard::new(Command::new("sleep").arg("600").spawn().unwrap());
         let decoy_pid = decoy.id();
         fs::write(&pid_path, decoy_pid.to_string()).unwrap();
 
@@ -2537,16 +2562,15 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             ],
         );
         let worker_was_still_alive = process_is_alive(worker_pid);
-        let decoy_survived = decoy.try_wait().unwrap().is_none();
+        let decoy_survived = decoy.as_mut().try_wait().unwrap().is_none();
 
         if worker_was_still_alive {
             let _ = Command::new("kill").arg(worker_pid.to_string()).status();
         }
-        let original = running.wait_with_output().unwrap();
+        let original = running.into_inner().wait_with_output().unwrap();
         if decoy_survived {
-            let _ = decoy.kill();
+            decoy.kill_now();
         }
-        let _ = decoy.wait();
 
         assert!(
             redirect.status.success(),
@@ -2572,7 +2596,8 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "  - id: YARD-DEAD-WORKER\n    title: externally killed worker status\n    state: running\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
         );
 
-        let mut worker = Command::new("sleep").arg("599").spawn().unwrap();
+        // Same shape, same leak (issue #64).
+        let mut worker = ChildGuard::new(Command::new("sleep").arg("599").spawn().unwrap());
         let worker_pid = worker.id();
         let marker =
             process_start_marker(worker_pid).expect("fixture worker identity must be observable");
@@ -2611,8 +2636,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "verified live worker must not be diagnosed as interrupted"
         );
 
-        worker.kill().unwrap();
-        worker.wait().unwrap();
+        worker.kill_now();
         assert!(!process_is_alive(worker_pid));
 
         let queue_path = fixture.root.join(".agents/work-queue.yaml");
@@ -2817,13 +2841,17 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "  - id: YARD-LIVE\n    title: live provider progress and artifacts\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: codex\n",
         );
 
-        let mut running = Command::new(&fixture.binary)
-            .args(["run", "--task", "YARD-LIVE", "--execute"])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+        // Guarded so an assertion below cannot unwind past the kill and
+        // abandon a live child (issue #64).
+        let mut running = ChildGuard::new(
+    Command::new(&fixture.binary)
+                .args(["run", "--task", "YARD-LIVE", "--execute"])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        );
 
         let live_events_visible = wait_until(LOAD_TOLERANT_WAIT, || {
             let Some(channel) = maybe_channel_dir(&fixture.root, "YARD-LIVE") else {
@@ -2860,7 +2888,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             "normalized events were not visible while the worker lived"
         );
         assert!(
-            running.try_wait().unwrap().is_none(),
+            running.as_mut().try_wait().unwrap().is_none(),
             "worker run exited before live channel observation"
         );
 
@@ -2895,7 +2923,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
                 .contains("private fixture reasoning")
         }));
 
-        let output = running.wait_with_output().unwrap();
+        let output = running.into_inner().wait_with_output().unwrap();
         assert!(
             output.status.success(),
             "live fixture failed\nstdout:\n{}\nstderr:\n{}",
@@ -3111,13 +3139,17 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         fixture.write_queue(
             "  - id: YARD-REDIRECT\n    title: redirect receipt crash recovery\n    state: queued\n    priority: 10\n    kind: implementation\n    preferred_worker: fixture\n",
         );
-        let running = Command::new(&fixture.binary)
-            .args(["run", "--task", "YARD-REDIRECT", "--execute"])
-            .current_dir(&fixture.root)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
+        // Guarded so an assertion below cannot unwind past the kill and
+        // abandon a live child (issue #64).
+        let running = ChildGuard::new(
+    Command::new(&fixture.binary)
+                .args(["run", "--task", "YARD-REDIRECT", "--execute"])
+                .current_dir(&fixture.root)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .unwrap(),
+        );
         assert!(wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
                 && !files_below(&fixture.root.join(".agents/runs"), "/worker.pid").is_empty()
@@ -3141,7 +3173,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             !crashed.status.success(),
             "redirect did not stop after the terminal receipt"
         );
-        let original = running.wait_with_output().unwrap();
+        let original = running.into_inner().wait_with_output().unwrap();
         assert!(original.status.success());
         let channel = channel_dir(&fixture.root, "YARD-REDIRECT");
         let prepared_attempts = yaml_dir(&channel.join("attempts"));

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -828,8 +828,13 @@ exit 1
         permissions.set_mode(0o755);
         fs::set_permissions(&hook, permissions).unwrap();
 
-        // Guarded so the assertion below cannot unwind past the kill and abandon
-        // a live `yardlet run` (issue #64: four of these survived 26 hours).
+        // A direct-child guard on purpose, NOT a group-leader one: this test
+        // deliberately produces a receipted ORPHAN. It kills the parent and then
+        // requires the worker to still be there for `recover` to finalize, so a
+        // guard that took down the whole tree would destroy the state under test
+        // (proven: group-killing here left `failover-hook-exited` unwritten).
+        // The guard still covers what it is for — an assertion unwinding past the
+        // kill and abandoning the parent.
         let mut running = ChildGuard::new(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-FAILOVER", "--execute"])
@@ -2076,7 +2081,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut resumed = ChildGuard::new(
+        let mut resumed = ChildGuard::spawn_group_leader(
             Command::new(&fixture.binary)
                 .args([
                     "answer",
@@ -2088,9 +2093,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
                 ])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
+                .stderr(Stdio::piped()),
         );
         assert!(
             wait_until(LOAD_TOLERANT_WAIT, || {
@@ -2246,14 +2249,12 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::new(
+        let mut running = ChildGuard::spawn_group_leader(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
+                .stderr(Stdio::piped()),
         );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
@@ -2355,14 +2356,12 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::new(
+        let mut running = ChildGuard::spawn_group_leader(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-EXACT-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
+                .stderr(Stdio::piped()),
         );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-EXACT-REDIRECT") == "running"
@@ -2477,14 +2476,12 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::new(
+        let mut running = ChildGuard::spawn_group_leader(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
+                .stderr(Stdio::piped()),
         );
         let started = wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"
@@ -2551,7 +2548,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // The long-lived decoy that leaked for 26 hours when an assertion below
         // fired before its kill (issue #64).
-        let mut decoy = ChildGuard::new(Command::new("sleep").arg("600").spawn().unwrap());
+        let mut decoy = ChildGuard::spawn_group_leader(Command::new("sleep").arg("600"));
         let decoy_pid = decoy.id();
         fs::write(&pid_path, decoy_pid.to_string()).unwrap();
 
@@ -2604,7 +2601,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         );
 
         // Same shape, same leak (issue #64).
-        let mut worker = ChildGuard::new(Command::new("sleep").arg("599").spawn().unwrap());
+        let mut worker = ChildGuard::spawn_group_leader(Command::new("sleep").arg("599"));
         let worker_pid = worker.id();
         let marker =
             process_start_marker(worker_pid).expect("fixture worker identity must be observable");
@@ -2850,14 +2847,12 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
 
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let mut running = ChildGuard::new(
+        let mut running = ChildGuard::spawn_group_leader(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-LIVE", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
+                .stderr(Stdio::piped()),
         );
 
         let live_events_visible = wait_until(LOAD_TOLERANT_WAIT, || {
@@ -3148,14 +3143,12 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
         );
         // Guarded so an assertion below cannot unwind past the kill and
         // abandon a live child (issue #64).
-        let running = ChildGuard::new(
+        let running = ChildGuard::spawn_group_leader(
             Command::new(&fixture.binary)
                 .args(["run", "--task", "YARD-REDIRECT", "--execute"])
                 .current_dir(&fixture.root)
                 .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .unwrap(),
+                .stderr(Stdio::piped()),
         );
         assert!(wait_until(LOAD_TOLERANT_WAIT, || {
             task_state(&fixture.root, "YARD-REDIRECT") == "running"


### PR DESCRIPTION
Closes #92.

Four defects, each proven before it was fixed and each pinned afterwards in `tests/pty_child_guard.rs`.

## The wait predicate was weaker than the assertion

`wait_for_file` returned on `path.exists()`, but the planner fixture writes with `printf '%s' "$packet" >"$file"`, which creates the file and fills it in two steps. The read landed in the gap and the assertion failed on an empty string — it observed no value at all, which is why a one-file `chore` commit that touches no code could break it ([PR #99's CI run](https://github.com/zzunkie/yardlet/actions/runs/30390707932/job/90381268982)). Reproduced locally at 1 in 3 with a prebuilt binary; 8 of 8 after the fix.

`wait_for_file_contents` takes the predicate the caller is about to assert and, on timeout, reports whether the file was missing, empty, or held something else.

## The workspace leaked on every red run

`ChildGuard` closed half of #64. The other half stayed open: every PTY test called `remove_dir_all` on its happy path only, so the same unwind abandoned the temp root. Two leaked roots were collected from one reproduction run. `WorkspaceGuard` owns exactly the path it was handed — no globbing the temp directory, no removing roots another session left.

## Eight spawns in the task-channel tests were never guarded

#64 was fixed in the five files it named, and `v010_003_task_channels_process.rs` was not one of them. Its `sleep 600`/`sleep 599` fixtures and six `yardlet run` children all kill after the assertions. Four such processes were found alive 26 hours later. Proven by wiring rather than assumption: a panic injected before the decoy's kill left its pid reaped instead of running.

## The harness was pasted into four files

403 duplicated lines, which is why #92 could be half-fixed — the cumulative-sink defect was corrected in `tui_key_list_process.rs` and left standing in its three copies. One home now.

`open_pty` takes its size instead of hardcoding one. Not cosmetic: the key-list test hid the #71 scroll defect precisely because it was pinned at 40 rows, where the list fits.

## What I did NOT find

The assertion windows in the review and re-entry tests are narrowed, but I measured them first and they were **not** vacuous: none of the eight Korean review labels was in the sink before the review screen existed, and Home does not render the draft summary before `o`. The comments say so. Those changes keep an assertion from going vacuous later; they did not fix a broken one.

## Verification

Eight targets that include the shared module, all green: the four TUI PTY tests, `pty_child_guard` (7 tests), `v010_003_task_channels_process` (40 tests), and both `worker_*_process` tests. `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean. No temp workspace and no `sleep` child left behind after the runs.

#58 is left open: its symptom does not reproduce at this HEAD (8 of 8 passes on the macOS host that reported it), and I have not established what changed. Details in a comment there.