### PR TITLE
fix(runtime): refuse a task allowed to write the evidence it was handed

### DIFF
--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -183,6 +183,16 @@ fn normalized_scope(scope: &[String]) -> Vec<String> {
         .collect()
 }
 
+/// Does a declared scope entry cover this exact path?
+///
+/// Shares the normalization the parallel admission filter uses, so "what a scope
+/// covers" means one thing in the scheduler and in the evidence guard.
+pub(crate) fn scope_covers(entry: &str, path: &str) -> bool {
+    normalized_scope(std::slice::from_ref(&entry.to_string()))
+        .iter()
+        .any(|normalized| scopes_overlap(normalized, path))
+}
+
 /// Do two normalized scope entries name overlapping regions?
 ///
 /// Equal, or one is a directory containing the other. Compared on path

--- a/src/run.rs
+++ b/src/run.rs
@@ -189,6 +189,21 @@ fn prepare_serial_worktree(
             .ok_or_else(|| anyhow!("task {task_id} disappeared during worktree preparation"))?;
         let dependency_input_overlays =
             state::materialize_resolved_dependency_outputs(ws, &queue, task, &path)?;
+        // Refuse BEFORE a worker starts. A dependency overlay pins an upstream
+        // output by digest precisely so downstream work can rely on it; granting
+        // that same path as writable scope authorizes the task to invalidate the
+        // evidence it was handed. Today that is only discovered after the task
+        // has passed its own evaluation and integrated, when a later review finds
+        // the pinned digest no longer reproduces (issue #15) — the whole run, and
+        // the one after it, spent before anyone notices.
+        if let Some(conflict) = scope_conflicts_with_pinned_evidence(
+            task,
+            &core_input_overlays,
+            &dependency_input_overlays,
+        ) {
+            crate::parallel::remove_worktree(&ws.root, &path, &branch);
+            return Err(anyhow!("{conflict}"));
+        }
         let worker_run_dir = wt_agents.join("runs").join(run_id);
         std::fs::create_dir_all(&worker_run_dir)?;
         Ok(SerialWorktree {
@@ -3746,6 +3761,52 @@ fn no_change_contradiction(
     );
     if !declared.is_empty() {
         return Some(("no_change_contradicts_declared_outputs", declared));
+    }
+    None
+}
+
+/// A task's writable scope overlapping evidence that is pinned by digest.
+///
+/// Both overlay kinds exist to make an input reproducible: the core seed for a
+/// serial run, and an upstream task's output for a downstream one. A scope that
+/// covers a pinned path hands the task permission to break the guarantee it was
+/// given, and the breakage surfaces late — the task passes, integrates, and a
+/// later review finds the digest no longer reproduces (issue #15).
+///
+/// Reported as a refusal rather than a silent narrowing: the plan said this task
+/// may edit that file and something upstream said it may not change, and only a
+/// human can decide which was meant. The message names both sides so the fix —
+/// reroute the change to an evidence-disjoint file, or schedule a successor that
+/// re-pins it — is obvious from the error.
+fn scope_conflicts_with_pinned_evidence(
+    task: &crate::schemas::Task,
+    core: &[state::SerialInputOverlay],
+    dependencies: &[state::DependencyInputOverlay],
+) -> Option<String> {
+    let pinned: Vec<(&str, String)> = core
+        .iter()
+        .map(|overlay| (overlay.path.as_str(), "the run's core seed".to_string()))
+        .chain(dependencies.iter().map(|overlay| {
+            (
+                overlay.path.as_str(),
+                format!("dependency {}", overlay.dependency_task_id),
+            )
+        }))
+        .collect();
+    for (path, source) in pinned {
+        if task
+            .allowed_scope
+            .iter()
+            .any(|entry| crate::parallel::scope_covers(entry, path))
+        {
+            return Some(format!(
+                "task {} is allowed to write `{path}`, which {source} pins by content digest. \
+                 Editing it would invalidate evidence this run was given as reproducible, and \
+                 that only surfaces after the task has passed and integrated. Route the change \
+                 to a file the evidence does not bind, or schedule a successor that re-pins it.",
+                task.id
+            ));
+        }
     }
     None
 }
@@ -12796,6 +12857,75 @@ printf "# worker handoff
 
         let _ = std::fs::remove_dir_all(&source);
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// Issue #15: a downstream task granted write scope over a path that a
+    /// dependency pins by digest. It passed, integrated, and only a later review
+    /// found the pinned evidence no longer reproduced — two runs spent.
+    #[test]
+    fn a_scope_over_pinned_evidence_is_refused_before_the_worker_starts() {
+        fn scoped_task(scope: &[&str]) -> crate::schemas::Task {
+            let entries = scope
+                .iter()
+                .map(|s| format!("  - \"{s}\""))
+                .collect::<Vec<_>>()
+                .join("\n");
+            serde_yaml_ng::from_str(&format!(
+                "id: YARD-003\ntitle: t\nstate: queued\npriority: 10\nallowed_scope:\n{entries}\n"
+            ))
+            .expect("task fixture")
+        }
+        let dependency = state::DependencyInputOverlay {
+            dependency_task_id: "YARD-001".into(),
+            path: "tests/yard007_tests.gd".into(),
+            content_digest: "0a7f0a8d".into(),
+        };
+        let core = state::SerialInputOverlay {
+            path: ".agents/skills/seeded/SKILL.md".into(),
+            content_digest: "digest".into(),
+        };
+
+        // The reported case: the exact pinned file is in scope.
+        let conflict = scope_conflicts_with_pinned_evidence(
+            &scoped_task(&["tests/yard007_tests.gd"]),
+            &[],
+            std::slice::from_ref(&dependency),
+        )
+        .expect("a scope over a dependency-pinned path must be refused");
+        assert!(
+            conflict.contains("tests/yard007_tests.gd") && conflict.contains("YARD-001"),
+            "the refusal must name both the path and what pins it: {conflict}"
+        );
+
+        // A directory scope covering it counts too — the conflict is the file
+        // being writable, not how the scope spelled it.
+        assert!(scope_conflicts_with_pinned_evidence(
+            &scoped_task(&["tests/**"]),
+            &[],
+            std::slice::from_ref(&dependency),
+        )
+        .is_some());
+
+        // The core seed is pinned for the same reason.
+        assert!(scope_conflicts_with_pinned_evidence(
+            &scoped_task(&[".agents/skills/seeded/**"]),
+            std::slice::from_ref(&core),
+            &[],
+        )
+        .is_some());
+
+        // A neighbouring path is not the pinned one.
+        assert!(scope_conflicts_with_pinned_evidence(
+            &scoped_task(&["tests/yard007_regression.gd"]),
+            &[],
+            std::slice::from_ref(&dependency),
+        )
+        .is_none());
+
+        // Nothing pinned: nothing to conflict with.
+        assert!(
+            scope_conflicts_with_pinned_evidence(&scoped_task(&["tests/**"]), &[], &[]).is_none()
+        );
     }
 
     /// Issue #19: a task whose confirmed contract grants it a skill package


### PR DESCRIPTION
Closes #15.

## A plan could authorize breaking its own guarantee

A dependency overlay pins an upstream output by content digest precisely so the downstream task can rely on it. Nothing checked whether that same task's `allowed_scope` granted it permission to edit the pinned path.

The reported case cost two runs:

1. YARD-001 created a foundation binding `tests/yard007_tests.gd` at a known SHA-256.
2. YARD-003 was **planned with that file in its allowed scope**. It changed the file, **passed its own evaluation**, and integrated.
3. The independent review after it failed — the pinned digest no longer reproduced.
4. A remediation run restored the file byte-for-byte and moved the change to a separate file.

Nothing was wrong with the worker or the evaluator. The plan authorized the conflict, and the conflict was only observable two runs later.

## What changed

The conflict is refused during worktree preparation, before a worker starts. Both overlay kinds are covered — the serial core seed and a dependency's output — because both exist for the same reason.

**Refused, not silently narrowed.** The plan said this task may edit that file, and something upstream said it may not change. Only a human can decide which was meant, so the error names the path, what pins it, and the two ways out: route the change to a file the evidence does not bind, or schedule a successor that re-pins it.

"Covered" means the same thing here as in parallel admission — the scope normalization is shared rather than reimplemented, so a directory or glob covering the pinned file counts and a neighbouring path does not.

## What this does not see

The issue's own reproduction bound the file in a **project-level** artifact — a Godot validator in the operator's workspace — which Yardlet has no visibility into. This enforces the invariant for evidence **Yardlet itself pins**. A project that binds its own digests still needs its own check; Yardlet cannot invent knowledge of it. Worth saying plainly, because the issue title reads broader than what any change inside Yardlet can deliver.

## Verification

Five cases: the exact reported shape, a directory scope covering the pinned file, the core seed for the same reason, a neighbouring path that must NOT trip it, and nothing pinned at all. Confirmed RED — disabling the overlap test fails with *"a scope over a dependency-pinned path must be refused"*.

689 unit tests and all 26 targets green; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.