### PR TITLE
perf(test): tier the slow process fixtures, and make the skip say so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - run: cargo fmt --check
-      - run: cargo clippy --all-targets -- -D warnings
+      # `--all-features` so the gated slow tier is linted too, not just the
+      # targets a default build happens to compile (issue #105).
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
     name: test (${{ matrix.os }})
@@ -64,5 +66,9 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - run: cargo build --all-targets
-      - run: cargo test
+      - run: cargo build --all-targets --all-features
+      # `--all-features` is what runs the slow process tier (issue #105). It is
+      # off by default so a LOCAL `cargo test` stays usable; CI must never make
+      # that same trade, because the tier is where the defects unit tests cannot
+      # see get caught.
+      - run: cargo test --all-features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,21 @@ Rust 2021 (rustc ≥ 1.82) | Ratatui (TUI) | clap (CLI) | serde / serde_json / s
 ## Build / Test
 
 ```bash
-cargo build && cargo test     # keep the whole suite green
-cargo install --path .        # installs `yardlet` to ~/.cargo/bin
+cargo build && cargo test              # fast tier: units + fast integration
+cargo test --all-features              # everything, including the slow process tier
+cargo install --path .                 # installs `yardlet` to ~/.cargo/bin
 ```
+
+`cargo test` leaves out four process targets that are 56% of a full run's wall
+clock (issue #105). CI runs them on every PR with `--all-features`; locally they
+are opt-in. The skip is never silent — each gated target keeps a test whose name
+says so, e.g.
+`v010_001a_serial_git_finish_process_is_gated_off_run_with_features_slow_process_tests`,
+so a local run lists what it did not verify.
+
+**Before claiming a change is verified, run `--all-features`.** The gated tier is
+where the defects unit tests structurally cannot see get caught (#52, #64, #83,
+#91, #107 were all found or proven there).
 
 ## Operational rules
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,17 @@ unicode-width = "0.2"
 ctrlc = "3"
 libc = "0.2"
 
+[features]
+# The slow process fixtures: they spawn real binaries, open PTYs, and wait on
+# real timing. They are 56% of a full test run's wall clock and they are what
+# catches the defects unit tests structurally cannot (#52, #64, #83, #91, #107
+# were all found or proven there), so they run in CI on every PR — this feature
+# only decides whether a LOCAL `cargo test` pays for them (issue #105).
+#
+# Off by default, and never silently: each gated target keeps a test whose NAME
+# says it is gated, so a local run lists what it did not verify.
+slow-process-tests = []
+
 [profile.test]
 # Line tables keep backtraces and panic locations readable while dropping the
 # full type/variable debug info. That info is what made the test artifacts

--- a/tests/protected_branch_pr_delivery_process.rs
+++ b/tests/protected_branch_pr_delivery_process.rs
@@ -1,3 +1,14 @@
+//! Slow process tier: gated behind the `slow-process-tests` feature (#105).
+//!
+//! CI runs it on every PR. A local `cargo test` does not, because this target
+//! spawns real binaries and waits on real timing — the four gated targets are
+//! 56% of a full run's wall clock.
+//!
+//! Skipping is never silent: with the feature off this file still compiles one
+//! test whose NAME says what was not verified, so a local run lists it.
+
+#![cfg(all(unix, feature = "slow-process-tests"))]
+
 #[cfg(unix)]
 #[test]
 fn protected_branch_delivery_and_crash_recovery_are_process_safe() {

--- a/tests/protected_branch_pr_delivery_process_gate.rs
+++ b/tests/protected_branch_pr_delivery_process_gate.rs
@@ -1,0 +1,14 @@
+//! Names what a local `cargo test` did not run (#105).
+//!
+//! `protected_branch_pr_delivery_process` is in the slow process tier. This exists so the skip appears in the
+//! test list by name instead of the tier vanishing from the output — a run that
+//! silently omits 56% of its wall clock reads as "everything passed".
+
+#[cfg(not(feature = "slow-process-tests"))]
+#[test]
+fn protected_branch_pr_delivery_process_is_gated_off_run_with_features_slow_process_tests() {
+    eprintln!(
+        "skipped: the protected-branch PR delivery process fixtures need \
+         `cargo test --features slow-process-tests` (CI always runs them)"
+    );
+}

--- a/tests/v010_001a_serial_git_finish_process.rs
+++ b/tests/v010_001a_serial_git_finish_process.rs
@@ -1,3 +1,14 @@
+//! Slow process tier: gated behind the `slow-process-tests` feature (#105).
+//!
+//! CI runs it on every PR. A local `cargo test` does not, because this target
+//! spawns real binaries and waits on real timing — the four gated targets are
+//! 56% of a full run's wall clock.
+//!
+//! Skipping is never silent: with the feature off this file still compiles one
+//! test whose NAME says what was not verified, so a local run lists it.
+
+#![cfg(all(unix, feature = "slow-process-tests"))]
+
 #[cfg(unix)]
 #[test]
 fn yardlet_serial_chain_and_crash_recovery_converge_without_manual_git_finish() {

--- a/tests/v010_001a_serial_git_finish_process_gate.rs
+++ b/tests/v010_001a_serial_git_finish_process_gate.rs
@@ -1,0 +1,14 @@
+//! Names what a local `cargo test` did not run (#105).
+//!
+//! `v010_001a_serial_git_finish_process` is in the slow process tier. This exists so the skip appears in the
+//! test list by name instead of the tier vanishing from the output — a run that
+//! silently omits 56% of its wall clock reads as "everything passed".
+
+#[cfg(not(feature = "slow-process-tests"))]
+#[test]
+fn v010_001a_serial_git_finish_process_is_gated_off_run_with_features_slow_process_tests() {
+    eprintln!(
+        "skipped: the serial git finish process fixtures need \
+         `cargo test --features slow-process-tests` (CI always runs them)"
+    );
+}

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -1,3 +1,14 @@
+//! Slow process tier: gated behind the `slow-process-tests` feature (#105).
+//!
+//! CI runs it on every PR. A local `cargo test` does not, because this target
+//! spawns real binaries and waits on real timing — the four gated targets are
+//! 56% of a full run's wall clock.
+//!
+//! Skipping is never silent: with the feature off this file still compiles one
+//! test whose NAME says what was not verified, so a local run lists it.
+
+#![cfg(all(unix, feature = "slow-process-tests"))]
+
 #[cfg(unix)]
 #[path = "fixtures/support/process-binary-preflight.rs"]
 mod process_binary_preflight;

--- a/tests/v010_003_task_channels_process_gate.rs
+++ b/tests/v010_003_task_channels_process_gate.rs
@@ -1,0 +1,14 @@
+//! Names what a local `cargo test` did not run (#105).
+//!
+//! `v010_003_task_channels_process` is in the slow process tier. This exists so the skip appears in the
+//! test list by name instead of the tier vanishing from the output — a run that
+//! silently omits 56% of its wall clock reads as "everything passed".
+
+#[cfg(not(feature = "slow-process-tests"))]
+#[test]
+fn v010_003_task_channels_process_is_gated_off_run_with_features_slow_process_tests() {
+    eprintln!(
+        "skipped: the task channels process fixtures need \
+         `cargo test --features slow-process-tests` (CI always runs them)"
+    );
+}

--- a/tests/v010_004_resource_publication.rs
+++ b/tests/v010_004_resource_publication.rs
@@ -1,3 +1,14 @@
+//! Slow process tier: gated behind the `slow-process-tests` feature (#105).
+//!
+//! CI runs it on every PR. A local `cargo test` does not, because this target
+//! spawns real binaries and waits on real timing — the four gated targets are
+//! 56% of a full run's wall clock.
+//!
+//! Skipping is never silent: with the feature off this file still compiles one
+//! test whose NAME says what was not verified, so a local run lists it.
+
+#![cfg(all(unix, feature = "slow-process-tests"))]
+
 #[cfg(unix)]
 mod unix {
     use serde_json::Value;

--- a/tests/v010_004_resource_publication_gate.rs
+++ b/tests/v010_004_resource_publication_gate.rs
@@ -1,0 +1,14 @@
+//! Names what a local `cargo test` did not run (#105).
+//!
+//! `v010_004_resource_publication` is in the slow process tier. This exists so the skip appears in the
+//! test list by name instead of the tier vanishing from the output — a run that
+//! silently omits 56% of its wall clock reads as "everything passed".
+
+#[cfg(not(feature = "slow-process-tests"))]
+#[test]
+fn v010_004_resource_publication_is_gated_off_run_with_features_slow_process_tests() {
+    eprintln!(
+        "skipped: the resource publication process fixtures need \
+         `cargo test --features slow-process-tests` (CI always runs them)"
+    );
+}


### PR DESCRIPTION
Finishes #105 — on the direction the measurement supported, not the one the issue was filed on.

The first half (landed in #111) found that test binaries were only 3% of the build cache and that a clean build is twenty seconds. What actually costs the operator is **test execution**, and it is concentrated:

| target | time | share |
|---|---|---|
| `v010_001a_serial_git_finish_process` | 92.5s | 30% |
| `v010_004_resource_publication` | 31.3s | 10% |
| `v010_003_task_channels_process` | 26.9s | 9% |
| `protected_branch_pr_delivery_process` | 24.0s | 8% |

Four targets, **56% of the wall clock**. They spawn real binaries, open PTYs, and wait on real timing — which is also exactly why they are worth having: #52, #64, #83, #91 and #107 were all found or proven at that layer, and no unit test could have caught any of them.

## The split

A `slow-process-tests` feature, off locally and on in CI.

- `cargo test` — **310s → 161s**
- `cargo test --all-features` — everything, **353s**, which is what CI now runs on every PR
- clippy widened to `--all-features` too, so the gated targets stay linted rather than falling out of the lint surface along with the tests

## The part that mattered more than the split

A run that quietly omits 56% of its wall clock reads as *everything passed*. That is the failure mode this repository has spent the day fixing in other forms — vacuous assertions, unverified durability claims, a report that says Done about work that is not in git.

So the skip is not silent. Each gated target has a companion whose **test name is the notice**:

```
test v010_001a_serial_git_finish_process_is_gated_off_run_with_features_slow_process_tests ... ok
```

A local run lists what it did not verify. Skipping becomes a decision the operator can see rather than an absence they have to notice.

## Verification

Measured both ways: default **161s with 4 gate notices present**; `--all-features` **353s with all four gated targets running and passing**. `cargo fmt --check` clean, and clippy clean under **both** feature configurations — the second one matters, because a gated target that only compiles under a feature is exactly the kind of code that rots unlinted.