### PR TITLE
fix(runtime): give the worker the write scope its task contract already granted

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -318,6 +318,7 @@ pub fn scout(ws: &Workspace) -> Result<ScoutCommandReport> {
                         &[],
                         None,
                         false,
+                        &[],
                     )?;
                     let result_path = report_dir.join("scout-result.json");
                     let raw = std::fs::read_to_string(&result_path).with_context(|| {
@@ -525,6 +526,7 @@ fn draft(
         &[],
         None,
         false,
+        &[],
     )?;
 
     let result_path = run_dir.join("memory-result.json");

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -752,6 +752,10 @@ pub fn run_batch<F: FnMut(&str)>(
         let timeout = Duration::from_secs(p.profile.limits.max_wall_minutes as u64 * 60);
         let images = images.clone();
         let session = p.session.clone();
+        // Computed before the thread: the sandbox roots come from the task's
+        // confirmed contract and the workspace, neither of which may be borrowed
+        // across the spawn (issue #19).
+        let writable_roots = run::sandbox_writable_roots(&p.task, &ws.root);
         handles.push(std::thread::spawn(move || {
             let started = std::time::Instant::now();
             let outcome = workers::spawn_resolved_attempt(
@@ -768,6 +772,7 @@ pub fn run_batch<F: FnMut(&str)>(
                 &images,
                 session.as_deref(),
                 false,
+                &writable_roots,
             );
             let _ = tx.send(Finished {
                 prep_idx: i,
@@ -917,6 +922,7 @@ pub fn run_batch<F: FnMut(&str)>(
                             &images,
                             session.as_deref(),
                             false,
+                            &run::sandbox_writable_roots(&p.task, &ws.root),
                         ) {
                             Ok(completed) => completed,
                             Err(error) => {

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -619,6 +619,7 @@ fn invoke_planning_scout(
         &[],
         None,
         false,
+        &[],
     );
 
     let active_after = active_snapshot_digest(ws)?;
@@ -1449,6 +1450,7 @@ fn plan_core(
         images,
         None,
         false,
+        &[],
     )?;
     lines.push(format!("worker outcome: {}", outcome.note));
 
@@ -1657,6 +1659,7 @@ pub fn run_planning_amend(ws: &Workspace, request: &str) -> Result<PlanningRepor
         &images,
         None,
         false,
+        &[],
     )?;
     lines.push(format!("worker outcome: {}", outcome.note));
     let result_path = run_dir.join("planning-result.json");

--- a/src/run.rs
+++ b/src/run.rs
@@ -2850,6 +2850,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         &images,
         session_id.as_deref(),
         effective_chained,
+        &sandbox_writable_roots(&task, &ws.root),
     ) {
         Ok(outcome) => outcome,
         Err(error) => {
@@ -2958,6 +2959,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             &images,
             session_id.as_deref(),
             true,
+            &sandbox_writable_roots(&task, &ws.root),
         ) {
             Ok(outcome) => outcome,
             Err(error) => {
@@ -3115,6 +3117,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
             &images,
             session_id.as_deref(),
             false,
+            &sandbox_writable_roots(&task, &ws.root),
         ) {
             Ok(outcome) => outcome,
             Err(error) => {
@@ -3245,6 +3248,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                     &images,
                     session_id.as_deref(),
                     false,
+                    &sandbox_writable_roots(&task, &ws.root),
                 ) {
                     Ok(outcome) => outcome,
                     Err(error) => {
@@ -3744,6 +3748,58 @@ fn no_change_contradiction(
         return Some(("no_change_contradicts_declared_outputs", declared));
     }
     None
+}
+
+/// Workspace directories the task's confirmed contract says it may write, which
+/// the sandbox would otherwise refuse.
+///
+/// A worker runs under `workspace-write`, and that sandbox treats the hidden
+/// `.agents/` tree as read-only. So a task whose `allowed_scope` grants it a
+/// skill package could not write there: the worker reported `needs_user` and
+/// asked the operator to authorize what the confirmed contract had already
+/// granted (issue #19).
+///
+/// Only `.agents/` entries are lifted. Everything else in a scope is ordinary
+/// workspace content the sandbox already allows, and widening beyond what the
+/// sandbox actually blocks would hand out permission nobody needed.
+///
+/// A glob is truncated to the directory that contains it, because `--add-dir`
+/// takes roots rather than patterns. That is wider than the declared scope for
+/// something like `.agents/skills/x/**` excluding `archive/v1/**` — the sandbox
+/// cannot express that split. The narrower contract is still enforced, by the
+/// evaluator's forbidden-path check after the fact, which is the same
+/// belt-and-braces shape the danger-list already uses: the sandbox bounds what
+/// is reachable, the evaluator judges what was touched.
+pub(crate) fn sandbox_writable_roots(
+    task: &crate::schemas::Task,
+    ws_root: &std::path::Path,
+) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = task
+        .allowed_scope
+        .iter()
+        .filter_map(|entry| {
+            let entry = entry.trim().trim_start_matches("./");
+            if !entry.starts_with(".agents/") {
+                return None;
+            }
+            let directory = entry
+                .split('*')
+                .next()
+                .unwrap_or(entry)
+                .trim_end_matches('/');
+            // A file entry contributes the directory holding it.
+            let directory = if directory.ends_with(".md") || directory.ends_with(".yaml") {
+                std::path::Path::new(directory).parent()?.to_str()?
+            } else {
+                directory
+            };
+            (!directory.is_empty() && directory != ".agents").then(|| ws_root.join(directory))
+        })
+        .filter(|path| path.exists())
+        .collect();
+    roots.sort();
+    roots.dedup();
+    roots
 }
 
 /// Declared outputs that exist on disk but did NOT reach the integration commit.
@@ -12740,6 +12796,63 @@ printf "# worker handoff
 
         let _ = std::fs::remove_dir_all(&source);
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// Issue #19: a task whose confirmed contract grants it a skill package
+    /// could not write there, because `workspace-write` treats the hidden
+    /// `.agents/` tree as read-only. The worker reported `needs_user` and asked
+    /// the operator to authorize what had already been authorized.
+    #[test]
+    fn sandbox_roots_lift_only_the_agents_scope_the_sandbox_would_refuse() {
+        fn scoped_task(scope: &[&str]) -> crate::schemas::Task {
+            let entries = scope
+                .iter()
+                .map(|s| format!("  - \"{s}\""))
+                .collect::<Vec<_>>()
+                .join("\n");
+            serde_yaml_ng::from_str(&format!(
+                "id: YARD-001\ntitle: t\nstate: queued\npriority: 10\nallowed_scope:\n{entries}\n"
+            ))
+            .expect("task fixture")
+        }
+
+        let root = std::env::temp_dir().join(format!(
+            "yard-sandbox-roots-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let package = root.join(".agents/skills/route-game-development");
+        std::fs::create_dir_all(package.join("fixtures")).unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+
+        // The package the contract granted (glob), ordinary workspace content
+        // the sandbox already allows, and a declared path that does not exist.
+        let task = scoped_task(&[
+            ".agents/skills/route-game-development/**",
+            "src/**",
+            ".agents/skills/never-created/**",
+        ]);
+
+        assert_eq!(
+            sandbox_writable_roots(&task, &root),
+            vec![package.clone()],
+            "only the `.agents/` scope that exists may be lifted"
+        );
+
+        // A file entry contributes the directory that holds it — `--add-dir`
+        // takes roots, not files.
+        let task = scoped_task(&[".agents/skills/route-game-development/SKILL.md"]);
+        assert_eq!(sandbox_writable_roots(&task, &root), vec![package]);
+
+        // `.agents` itself is never a root: that would hand the worker the whole
+        // canonical state, which is what the sandbox is protecting.
+        let task = scoped_task(&[".agents/**"]);
+        assert!(sandbox_writable_roots(&task, &root).is_empty());
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Issue #91: SOME of the declared output reaching the commit is not the

--- a/src/skill_author.rs
+++ b/src/skill_author.rs
@@ -90,6 +90,7 @@ fn draft(
         &[],
         None,
         false,
+        &[],
     )?;
 
     let result_path = run_dir.join("skill-result.json");

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -552,6 +552,7 @@ pub fn build_command(
     model: &str,
     effort: &str,
     images: &[String],
+    writable_roots: &[PathBuf],
 ) -> Command {
     let mut cmd = Command::new(bin);
     // The worker must be able to write its artifacts into the run directory.
@@ -586,6 +587,14 @@ pub fn build_command(
                 cmd.arg("-i").arg(img);
             }
             cmd.arg("--add-dir").arg(run_dir);
+            // The task's own declared writable scope. Codex's workspace-write
+            // sandbox treats the hidden `.agents/` tree as read-only, so a task
+            // whose confirmed contract grants it a skill package could not write
+            // there and asked the operator to re-authorize work already approved
+            // (issue #19).
+            for root in writable_roots {
+                cmd.arg("--add-dir").arg(root);
+            }
         }
         "claude-code" => {
             if full_access {
@@ -604,6 +613,9 @@ pub fn build_command(
                 cmd.arg("--effort").arg(effort);
             }
             cmd.arg("--add-dir").arg(run_dir);
+            for root in writable_roots {
+                cmd.arg("--add-dir").arg(root);
+            }
         }
         _ => {}
     }
@@ -851,6 +863,7 @@ pub fn spawn(
     images: &[String],
     session: Option<&str>,
     resume: bool,
+    writable_roots: &[PathBuf],
 ) -> Result<WorkerOutcome> {
     spawn_internal(
         profile,
@@ -868,6 +881,7 @@ pub fn spawn(
         images,
         session,
         resume,
+        writable_roots,
     )
 }
 
@@ -886,6 +900,7 @@ pub fn spawn_attempt(
     images: &[String],
     session: Option<&str>,
     resume: bool,
+    writable_roots: &[PathBuf],
 ) -> Result<WorkerOutcome> {
     spawn_attempt_with_sink(
         profile,
@@ -901,6 +916,7 @@ pub fn spawn_attempt(
         images,
         session,
         resume,
+        writable_roots,
     )
 }
 
@@ -920,6 +936,7 @@ pub fn spawn_attempt_with_sink(
     images: &[String],
     session: Option<&str>,
     resume: bool,
+    writable_roots: &[PathBuf],
 ) -> Result<WorkerOutcome> {
     spawn_internal(
         profile,
@@ -937,6 +954,7 @@ pub fn spawn_attempt_with_sink(
         images,
         session,
         resume,
+        writable_roots,
     )
 }
 
@@ -955,6 +973,7 @@ pub fn spawn_resolved_attempt(
     images: &[String],
     session: Option<&str>,
     resume: bool,
+    writable_roots: &[PathBuf],
 ) -> Result<WorkerOutcome> {
     spawn_resolved_attempt_with_sink(
         profile,
@@ -971,6 +990,7 @@ pub fn spawn_resolved_attempt(
         images,
         session,
         resume,
+        writable_roots,
     )
 }
 
@@ -990,6 +1010,7 @@ pub fn spawn_resolved_attempt_with_sink(
     images: &[String],
     session: Option<&str>,
     resume: bool,
+    writable_roots: &[PathBuf],
 ) -> Result<WorkerOutcome> {
     spawn_internal(
         profile,
@@ -1007,6 +1028,7 @@ pub fn spawn_resolved_attempt_with_sink(
         images,
         session,
         resume,
+        writable_roots,
     )
 }
 
@@ -1027,6 +1049,7 @@ fn spawn_internal(
     images: &[String],
     session: Option<&str>,
     resume: bool,
+    writable_roots: &[PathBuf],
 ) -> Result<WorkerOutcome> {
     use std::io::{Read, Write};
 
@@ -1057,6 +1080,7 @@ fn spawn_internal(
                 &profile.model,
                 &profile.effort,
                 images,
+                writable_roots,
             ),
             // Anything else: the profile's own invocation template.
             _ => build_generic_command(
@@ -2071,10 +2095,30 @@ image_args: ["-i", "{image}"]
     #[test]
     fn codex_sandbox_toggles_with_full_access() {
         let (bin, run, cwd) = (Path::new("codex"), Path::new("/tmp/r"), Path::new("/tmp"));
-        let safe = args_of(&build_command("codex", bin, run, cwd, false, "", "", &[]));
+        let safe = args_of(&build_command(
+            "codex",
+            bin,
+            run,
+            cwd,
+            false,
+            "",
+            "",
+            &[],
+            &[],
+        ));
         assert!(safe.iter().any(|a| a == "workspace-write"));
         assert!(!safe.iter().any(|a| a == "danger-full-access"));
-        let full = args_of(&build_command("codex", bin, run, cwd, true, "", "", &[]));
+        let full = args_of(&build_command(
+            "codex",
+            bin,
+            run,
+            cwd,
+            true,
+            "",
+            "",
+            &[],
+            &[],
+        ));
         assert!(full.iter().any(|a| a == "danger-full-access"));
     }
 
@@ -2085,7 +2129,7 @@ image_args: ["-i", "{image}"]
             Path::new("/tmp/run"),
             Path::new("/tmp/declared-worktree"),
         );
-        let fresh = build_command("codex", bin, run, cwd, true, "", "", &[]);
+        let fresh = build_command("codex", bin, run, cwd, true, "", "", &[], &[]);
         let fresh_args = args_of(&fresh);
         assert_eq!(fresh.get_current_dir(), Some(cwd));
         assert!(fresh_args.windows(2).any(|args| {
@@ -2121,6 +2165,7 @@ image_args: ["-i", "{image}"]
             "",
             "",
             &[],
+            &[],
         ));
         assert!(safe.iter().any(|a| a == "acceptEdits"));
         let full = args_of(&build_command(
@@ -2131,6 +2176,7 @@ image_args: ["-i", "{image}"]
             true,
             "",
             "",
+            &[],
             &[],
         ));
         assert!(full.iter().any(|a| a == "--dangerously-skip-permissions"));
@@ -2148,6 +2194,7 @@ image_args: ["-i", "{image}"]
             "gpt-5",
             "high",
             &[],
+            &[],
         ));
         assert!(cx.windows(2).any(|w| w[0] == "-m" && w[1] == "gpt-5"));
         assert!(cx
@@ -2162,16 +2209,80 @@ image_args: ["-i", "{image}"]
             "opus",
             "high",
             &[],
+            &[],
         ));
         assert!(cl.windows(2).any(|w| w[0] == "--model" && w[1] == "opus"));
         assert!(cl.windows(2).any(|w| w[0] == "--effort" && w[1] == "high"));
+    }
+
+    /// The helper deciding the roots is only half of it: the command has to
+    /// carry them, for both built-in adapters (issue #19).
+    #[test]
+    fn declared_writable_roots_reach_the_sandbox_arguments() {
+        let bin = Path::new("/bin/true");
+        let run = Path::new("/ws/.agents/runs/run-1");
+        let cwd = Path::new("/ws");
+        let package = PathBuf::from("/ws/.agents/skills/route-game-development");
+
+        for worker in ["codex", "claude-code"] {
+            let with = args_of(&build_command(
+                worker,
+                bin,
+                run,
+                cwd,
+                false,
+                "",
+                "",
+                &[],
+                std::slice::from_ref(&package),
+            ));
+            assert!(
+                with.windows(2)
+                    .any(|pair| pair[0] == "--add-dir" && pair[1] == package.to_string_lossy()),
+                "{worker} did not receive the task's declared writable root: {with:?}"
+            );
+            // The run directory stays writable regardless — that is what the
+            // worker writes its own artifacts into.
+            assert!(
+                with.windows(2)
+                    .any(|pair| pair[0] == "--add-dir" && pair[1] == run.to_string_lossy()),
+                "{worker} lost the run directory root: {with:?}"
+            );
+
+            let without = args_of(&build_command(
+                worker,
+                bin,
+                run,
+                cwd,
+                false,
+                "",
+                "",
+                &[],
+                &[],
+            ));
+            assert_eq!(
+                without.iter().filter(|a| *a == "--add-dir").count(),
+                1,
+                "{worker} added a root nothing asked for: {without:?}"
+            );
+        }
     }
 
     #[test]
     fn codex_attaches_images() {
         let (bin, run, cwd) = (Path::new("codex"), Path::new("/tmp/r"), Path::new("/tmp"));
         let imgs = vec!["a.png".to_string(), "b.jpg".to_string()];
-        let cx = args_of(&build_command("codex", bin, run, cwd, false, "", "", &imgs));
+        let cx = args_of(&build_command(
+            "codex",
+            bin,
+            run,
+            cwd,
+            false,
+            "",
+            "",
+            &imgs,
+            &[],
+        ));
         assert!(cx.windows(2).any(|w| w[0] == "-i" && w[1] == "a.png"));
         assert!(cx.windows(2).any(|w| w[0] == "-i" && w[1] == "b.jpg"));
     }
@@ -2249,6 +2360,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
             &[],
             None,
             false,
+            &[],
         )
         .unwrap();
 
@@ -2301,6 +2413,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
             &[],
             None,
             false,
+            &[],
         )
         .unwrap();
 
@@ -2323,6 +2436,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
                 model,
                 effort,
                 &[],
+                &[],
             ));
             assert!(
                 !cx.iter().any(|a| a == "-m"),
@@ -2340,6 +2454,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
                 false,
                 model,
                 effort,
+                &[],
                 &[],
             ));
             assert!(
@@ -2456,6 +2571,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
             &[],
             None,
             false,
+            &[],
         )
         .unwrap();
 
@@ -2547,6 +2663,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
             &[],
             None,
             false,
+            &[],
         )
         .unwrap();
         let elapsed = started.elapsed();
@@ -2636,6 +2753,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
                 &[],
                 resume.then_some("11111111-1111-4111-8111-111111111111"),
                 resume,
+                &[],
             )
             .unwrap();
             assert!(outcome.exit_ok);
@@ -2752,6 +2870,7 @@ limits: {max_wall_minutes: 1}
             &[],
             None,
             false,
+            &[],
         )
         .unwrap();
         assert!(outcome.exit_ok);
@@ -2780,6 +2899,7 @@ limits: {max_wall_minutes: 1}
             &[],
             None,
             false,
+            &[],
         )
         .unwrap_err();
         assert!(error


### PR DESCRIPTION
Closes #19.

## Permission that was granted and then withheld

A worker runs under `workspace-write`, and that sandbox treats the hidden `.agents/` tree as read-only. Yardlet already knew this — the run directory is added back as an explicit writable root so the worker can write its own artifacts.

A task whose confirmed `allowed_scope` grants it a skill package got no such treatment. It could not write the package it was told to write, reported `needs_user`, and asked the operator to authorize work the contract had already authorized. The workaround was `--full-access`, which drops the entire sandbox to grant one directory.

The task's declared scope now travels to the sandbox as `--add-dir` roots, for both built-in adapters.

## Three deliberate narrowings

- **Only `.agents/` entries are lifted.** Everything else in a scope is ordinary workspace content the sandbox already permits; widening past what it actually blocks would hand out permission nobody needed.
- **`.agents` itself is never a root.** That would hand over the whole canonical state — the thing the read-only default exists to protect.
- **A declared path that does not exist is not added.** A root that is not there makes the sandbox argument a claim about a workspace that does not match it.

## The honest limit

A glob is truncated to its containing directory, because `--add-dir` takes roots rather than patterns. That **is** wider than a contract like `skills/x/**` excluding `archive/v1/**` — the sandbox cannot express that split, which is exactly what the issue anticipated.

The narrower contract is still enforced, by the evaluator's forbidden-path check after the fact. That is the same belt-and-braces shape the packet danger-list already uses: the sandbox bounds what is *reachable*, the evaluator judges what was *touched*. The issue's alternative — fail during preparation when the split cannot be expressed — would refuse a task whose scope is perfectly workable, so it is not taken.

## Verification

Two tests, because the decision and the wiring can each be right while the other is wrong: one pins which roots are chosen, one pins that they reach the command for both adapters, with the run directory preserved and no extra root when nothing was declared.

Both confirmed RED — dropping the `--add-dir` loop leaves codex with only the run directory.

688 unit tests and all 26 targets green; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.