### PR TITLE
fix(runtime): take the worker down when Yardlet is asked to stop

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2630,16 +2630,6 @@ fn cmd_packet(cwd: &std::path::Path, args: PacketArgs) -> Result<()> {
 
 fn cmd_run(cwd: &std::path::Path, args: RunArgs) -> Result<()> {
     let ws = init::ensure_initialized(cwd)?.0;
-    // A worker leads its own process group so it survives the terminal (#52),
-    // which also means no signal the operator sends can reach it. Yardlet holds
-    // the only handle, so it has to be the one that takes the worker down when
-    // it is asked to stop (issue #107).
-    if !crate::signals::install_stop_handler() {
-        eprintln!(
-            "yardlet: could not install a stop handler; interrupting this run may \
-             leave its worker running"
-        );
-    }
     let _ = (args.next, args.headless); // --next is implied; --task targets one
     if args.auto {
         run::run_auto(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2630,6 +2630,16 @@ fn cmd_packet(cwd: &std::path::Path, args: PacketArgs) -> Result<()> {
 
 fn cmd_run(cwd: &std::path::Path, args: RunArgs) -> Result<()> {
     let ws = init::ensure_initialized(cwd)?.0;
+    // A worker leads its own process group so it survives the terminal (#52),
+    // which also means no signal the operator sends can reach it. Yardlet holds
+    // the only handle, so it has to be the one that takes the worker down when
+    // it is asked to stop (issue #107).
+    if !crate::signals::install_stop_handler() {
+        eprintln!(
+            "yardlet: could not install a stop handler; interrupting this run may \
+             leave its worker running"
+        );
+    }
     let _ = (args.next, args.headless); // --next is implied; --task targets one
     if args.auto {
         run::run_auto(

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod routing;
 mod rubric;
 mod run;
 mod schemas;
+mod signals;
 mod skill_author;
 mod skills;
 mod snapshot;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -757,7 +757,9 @@ pub fn run_batch<F: FnMut(&str)>(
             continue;
         }
 
-        if !p.run_dir.join("result.json").exists() {
+        // Same rule as the serial path: a stop is not a worker being unwell, so
+        // it must not start a replacement (issue #107).
+        if !crate::signals::stop_requested() && !p.run_dir.join("result.json").exists() {
             match routing::resolve_failover_worker_for_task(
                 &workers_file,
                 &billing,

--- a/src/run.rs
+++ b/src/run.rs
@@ -3017,11 +3017,18 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         });
     }
 
-    // A stop cancels recovery too. This spawns a fresh attempt on a typed
+    // A stop cancels recovery too: this spawns a fresh attempt on a typed
     // refusal, which is right when the worker is unwell and wrong when the
-    // operator has asked Yardlet to stop — an independent review reproduced
-    // `attempt-2` being created after a SIGINT (issue #107).
-    if run_dir.join("cancelled").is_file() {
+    // operator has asked Yardlet to stop (issue #107).
+    //
+    // Keyed on the OUTCOME, not on the `cancelled` marker. `yardlet redirect`
+    // writes that same marker to stop a run, so reading it here made a redirect
+    // look like a process stop and changed the path it takes — the full suite
+    // caught it as `redirect_ignores_decoy_pid_and_signals_verified_worker`
+    // failing under load while main passed. The marker means "this run was
+    // stopped, do not resume it", which redirect also wants; it does not mean
+    // "this process is shutting down", which is what these two branches need.
+    if outcome.stopped {
         output_contract_incident = None;
     }
     if let Some(mut incident) = output_contract_incident.take() {
@@ -3137,7 +3144,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     // worker is unwell and another should try, but here the missing result is
     // what the operator asked for, and spawning a replacement is the one thing a
     // stop is meant to prevent (issue #107).
-    if !run_dir.join("cancelled").is_file()
+    if !outcome.stopped
         && !run_dir.join("result.json").exists()
         && output_contract_incident.is_none()
     {
@@ -7181,27 +7188,6 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             task.id
         ));
         next_state = TaskState::Done;
-    }
-    // An interrupted run cannot finish a task, whichever attempt produced the
-    // result and whichever path got here.
-    //
-    // This is the ONE place that decides, deliberately. Marking the spawn sites
-    // instead left three holes an independent review walked through: a serial
-    // FAILOVER worker never wrote the marker, the parallel path never wrote it
-    // at all, and the marker itself was deleted before the queue transition was
-    // durable — so a save that failed left `recover` finalizing the task Done.
-    // Every one of those routes passes through here.
-    //
-    // Reads the process flag rather than a file: the flag cannot be deleted by
-    // an intervening step, and it is true for exactly the runs this process was
-    // asked to abandon. Partial, not Failed — the work may well be usable, and
-    // `run --auto` retries Failed, which would restart what the operator stopped.
-    if crate::signals::stop_requested() && next_state == TaskState::Done {
-        lines.push(format!(
-            "{}: interrupted before it could be finished; left Partial",
-            task.id
-        ));
-        next_state = TaskState::Partial;
     }
     // Preserve the worker/evaluator outcome before Git integration can turn a
     // passing Done into a manual-integration Partial. Review remediation is

--- a/src/run.rs
+++ b/src/run.rs
@@ -7182,6 +7182,27 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         ));
         next_state = TaskState::Done;
     }
+    // An interrupted run cannot finish a task, whichever attempt produced the
+    // result and whichever path got here.
+    //
+    // This is the ONE place that decides, deliberately. Marking the spawn sites
+    // instead left three holes an independent review walked through: a serial
+    // FAILOVER worker never wrote the marker, the parallel path never wrote it
+    // at all, and the marker itself was deleted before the queue transition was
+    // durable — so a save that failed left `recover` finalizing the task Done.
+    // Every one of those routes passes through here.
+    //
+    // Reads the process flag rather than a file: the flag cannot be deleted by
+    // an intervening step, and it is true for exactly the runs this process was
+    // asked to abandon. Partial, not Failed — the work may well be usable, and
+    // `run --auto` retries Failed, which would restart what the operator stopped.
+    if crate::signals::stop_requested() && next_state == TaskState::Done {
+        lines.push(format!(
+            "{}: interrupted before it could be finished; left Partial",
+            task.id
+        ));
+        next_state = TaskState::Partial;
+    }
     // Preserve the worker/evaluator outcome before Git integration can turn a
     // passing Done into a manual-integration Partial. Review remediation is
     // about failed review evidence, not a later delivery hold.

--- a/src/run.rs
+++ b/src/run.rs
@@ -2233,6 +2233,11 @@ pub(crate) fn prepare_answer_action_with_deviations(
 }
 
 pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
+    // Installed at the entry point, not at each caller: `yardlet goal` reaches
+    // `run_auto` without going through `cmd_run`, and an independent review found
+    // exactly that path still orphaning its worker. Every route that can start a
+    // worker passes through here or `run_next` (issue #107).
+    crate::signals::install_stop_handler();
     // Serialize queue selection and the first runtime transition against a
     // planning confirmation. Once Running is canonical, confirm observes it
     // and fails closed; the worker itself never holds this lock.
@@ -3109,7 +3114,14 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     }
 
     let mut failover_note: Option<String> = None;
-    if !run_dir.join("result.json").exists() && output_contract_incident.is_none() {
+    // A stopped run must not fail over. "No result.json" is normally evidence the
+    // worker is unwell and another should try, but here the missing result is
+    // what the operator asked for, and spawning a replacement is the one thing a
+    // stop is meant to prevent (issue #107).
+    if !outcome.stopped
+        && !run_dir.join("result.json").exists()
+        && output_contract_incident.is_none()
+    {
         match routing::resolve_failover_worker_for_task(
             &workers,
             &billing,
@@ -3785,6 +3797,11 @@ pub fn run_auto<F: FnMut(&str)>(
     accept_ambiguity: bool,
     mut on_event: F,
 ) -> Result<Vec<String>> {
+    // Installed at the entry point, not at each caller: `yardlet goal` reaches
+    // `run_auto` without going through `cmd_run`, and an independent review found
+    // exactly that path still orphaning its worker. Every route that can start a
+    // worker passes through here or `run_next` (issue #107).
+    crate::signals::install_stop_handler();
     use std::collections::HashMap;
     let max_parallel = parallel
         .or_else(|| ws.load_config().ok().map(|c| c.max_parallel))
@@ -3832,6 +3849,14 @@ pub fn run_auto<F: FnMut(&str)>(
     }
 
     loop {
+        // An interrupt ends the drain, it does not just end the current task.
+        // Without this the loop reads the stopped task as Failed, calls that
+        // transient, and starts the next worker — after the operator asked
+        // Yardlet to stop (issue #107).
+        if crate::signals::stop_requested() {
+            emit("stopped at your request; the queue is unchanged".to_string());
+            break;
+        }
         // Graceful pause: stop between tasks (the current task, if any, has
         // already finished here). Resume by running auto again.
         if pause

--- a/src/run.rs
+++ b/src/run.rs
@@ -1727,6 +1727,12 @@ fn worker_attempt_result(
     if run_dir.join("cancelled").is_file() {
         return "cancelled";
     }
+    // Checked before `result.json`: an interrupted worker may already have
+    // written a result it had not finished acting on, and recording that as a
+    // success would tell the operator their Ctrl-C completed the task.
+    if outcome.stopped {
+        return "stopped";
+    }
     if outcome.timed_out {
         return "timed_out";
     }
@@ -4327,7 +4333,12 @@ pub(crate) fn gen_session_uuid(seed: &str) -> String {
 /// A transient (likely network/infra) failure: the worker did not exit cleanly,
 /// left no result, and was not stopped by us — worth resuming rather than redoing.
 fn is_transient_failure(outcome: &workers::WorkerOutcome, run_dir: &std::path::Path) -> bool {
-    !outcome.exit_ok && !outcome.timed_out && !run_dir.join("result.json").exists()
+    // A run the operator stopped is not transient infrastructure trouble, and
+    // resuming it automatically would undo the stop they asked for.
+    !outcome.exit_ok
+        && !outcome.timed_out
+        && !outcome.stopped
+        && !run_dir.join("result.json").exists()
 }
 
 /// Validation commands configured on a task: `validation: { commands: [..] }`

--- a/src/run.rs
+++ b/src/run.rs
@@ -2857,6 +2857,18 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             return Err(error);
         }
     };
+    // A stop joins the convention the TUI's Esc already uses. The marker is what
+    // the rest of this function reads: it stops the resume loop, it stops typed
+    // output-contract recovery and failover from starting a REPLACEMENT worker,
+    // and it makes the attempt's outcome `cancelled` rather than a success
+    // finalized from whatever the interrupted worker had written (issue #107).
+    //
+    // Written durably before any of those decisions, so a crash in this window
+    // leaves the same answer on disk that this process would have given.
+    if outcome.stopped || crate::signals::stop_requested() {
+        outcome.stopped = true;
+        crate::state::write_str_atomic(&run_dir.join("cancelled"), "stopped\n")?;
+    }
     // From this point the worktree may contain completed or partially completed
     // worker work. Any import/finalization error must retain it for recovery;
     // the guard is only for failures before a worker actually ran.
@@ -3005,6 +3017,13 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         });
     }
 
+    // A stop cancels recovery too. This spawns a fresh attempt on a typed
+    // refusal, which is right when the worker is unwell and wrong when the
+    // operator has asked Yardlet to stop — an independent review reproduced
+    // `attempt-2` being created after a SIGINT (issue #107).
+    if run_dir.join("cancelled").is_file() {
+        output_contract_incident = None;
+    }
     if let Some(mut incident) = output_contract_incident.take() {
         // Consume the one-shot budget durably BEFORE spawning. If Yardlet dies
         // in this crash window, orphan recovery reads this receipt and parks
@@ -3118,7 +3137,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     // worker is unwell and another should try, but here the missing result is
     // what the operator asked for, and spawning a replacement is the one thing a
     // stop is meant to prevent (issue #107).
-    if !outcome.stopped
+    if !run_dir.join("cancelled").is_file()
         && !run_dir.join("result.json").exists()
         && output_contract_incident.is_none()
     {

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -33,18 +33,31 @@ fn live_workers() -> &'static Mutex<Vec<u32>> {
     LIVE.get_or_init(|| Mutex::new(Vec::new()))
 }
 
-/// Record a worker this process owns, for the duration of its run.
-pub fn track_worker(pid: u32) {
-    if let Ok(mut live) = live_workers().lock() {
-        live.push(pid);
+/// Tracks one worker for as long as this value lives.
+///
+/// RAII because a hand-placed untrack is a leak waiting to happen, and an
+/// independent review found two: the provenance-failure path and the reader-error
+/// path both return before reaching it. A pid left tracked after being reaped is
+/// a recycled-pid kill — the emergency exit would SIGKILL whatever the OS handed
+/// that number to next. Same defect this branch already fixed in `PidFileGuard`.
+pub struct TrackedWorker {
+    pid: u32,
+}
+
+impl TrackedWorker {
+    pub fn new(pid: u32) -> Self {
+        if let Ok(mut live) = live_workers().lock() {
+            live.push(pid);
+        }
+        Self { pid }
     }
 }
 
-/// Forget a worker that has been reaped, so its pid is never signalled again
-/// after the OS may have handed it to someone else.
-pub fn untrack_worker(pid: u32) {
-    if let Ok(mut live) = live_workers().lock() {
-        live.retain(|tracked| *tracked != pid);
+impl Drop for TrackedWorker {
+    fn drop(&mut self) {
+        if let Ok(mut live) = live_workers().lock() {
+            live.retain(|tracked| *tracked != self.pid);
+        }
     }
 }
 

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,0 +1,74 @@
+//! One place that knows the operator asked this process to stop.
+//!
+//! Yardlet starts workers in their own process group on purpose (issue #52), so
+//! they survive the terminal that launched them. The cost is that nothing
+//! outside Yardlet can clean one up: not the shell, whose signal goes to its own
+//! foreground group; not a test harness, which has no handle on a group it did
+//! not create. Yardlet is the only process that knows the worker's pid, so
+//! Yardlet has to be the one that takes it down.
+//!
+//! Before this, it did not. `terminate_worker_tree` existed and was correct, and
+//! nothing called it when the orchestrator itself was asked to stop, so a
+//! Ctrl-C on `yardlet run` killed the parent and left the worker holding the run
+//! directory (issue #107 — the likely source of the four `yardlet` processes
+//! found alive 26 hours later in #64).
+//!
+//! `ctrlc::set_handler` may only be installed once per process, so this owns the
+//! single installation and everything else reads the flag.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Once;
+
+static REQUESTED: AtomicBool = AtomicBool::new(false);
+static INSTALL: Once = Once::new();
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// Install the process-wide stop handler. Idempotent, and safe to call from any
+/// command; the second call is a no-op rather than the `MultipleHandlers` error
+/// `ctrlc` returns for a second registration.
+///
+/// Returns whether a handler is in place. A platform that refuses one is not
+/// fatal — the caller simply never sees a request — but it is worth reporting,
+/// because it means an interrupted run reverts to the old behaviour.
+pub fn install_stop_handler() -> bool {
+    INSTALL.call_once(|| {
+        let installed = ctrlc::set_handler(|| {
+            // Signal-handler context: set a flag and return. The teardown that
+            // follows takes locks and spawns processes, neither of which is safe
+            // here, so the polling side does that work.
+            REQUESTED.store(true, Ordering::SeqCst);
+        })
+        .is_ok();
+        INSTALLED.store(installed, Ordering::SeqCst);
+    });
+    INSTALLED.load(Ordering::SeqCst)
+}
+
+/// Has the operator asked this process to stop?
+pub fn stop_requested() -> bool {
+    REQUESTED.load(Ordering::SeqCst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The flag starts clear, so a run that is never interrupted takes no
+    /// teardown path it did not ask for.
+    #[test]
+    fn nothing_is_requested_until_a_signal_arrives() {
+        assert!(!stop_requested());
+    }
+
+    /// Installing twice must not fail. `watch` already registers a handler, and
+    /// a second registration is exactly what `ctrlc` refuses.
+    #[test]
+    fn installing_twice_is_not_an_error() {
+        let first = install_stop_handler();
+        let second = install_stop_handler();
+        assert_eq!(
+            first, second,
+            "the second install must report the same state, not a fresh attempt"
+        );
+    }
+}

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -33,10 +33,19 @@ static INSTALLED: AtomicBool = AtomicBool::new(false);
 pub fn install_stop_handler() -> bool {
     INSTALL.call_once(|| {
         let installed = ctrlc::set_handler(|| {
-            // Signal-handler context: set a flag and return. The teardown that
-            // follows takes locks and spawns processes, neither of which is safe
-            // here, so the polling side does that work.
-            REQUESTED.store(true, Ordering::SeqCst);
+            // The FIRST request asks for an orderly stop: set a flag and let the
+            // polling side do the teardown, which takes locks and signals
+            // processes.
+            //
+            // The SECOND means the operator is done waiting, and must actually
+            // work. Replacing the default disposition otherwise makes Ctrl-C
+            // unable to end the process at all — during the stop grace period, or
+            // if a teardown ever wedges. `ctrlc` runs this on its own thread, not
+            // in a raw handler, so exiting from here is allowed.
+            if REQUESTED.swap(true, Ordering::SeqCst) {
+                eprintln!("\nyardlet: second interrupt — exiting now, workers may be left running");
+                std::process::exit(130); // 128 + SIGINT, what a shell reports
+            }
         })
         .is_ok();
         INSTALLED.store(installed, Ordering::SeqCst);

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -17,11 +17,51 @@
 //! single installation and everything else reads the flag.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Once;
+use std::sync::{Mutex, Once, OnceLock};
 
 static REQUESTED: AtomicBool = AtomicBool::new(false);
 static INSTALL: Once = Once::new();
 static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+/// Workers this process started and has not yet reaped.
+///
+/// The emergency exit needs them: a second interrupt that leaves the process
+/// without taking its workers down produces the exact orphan #107 is about, only
+/// faster. Yardlet is still the only holder of these pids.
+fn live_workers() -> &'static Mutex<Vec<u32>> {
+    static LIVE: OnceLock<Mutex<Vec<u32>>> = OnceLock::new();
+    LIVE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Record a worker this process owns, for the duration of its run.
+pub fn track_worker(pid: u32) {
+    if let Ok(mut live) = live_workers().lock() {
+        live.push(pid);
+    }
+}
+
+/// Forget a worker that has been reaped, so its pid is never signalled again
+/// after the OS may have handed it to someone else.
+pub fn untrack_worker(pid: u32) {
+    if let Ok(mut live) = live_workers().lock() {
+        live.retain(|tracked| *tracked != pid);
+    }
+}
+
+/// Take down every worker this process still owns. Used by the emergency exit,
+/// which cannot rely on the normal teardown running.
+fn kill_tracked_workers() {
+    let pids = match live_workers().lock() {
+        Ok(live) => live.clone(),
+        // A poisoned lock means a panic while holding it; the pid list is still
+        // the best information available and leaking workers is the worse
+        // outcome.
+        Err(poisoned) => poisoned.into_inner().clone(),
+    };
+    for pid in pids {
+        crate::workers::terminate_worker_tree(pid, crate::workers::Signal::Kill);
+    }
+}
 
 /// Install the process-wide stop handler. Idempotent, and safe to call from any
 /// command; the second call is a no-op rather than the `MultipleHandlers` error
@@ -43,7 +83,14 @@ pub fn install_stop_handler() -> bool {
             // if a teardown ever wedges. `ctrlc` runs this on its own thread, not
             // in a raw handler, so exiting from here is allowed.
             if REQUESTED.swap(true, Ordering::SeqCst) {
-                eprintln!("\nyardlet: second interrupt — exiting now, workers may be left running");
+                // Take the workers with us BEFORE exiting. `process::exit` runs
+                // no destructors, so an emergency exit that skipped this would
+                // produce the very orphan #107 is about, just faster.
+                kill_tracked_workers();
+                eprintln!(
+                    "\nyardlet: second interrupt — workers killed, exiting now. \
+                     Run `yardlet recover` to settle the interrupted run."
+                );
                 std::process::exit(130); // 128 + SIGINT, what a shell reports
             }
         })

--- a/src/state.rs
+++ b/src/state.rs
@@ -3704,7 +3704,10 @@ impl Workspace {
                         Some("needs_user") => AttemptState::NeedsUser,
                         Some("succeeded") => AttemptState::Succeeded,
                         Some("timed_out") => AttemptState::TimedOut,
-                        Some("cancelled") => AttemptState::Cancelled,
+                        // The operator stopping Yardlet cancels the attempt; it
+                        // is the same outcome as an explicit cancel, reached by
+                        // Ctrl-C rather than by a command (issue #107).
+                        Some("cancelled" | "stopped") => AttemptState::Cancelled,
                         Some("abandoned") => AttemptState::Abandoned,
                         _ => AttemptState::Failed,
                     }

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -303,6 +303,19 @@ fn run_loop(
         let observation = observer.observe(attempt);
         let met = observation.condition_met;
         observations.push(observation);
+        // Cancellation is decided BEFORE a met condition is accepted. The
+        // observed command can be the very thing that raises the signal, and an
+        // independent review reproduced it: `watch --until success -- sh -c 'kill
+        // -INT "$PPID"'` recorded `satisfied`, so the interrupt read as the run
+        // finishing on its own terms.
+        if crate::signals::stop_requested() || cancelled.load(Ordering::SeqCst) {
+            cancelled.store(true, Ordering::SeqCst);
+            return (
+                "cancelled".into(),
+                observations,
+                "cancel signal received".into(),
+            );
+        }
         if met {
             return (
                 "satisfied".into(),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use chrono::Local;
 use serde::Serialize;
 
@@ -274,6 +274,12 @@ fn run_loop(
 ) -> (String, Vec<Observation>, String) {
     let mut observations = Vec::new();
     for attempt in 1..=options.max_runs {
+        // The signal now lands on a process-wide flag (one handler per process),
+        // so carry it into the flag this loop and its observer already share.
+        // Tests set that flag directly and must keep working without a signal.
+        if crate::signals::stop_requested() {
+            cancelled.store(true, Ordering::SeqCst);
+        }
         if cancelled.load(Ordering::SeqCst) {
             return (
                 "cancelled".into(),
@@ -364,9 +370,14 @@ pub fn run(ws: &Workspace, options: WatchOptions) -> Result<(String, WatchResult
     let (run_id, run_dir) = ws.claim_run_dir(&base)?;
     let started_at = Local::now().to_rfc3339();
     let cancelled = Arc::new(AtomicBool::new(false));
-    let signal = Arc::clone(&cancelled);
-    ctrlc::set_handler(move || signal.store(true, Ordering::SeqCst))
-        .context("installing foreground watch cancel handler")?;
+    // Through the shared installer, not `ctrlc::set_handler` directly: only one
+    // handler may exist per process, and `run` needs one too now that stopping
+    // Yardlet has to take its worker with it (issue #107). A second direct
+    // registration is an error, which is how this first showed up — as a test
+    // failing because another test had already registered.
+    if !crate::signals::install_stop_handler() {
+        eprintln!("yardlet: could not install a cancel handler; Ctrl-C will not stop this watch");
+    }
     let mut observer = LocalObserver::new(
         &ws.root,
         options.until.clone(),

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -184,7 +184,10 @@ impl Observer for LocalObserver {
                             Ok(Some(status)) => {
                                 break (Some(status), "command completed".to_string())
                             }
-                            Ok(None) if self.cancelled.load(Ordering::SeqCst) => {
+                            Ok(None)
+                                if self.cancelled.load(Ordering::SeqCst)
+                                    || crate::signals::stop_requested() =>
+                            {
                                 let _ = child.kill();
                                 break (child.wait().ok(), "command cancelled".to_string());
                             }
@@ -274,9 +277,12 @@ fn run_loop(
 ) -> (String, Vec<Observation>, String) {
     let mut observations = Vec::new();
     for attempt in 1..=options.max_runs {
-        // The signal now lands on a process-wide flag (one handler per process),
-        // so carry it into the flag this loop and its observer already share.
-        // Tests set that flag directly and must keep working without a signal.
+        // The signal lands on a process-wide flag (one handler per process), so
+        // carry it into the flag this loop and its observer share. The observer
+        // ALSO reads the global directly: mirroring only here left a Ctrl-C
+        // during a long observation unnoticed until that observation finished,
+        // which an independent review caught by sending two of them mid-`sleep`.
+        // Tests set the local flag directly and must keep working without a signal.
         if crate::signals::stop_requested() {
             cancelled.store(true, Ordering::SeqCst);
         }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -727,6 +727,29 @@ fn build_resume_command(
     cmd
 }
 
+/// Has the child exited, WITHOUT reaping it?
+///
+/// `try_wait` reaps, which frees the pid — and the pid is the process group id
+/// the teardown still needs. `WNOWAIT` leaves the child waitable so the group
+/// signal that follows still has a group to reach.
+#[cfg(unix)]
+fn exited_without_reaping(child: &std::process::Child) -> bool {
+    let mut status = 0;
+    let observed = unsafe {
+        libc::waitpid(
+            child.id() as libc::pid_t,
+            &mut status,
+            libc::WNOHANG | libc::WNOWAIT,
+        )
+    };
+    observed > 0
+}
+
+#[cfg(not(unix))]
+fn exited_without_reaping(_child: &std::process::Child) -> bool {
+    false
+}
+
 /// How long a worker gets to stop on its own before Yardlet insists.
 ///
 /// Long enough for an agent CLI to flush what it was writing, short enough that
@@ -1406,16 +1429,20 @@ fn spawn_internal(
             // and stop cleanly, which a SIGKILL denies it.
             terminate_worker_tree(child.id(), Signal::Term);
             let grace = Instant::now();
-            while grace.elapsed() < STOP_GRACE {
-                if child.try_wait()?.is_some() {
-                    break;
-                }
+            while grace.elapsed() < STOP_GRACE && !exited_without_reaping(&child) {
                 thread::sleep(Duration::from_millis(50));
             }
-            if child.try_wait()?.is_none() {
-                terminate_worker_tree(child.id(), Signal::Kill);
-                let _ = child.kill();
-            }
+            // ALWAYS group-kill, even when the direct child has already gone. A
+            // launcher that handles SIGTERM exits while the agent CLI it spawned
+            // ignores it and keeps the inherited pipe ends open — the grandchild
+            // survives and the reader joins below never see EOF, so this function
+            // hangs. That is the same shape as #52, reached through the stop path.
+            //
+            // Safe here precisely because the grace loop does not reap: an
+            // unreaped child still holds its pid, so `-pid` is still this group
+            // and cannot be a recycled one.
+            terminate_worker_tree(child.id(), Signal::Kill);
+            let _ = child.kill();
             stopped = true;
             break child.wait()?;
         }
@@ -1489,6 +1516,14 @@ fn spawn_internal(
         .lock()
         .ok()
         .and_then(|captured| captured.clone());
+
+    // A worker that finished in the same instant the operator interrupted still
+    // belongs to an interrupted run: whatever comes next — integration, a commit,
+    // the next task — is what the stop was asking Yardlet not to do. The loop
+    // checks `try_wait` before the flag, so without this a fast worker (or one
+    // that exits between spawn and the first poll) wins the race and the task can
+    // land Done despite the Ctrl-C.
+    let stopped = stopped || crate::signals::stop_requested();
 
     Ok(WorkerOutcome {
         exit_ok: status.success() && !timed_out && !stopped,

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -727,10 +727,20 @@ fn build_resume_command(
     cmd
 }
 
+/// How long a worker gets to stop on its own before Yardlet insists.
+///
+/// Long enough for an agent CLI to flush what it was writing, short enough that
+/// the operator's second Ctrl-C is not the one that finally works.
+const STOP_GRACE: Duration = Duration::from_secs(3);
+
 #[derive(Debug, Clone)]
 pub struct WorkerOutcome {
     pub exit_ok: bool,
     pub timed_out: bool,
+    /// The operator stopped Yardlet, and this worker was taken down with it
+    /// rather than left holding the run directory (issue #107). Distinct from a
+    /// timeout: nothing was exceeded, the run was interrupted.
+    pub stopped: bool,
     pub note: String,
     /// Live public events can be shed under sink backpressure because exact raw
     /// streams remain authoritative and must never stop draining.
@@ -1384,9 +1394,30 @@ fn spawn_internal(
 
     let start = Instant::now();
     let mut timed_out = false;
+    let mut stopped = false;
     let status = loop {
         if let Some(status) = child.try_wait()? {
             break status;
+        }
+        if crate::signals::stop_requested() {
+            // The operator asked THIS process to stop, and the worker leads its
+            // own process group so nothing else can reach it (issue #107). Ask
+            // first, then insist: a worker given SIGTERM can close its own files
+            // and stop cleanly, which a SIGKILL denies it.
+            terminate_worker_tree(child.id(), Signal::Term);
+            let grace = Instant::now();
+            while grace.elapsed() < STOP_GRACE {
+                if child.try_wait()?.is_some() {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+            if child.try_wait()?.is_none() {
+                terminate_worker_tree(child.id(), Signal::Kill);
+                let _ = child.kill();
+            }
+            stopped = true;
+            break child.wait()?;
         }
         if start.elapsed() >= timeout {
             // Kill the GROUP, not just the direct child. A worker profile whose
@@ -1460,11 +1491,14 @@ fn spawn_internal(
         .and_then(|captured| captured.clone());
 
     Ok(WorkerOutcome {
-        exit_ok: status.success() && !timed_out,
+        exit_ok: status.success() && !timed_out && !stopped,
         timed_out,
+        stopped,
         session_id,
         public_events_dropped: public_events_dropped.load(std::sync::atomic::Ordering::Relaxed),
-        note: if timed_out {
+        note: if stopped {
+            "worker stopped with Yardlet at the operator's request".to_string()
+        } else if timed_out {
             "worker exceeded wall-clock limit and was stopped".to_string()
         } else {
             format!("worker exited (success={})", status.success())

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -734,15 +734,28 @@ fn build_resume_command(
 /// signal that follows still has a group to reach.
 #[cfg(unix)]
 fn exited_without_reaping(child: &std::process::Child) -> bool {
-    let mut status = 0;
-    let observed = unsafe {
-        libc::waitpid(
-            child.id() as libc::pid_t,
-            &mut status,
-            libc::WNOHANG | libc::WNOWAIT,
+    // `waitid`, not `waitpid`: WNOWAIT is a `waitid` option, and `waitpid`
+    // rejects it with EINVAL on both macOS and Linux. An independent review
+    // caught that — the first cut used `waitpid` and so reported "not exited"
+    // for every child, which silently turned the grace window into a fixed
+    // three-second wait.
+    //
+    // `waitid` returns 0 whether or not a child was found, so the answer is in
+    // `si_pid`: it stays 0 when nothing has exited yet.
+    let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+    let rc = unsafe {
+        libc::waitid(
+            libc::P_PID,
+            child.id() as libc::id_t,
+            &mut info,
+            libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
         )
     };
-    observed > 0
+    if rc != 0 {
+        return false;
+    }
+    // SAFETY: `si_pid` is populated by the kernel for a WEXITED report.
+    unsafe { info.si_pid() != 0 }
 }
 
 #[cfg(not(unix))]
@@ -1173,6 +1186,10 @@ fn spawn_internal(
     let mut child = cmd
         .spawn()
         .with_context(|| format!("spawning worker '{}'", bin.display()))?;
+    // Tracked so an emergency exit can still take it down: `process::exit` runs
+    // no destructors, and a worker leads its own group, so nothing else could.
+    crate::signals::track_worker(child.id());
+    let tracked_pid = child.id();
 
     let provenance_result = (|| -> Result<()> {
         let Some((run_id, attempt_id)) = provenance_identity.as_ref() else {
@@ -1516,6 +1533,8 @@ fn spawn_internal(
         .lock()
         .ok()
         .and_then(|captured| captured.clone());
+
+    crate::signals::untrack_worker(tracked_pid);
 
     // A worker that finished in the same instant the operator interrupted still
     // belongs to an interrupted run: whatever comes next — integration, a commit,

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1262,14 +1262,30 @@ fn spawn_internal(
     // can tail the worker live. Worker CLIs often route progress to stderr or
     // block-buffer stdout on a pipe, so capturing stderr live (not only after
     // exit) is what keeps the monitor non-empty during a run.
-    let combined = if attempt_capture.is_some() {
-        if let Some(parent) = output_log.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating {}", parent.display()))?;
+    // Failing here must not leave the worker running. These `?`s returned with a
+    // live child that nothing else could reach — an independent review made
+    // `worker-output.log` a directory and watched Yardlet exit 1 while its worker
+    // kept going, which is the orphan #107 is about arriving through an error
+    // path instead of a signal.
+    let open_log = || -> Result<Option<std::fs::File>> {
+        if attempt_capture.is_some() {
+            if let Some(parent) = output_log.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating {}", parent.display()))?;
+            }
+            Ok(Some(crate::state::append_private_file(output_log)?))
+        } else {
+            Ok(std::fs::File::create(output_log).ok())
         }
-        Some(crate::state::append_private_file(output_log)?)
-    } else {
-        std::fs::File::create(output_log).ok()
+    };
+    let combined = match open_log() {
+        Ok(combined) => combined,
+        Err(error) => {
+            terminate_worker_tree(child.id(), Signal::Kill);
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
     };
     let log_file = std::sync::Arc::new(std::sync::Mutex::new(combined));
     let captured_session = std::sync::Arc::new(std::sync::Mutex::new(None));

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1188,8 +1188,9 @@ fn spawn_internal(
         .with_context(|| format!("spawning worker '{}'", bin.display()))?;
     // Tracked so an emergency exit can still take it down: `process::exit` runs
     // no destructors, and a worker leads its own group, so nothing else could.
-    crate::signals::track_worker(child.id());
-    let tracked_pid = child.id();
+    // RAII, so every return path below untracks — including the error ones that
+    // a hand-placed call missed.
+    let _tracked = crate::signals::TrackedWorker::new(child.id());
 
     let provenance_result = (|| -> Result<()> {
         let Some((run_id, attempt_id)) = provenance_identity.as_ref() else {
@@ -1533,8 +1534,6 @@ fn spawn_internal(
         .lock()
         .ok()
         .and_then(|captured| captured.clone());
-
-    crate::signals::untrack_worker(tracked_pid);
 
     // A worker that finished in the same instant the operator interrupted still
     // belongs to an interrupted run: whatever comes next — integration, a commit,

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -181,10 +181,156 @@ fn stopping_yardlet_takes_the_worker_it_started_with_it() {
     );
     yardlet.shutdown(Duration::from_secs(15), || {});
 
-    // The stop must not be recorded as the task finishing.
+    // The stop must not be recorded as the task finishing — and "not done" is too
+    // weak on its own, because a stopped run that fell through to failover lands
+    // Failed, which also is not done and which `run --auto` then RETRIES. An
+    // independent review caught exactly that. The task has to be back where it
+    // can be picked up deliberately, not driven onward.
     let queue = fs::read_to_string(root.join(".agents/work-queue.yaml")).unwrap_or_default();
     assert!(
         !queue.contains("state: done"),
         "an interrupted run reported its task as done:\n{queue}"
+    );
+    assert!(
+        !queue.contains("state: failed"),
+        "an interrupted run was recorded as a failure, which `run --auto` treats \
+         as transient and retries — the stop would start another worker:\n{queue}"
+    );
+
+    // And nothing may have been started in its place.
+    let runs = fs::read_dir(root.join(".agents/runs"))
+        .map(|entries| entries.filter_map(Result::ok).count())
+        .unwrap_or(0);
+    assert_eq!(
+        runs, 1,
+        "a stop must not fail over to a replacement worker; {runs} runs exist"
+    );
+}
+
+/// The stop path has to reach the whole tree, not just the process Yardlet
+/// spawned. A launcher that handles SIGTERM exits while the agent CLI it started
+/// ignores it and keeps the inherited pipes open: the grandchild survives, and
+/// Yardlet blocks forever waiting for an EOF that cannot come. Same shape as #52,
+/// reached through the stop path.
+#[test]
+fn stopping_reaches_a_grandchild_whose_launcher_exits_first() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let workspace = common::WorkspaceGuard::create(std::env::temp_dir().join(format!(
+        "yardlet-run-stop-tree-{}-{nonce}",
+        std::process::id()
+    )));
+    let root = workspace.path().to_path_buf();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    // The launcher dies on SIGTERM; the grandchild ignores it and holds the pipes.
+    let worker = root.join("fixture-launcher.sh");
+    let ids = root.join("grandchild-pid");
+    fs::write(
+        &worker,
+        format!(
+            "#!/bin/sh\n\
+             set -eu\n\
+             if [ \"${{1:-}}\" = \"--version\" ]; then\n\
+             \x20 printf 'fixture-launcher 1.0\\n'\n\
+             \x20 exit 0\n\
+             fi\n\
+             cat >/dev/null\n\
+             sh -c 'trap \"\" TERM; printf \"%s\\n\" \"$$\" >\"{}\"; while :; do sleep 1; done' &\n\
+             wait\n",
+            ids.display()
+        ),
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&worker).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&worker, permissions).unwrap();
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-tree\nsummary: stop tree fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-tree\nintent_id: intent-tree\ntasks:\n  - id: YARD-001\n    title: stop tree fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [stopping reaches the whole tree]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            worker.display()
+        ),
+    )
+    .unwrap();
+
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            fs::File::create(root.join("yardlet.err")).unwrap(),
+        ))
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let yardlet_pid = yardlet.id() as i32;
+    let mut yardlet = common::ChildGuard::new(yardlet);
+
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "the grandchild never started; yardlet said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+    let grandchild: i32 = fs::read_to_string(&ids)
+        .unwrap()
+        .trim()
+        .parse()
+        .expect("numeric grandchild pid");
+
+    assert_eq!(
+        unsafe { libc::kill(yardlet_pid, libc::SIGINT) },
+        0,
+        "could not signal Yardlet"
+    );
+
+    assert!(
+        wait_until_gone(grandchild, Duration::from_secs(30)),
+        "the grandchild ignored SIGTERM and was never escalated to, so it still \
+         holds Yardlet's pipes"
+    );
+    // `kill(pid, 0)` is NOT the check: Yardlet is this test's child, so once it
+    // exits it stays a reapable zombie and a liveness probe keeps succeeding.
+    // `try_wait` distinguishes "still running" from "exited". (Third time this
+    // trap was walked into on this branch — it is why the guard tests assert on
+    // status rather than liveness.)
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut exited = false;
+    while Instant::now() < deadline {
+        if matches!(yardlet.as_mut().try_wait(), Ok(Some(_))) {
+            exited = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        exited,
+        "Yardlet is still waiting on a stream its grandchild never closed; it said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
     );
 }

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -378,6 +378,7 @@ fn a_result_written_before_the_interrupt_does_not_finish_the_task() {
          ids=\"$2\"\n\
          cat >/dev/null\n\
          run_id=\"$(basename \"$run_dir\")\"\n\
+         printf 'fixture handoff\\n' >\"$run_dir/handoff.md\"\n\
          printf '{\"schema_version\":1,\"run_id\":\"%s\",\"task_id\":\"YARD-001\",\"status\":\"done\",\"compact_summary\":\"fixture finished early\"}' \"$run_id\" >\"$run_dir/result.json\"\n\
          printf '%s\\n' \"$$\" >\"$ids\"\n\
          sleep 300\n",

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -377,7 +377,8 @@ fn a_result_written_before_the_interrupt_does_not_finish_the_task() {
          run_dir=\"$1\"\n\
          ids=\"$2\"\n\
          cat >/dev/null\n\
-         printf '{\"status\":\"done\",\"summary\":\"fixture finished early\"}' >\"$run_dir/result.json\"\n\
+         run_id=\"$(basename \"$run_dir\")\"\n\
+         printf '{\"schema_version\":1,\"run_id\":\"%s\",\"task_id\":\"YARD-001\",\"status\":\"done\",\"compact_summary\":\"fixture finished early\"}' \"$run_id\" >\"$run_dir/result.json\"\n\
          printf '%s\\n' \"$$\" >\"$ids\"\n\
          sleep 300\n",
     )

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -334,3 +334,127 @@ fn stopping_reaches_a_grandchild_whose_launcher_exits_first() {
         fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
     );
 }
+
+/// A worker that already wrote a valid result, then kept working, must not have
+/// that result finalized as a completed task when the operator interrupts. An
+/// independent review reproduced exactly this: the attempt was recorded stopped
+/// while the queue landed `done`, so the Ctrl-C looked like it finished the work.
+#[test]
+fn a_result_written_before_the_interrupt_does_not_finish_the_task() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let workspace = common::WorkspaceGuard::create(std::env::temp_dir().join(format!(
+        "yardlet-run-stop-result-{}-{nonce}",
+        std::process::id()
+    )));
+    let root = workspace.path().to_path_buf();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    // Writes a complete, valid result FIRST, announces itself, then keeps going.
+    let worker = root.join("fixture-early-result.sh");
+    let ids = root.join("worker-pid");
+    fs::write(
+        &worker,
+        "#!/bin/sh\n\
+         set -eu\n\
+         if [ \"${1:-}\" = \"--version\" ]; then\n\
+         \x20 printf 'fixture-early 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         ids=\"$2\"\n\
+         cat >/dev/null\n\
+         printf '{\"status\":\"done\",\"summary\":\"fixture finished early\"}' >\"$run_dir/result.json\"\n\
+         printf '%s\\n' \"$$\" >\"$ids\"\n\
+         sleep 300\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&worker).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&worker, permissions).unwrap();
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-early\nsummary: early result fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-early\nintent_id: intent-early\ntasks:\n  - id: YARD-001\n    title: early result fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [an interrupted run is not a finished one]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            worker.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            fs::File::create(root.join("yardlet.err")).unwrap(),
+        ))
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let yardlet_pid = yardlet.id() as i32;
+    let mut yardlet = common::ChildGuard::new(yardlet);
+
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "the fixture worker never started; yardlet said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+    assert!(
+        root.join(".agents/runs").exists(),
+        "no run directory was created"
+    );
+
+    assert_eq!(
+        unsafe { libc::kill(yardlet_pid, libc::SIGINT) },
+        0,
+        "could not signal Yardlet"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(40);
+    let mut exited = false;
+    while Instant::now() < deadline {
+        if matches!(yardlet.as_mut().try_wait(), Ok(Some(_))) {
+            exited = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        exited,
+        "Yardlet never finished after the interrupt; it said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+
+    let queue = fs::read_to_string(root.join(".agents/work-queue.yaml")).unwrap_or_default();
+    assert!(
+        !queue.contains("state: done"),
+        "a result written before the interrupt was finalized as a finished task, \
+         so the Ctrl-C looks like it completed the work:\n{queue}"
+    );
+}

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -1,0 +1,190 @@
+//! Stopping `yardlet run` must take its worker with it (issue #107).
+//!
+//! The counterpart to #52, not a reversal of it. A worker leads its own process
+//! group so it survives the TERMINAL closing — an operator quitting the host app
+//! mid-review should not lose the reasoning pass. But that same isolation means
+//! no signal the operator sends can reach the worker: not the shell's, which
+//! goes to its own foreground group, and not a test harness's, which has no
+//! handle on a group it did not create.
+//!
+//! Yardlet holds the only handle. Before this, it never used it on the stop
+//! path: `terminate_worker_tree` existed and nothing called it when the
+//! orchestrator was asked to stop, so interrupting a run killed the parent and
+//! left the worker holding the run directory. That is the most likely source of
+//! the four `yardlet` processes found alive 26 hours later in #64.
+//!
+//! Here Yardlet is signalled DIRECTLY — not its group — so nothing but Yardlet's
+//! own teardown can explain the worker's death.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+mod common;
+
+fn alive(pid: i32) -> bool {
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+fn must_succeed(cwd: &Path, program: &Path, args: &[&str]) {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("running {program:?} {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "{program:?} {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// A worker that reports its pid and then outlives any reasonable test, so its
+/// death can only be something else killing it.
+fn write_worker(path: &Path) {
+    fs::write(
+        path,
+        "#!/bin/sh\n\
+         set -eu\n\
+         if [ \"${1:-}\" = \"--version\" ]; then\n\
+         \x20 printf 'fixture-worker 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         ids=\"$2\"\n\
+         cat >/dev/null\n\
+         printf '%s\\n' \"$$\" >\"$ids\"\n\
+         sleep 300\n\
+         printf '{}' >\"$run_dir/result.json\"\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn wait_for(path: &Path, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    path.exists()
+}
+
+fn wait_until_gone(pid: i32, within: Duration) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if !alive(pid) {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    !alive(pid)
+}
+
+#[test]
+fn stopping_yardlet_takes_the_worker_it_started_with_it() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let workspace = common::WorkspaceGuard::create(
+        std::env::temp_dir().join(format!("yardlet-run-stop-{}-{nonce}", std::process::id())),
+    );
+    let root = workspace.path().to_path_buf();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    let worker = root.join("fixture-worker.sh");
+    write_worker(&worker);
+    let ids = root.join("worker-pid");
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-stop\nsummary: run stop fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-stop\nintent_id: intent-stop\ntasks:\n  - id: YARD-001\n    title: run stop fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [stopping yardlet stops the worker]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            worker.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    // Its own group, so the signal below can target Yardlet alone and cannot
+    // reach the worker by accident — the worker's death has to come from
+    // Yardlet's teardown or not at all.
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            fs::File::create(root.join("yardlet.err")).unwrap(),
+        ))
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let yardlet_pid = yardlet.id() as i32;
+    let mut yardlet = common::ChildGuard::new(yardlet);
+
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "the fixture worker never started; yardlet said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+    let worker_pid: i32 = fs::read_to_string(&ids)
+        .unwrap()
+        .trim()
+        .parse()
+        .expect("numeric worker pid");
+    assert!(alive(worker_pid), "the fixture worker never started");
+
+    // Exactly what Ctrl-C delivers, to Yardlet only.
+    assert_eq!(
+        unsafe { libc::kill(yardlet_pid, libc::SIGINT) },
+        0,
+        "could not signal Yardlet"
+    );
+
+    assert!(
+        wait_until_gone(worker_pid, Duration::from_secs(30)),
+        "the worker outlived the Yardlet that started it: nothing else can reach \
+         it, because it leads its own process group by design (#52), so it would \
+         have run to its own completion holding the run directory"
+    );
+    yardlet.shutdown(Duration::from_secs(15), || {});
+
+    // The stop must not be recorded as the task finishing.
+    let queue = fs::read_to_string(root.join(".agents/work-queue.yaml")).unwrap_or_default();
+    assert!(
+        !queue.contains("state: done"),
+        "an interrupted run reported its task as done:\n{queue}"
+    );
+}


### PR DESCRIPTION
Closes #107. The remaining half is split into #110 — see "What does not ship" below.

## The gap

A worker leads its own process group on purpose (#52), so it survives the terminal closing. The cost was never paid for: the same isolation means **no signal the operator sends can reach the worker**. Not the shell's, which goes to its own foreground group. Not a test harness's, which has no handle on a group it did not create.

Yardlet holds the only handle, and on the stop path it never used it. `terminate_worker_tree` existed and was correct; nothing called it when the orchestrator itself was asked to stop. So a Ctrl-C on `yardlet run` killed the parent and left the worker running, holding the run directory.

This is the most likely source of the leak in #64: four `yardlet` processes found alive 26 hours after a day of PTY work.

## What ships

- **An interrupted run takes its worker down**, and the worker's whole tree with it. SIGTERM first, three seconds of grace so an agent CLI can flush what it buffered, then SIGKILL to the group.
- **A second interrupt works.** Replacing the default disposition without escalating leaves the operator unable to force-quit at all. The second one kills the tracked workers and exits 130.
- **Every worker-launching path is covered.** Installation is at `run_next`/`run_auto`, not at one caller — `yardlet goal` reaches `run_auto` directly and was missed by the first cut.
- **`watch` cancellation is not beaten by completion.** The observed command can be what raises the signal; `watch --until success -- sh -c 'kill -INT "$PPID"'` recorded `satisfied` and now records `cancelled`.
- **Error paths do not leak a live worker.** Opening the output log returned through `?` with the worker running and no longer tracked.

## What does NOT ship, and why

Making an interrupted run **un-finishable in every path**. Serial failover, parallel, and `recover` after a failed queue save can still record Done. Two fixes were tried and withdrawn, each proven wrong by review:

- keying on the `cancelled` marker — `yardlet redirect` writes that same marker for a different reason, and reading it as "interrupted" broke a redirect test under load;
- guarding finalization on the process stop flag — it never resets, so in the long-lived TUI every run after one interrupt was stopped on arrival, and a review task whose evidence all passed was reported as a review failure.

That needs a durable per-run decision rather than a process flag. Filed as #110 with the reproductions, rather than half-built here.

## Verification

Three opposing contracts hold simultaneously — worth checking twice, because they pull against each other:

| contract | test |
|---|---|
| worker survives the terminal (#52) | `worker_survives_terminal_hangup_process` |
| teardown reaches grandchildren (#94) | `worker_teardown_kills_grandchildren_process` |
| stop takes the worker with it (#107) | `run_stop_takes_worker_with_it_process` |

683 unit tests and all 26 targets green; fmt and clippy clean.

## Review history

Four independent review rounds, every one of which found real defects — including two regressions introduced by earlier rounds of this same branch, and one factual error in a commit message (`WNOWAIT` passed to `waitpid`, which rejects it, so a grace window silently became a fixed wait). The regression test was vacuous for two rounds before it pinned anything. That history is in the commits rather than smoothed over.