### PR TITLE
perf(build): drop full debug info from test artifacts, and correct what #105 blamed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,17 @@ unicode-width = "0.2"
 ctrlc = "3"
 libc = "0.2"
 
+[profile.test]
+# Line tables keep backtraces and panic locations readable while dropping the
+# full type/variable debug info. That info is what made the test artifacts
+# dominate the build cache: every one of the integration test binaries carries
+# its own complete copy (issue #105).
+debug = "line-tables-only"
+
+[profile.dev]
+# Same reasoning for the binary the process tests spawn.
+debug = "line-tables-only"
+
 [profile.release]
 strip = true
 lto = true


### PR DESCRIPTION
Partially addresses #105 — and corrects the premise I filed it on.

## The measurement came out against my own hypothesis

I filed #105 blaming 24 separate integration-test binaries for a disproportionate build cache. Measured:

- **All 25 test binaries together: 94 MB.** 56 MB of that is two copies of `yardlet` itself. The individual test binaries are 2-3 MB each — about 38 MB, out of a **1029 MB** target directory.
- Consolidating them would reclaim roughly **3%**. The cache is dominated by dependency artifacts, not by how the tests are split up.
- A clean `cargo build --tests` is about **twenty seconds**, so build time was not the problem either.

## What this PR changes

`[profile.test]` and `[profile.dev]` set `debug = "line-tables-only"`:

| | target/ | deps/ | clean build |
|---|---|---|---|
| before | 1029 MB | 556 MB | 22s |
| after | 889 MB | 421 MB | 19s |

**140 MB, and nothing a failing test needs is lost.** Panic messages still carry file and line — forced one to confirm: `panicked at src/signals.rs:130:9` — and backtraces still resolve. What is dropped is full type and variable info, which serves a debugger, and that is not how this suite is read.

## What the operator actually pays for

Test **execution**. From a full run, 283 seconds of wall clock across 26 targets:

| target | time | share |
|---|---|---|
| `v010_001a_serial_git_finish_process` | 82.0s | 29% |
| unit tests | 35.0s | |
| `v010_004_resource_publication` | 34.0s | |
| `v010_003_task_channels_process` | 26.6s | |

One target is 29% of the run; the top four are 63%. These are the process fixtures that spawn real binaries and wait on real timing — which is why they catch what unit tests cannot (#52, #64, #83, #91 and #107 were all found or proven at that layer), and also why they saturate the machine.

So #105's remaining direction is tiering those slow tests, not consolidating targets. The numbers are on the issue so it can be re-scoped to what the measurement supports.

## Verification

All 26 targets green, `cargo clippy --all-targets --all-features -- -D warnings` clean. No test source changed — this is one config block.