### PR TITLE
chore(ci): move both codeql-action steps to v4 together

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,11 +41,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: github/codeql-action/init@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
-      - uses: github/codeql-action/analyze@4187e74d05793876e9989daffde9c3e66b4acd07 # v3
+      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Replaces #100 and #101.

Dependabot opened those two separately — one for `init`, one for `analyze` — and **each fails on its own**:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '3.37.3'
```

The two steps share state through a config file the first writes and the second reads. That makes them one upgrade, not two. Split across PRs, whichever merges first breaks CodeQL until the other follows, and on this repository CodeQL is both a required check and a `Require CodeQL on main` ruleset gate — so that window would block every open PR, not just this one.

Same SHA for both, which is what dependabot was proposing in aggregate anyway.

Closing #100 and #101 in favour of this.