### PR TITLE
fix(runtime): make the stop decision durable and per run

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -961,7 +961,7 @@ pub(crate) fn capture_serial_input_overlays(
 const PROVIDER_REFUSAL_CLASSIFICATION_SKIPS_FILE: &str =
     "provider-refusal-classification-skips.yaml";
 
-const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 19] = [
+const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 20] = [
     "run.yaml",
     "task-packet.md",
     "worker.pid",
@@ -972,6 +972,7 @@ const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 19] = [
     "feedback.json",
     "canonical-state-seed",
     "cancelled",
+    "stopped-reason",
     "partial-reason",
     "failover.json",
     "evaluation.json",
@@ -1111,6 +1112,15 @@ fn task_state_progress_line(lang: Lang, task_id: &str, state: TaskState) -> Stri
 // Every field defaults so a partial run.yaml (e.g. an older or hand-written one
 // that only carries run_id/task_id/worker) still deserializes — both
 // `seal_run_record` and `run_worker` read it through `state::load_yaml`.
+/// Did the operator interrupt THIS run?
+///
+/// Durable and per-run: read from the run's own directory rather than a process
+/// flag, so `finalize_run` and a later `recover` in a different process reach
+/// the same answer (issue #110).
+pub(crate) fn run_was_interrupted(run_dir: &std::path::Path) -> bool {
+    run_dir.join("stopped-reason").is_file()
+}
+
 /// Read the adoption policy off core-owned config, for the projection a worker
 /// gets to read before it does semantic work (issue #117).
 fn adoption_policy_for(ws: &Workspace) -> Option<AdoptionPolicy> {
@@ -2956,7 +2966,22 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
     // leaves the same answer on disk that this process would have given.
     if outcome.stopped || crate::signals::stop_requested() {
         outcome.stopped = true;
+        // Two records, because they answer different questions and one file
+        // could not answer both (issue #110).
+        //
+        // `cancelled` is the existing convention `yardlet redirect` also writes:
+        // "do not resume this run". Reusing it alone made a redirect look like a
+        // process stop.
+        //
+        // `stopped-reason` is this run's own durable answer to "was the operator
+        // interrupting?" — written before any terminal transition, in the run's
+        // OWN directory, so a later `recover` in a different process reaches the
+        // same conclusion instead of consulting a process flag that no longer
+        // exists. Per-run is the point: a long-lived TUI must not condemn its
+        // next run, and one stopped worker in a parallel batch must not condemn
+        // a sibling that finished correctly.
         crate::state::write_str_atomic(&run_dir.join("cancelled"), "stopped\n")?;
+        crate::state::write_str_atomic(&run_dir.join("stopped-reason"), "operator_interrupt\n")?;
     }
     // From this point the worktree may contain completed or partially completed
     // worker work. Any import/finalization error must retain it for recovery;
@@ -7415,6 +7440,22 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         })
         .flatten();
     let mut next_state = eval.next_task_state;
+    // An interrupted run cannot finish a task, whichever attempt produced the
+    // evidence and whichever process is finalizing (issue #110). Read from this
+    // run's own durable record rather than a process flag: `recover` runs later,
+    // in another process, where the flag is gone and the answer must be the same.
+    //
+    // Back to Queued, not Partial and not Failed, and each alternative was tried
+    // and was wrong. Partial is read as review failure for a review task, so a
+    // review whose evidence all passed got escalated to needs_user. Failed is
+    // treated as transient by `run --auto`, which would restart the very work
+    // the operator stopped. Queued claims nothing, retries nothing on its own,
+    // and leaves the run's evidence and retained worktree for the operator to
+    // pick up deliberately.
+    let interrupted = run_was_interrupted(run_dir);
+    if interrupted {
+        next_state = TaskState::Queued;
+    }
     if let Some(f) = &feedback {
         let _ = state::write_str(
             &run_dir.join("feedback.json"),
@@ -7470,7 +7511,11 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
             "{}: retained Done while repairing its verified Git finish projection",
             task.id
         ));
-        next_state = TaskState::Done;
+        next_state = if interrupted {
+            TaskState::Queued
+        } else {
+            TaskState::Done
+        };
     }
     // Preserve the worker/evaluator outcome before Git integration can turn a
     // passing Done into a manual-integration Partial. Review remediation is
@@ -12934,6 +12979,59 @@ printf "# worker handoff
 
         let _ = std::fs::remove_dir_all(&source);
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// Issue #110: the stop decision has to survive the process that made it.
+    /// A flag in memory cannot answer `recover` running later, and reusing the
+    /// `cancelled` marker cannot tell an interrupt from a `yardlet redirect`.
+    #[test]
+    fn the_interrupt_record_is_durable_per_run_and_distinct_from_redirect() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-stop-record-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let interrupted = root.join("run-interrupted");
+        let redirected = root.join("run-redirected");
+        let untouched = root.join("run-untouched");
+        for dir in [&interrupted, &redirected, &untouched] {
+            std::fs::create_dir_all(dir).unwrap();
+        }
+
+        // What a stop writes: both markers.
+        std::fs::write(interrupted.join("cancelled"), "stopped\n").unwrap();
+        std::fs::write(interrupted.join("stopped-reason"), "operator_interrupt\n").unwrap();
+        // What `yardlet redirect` writes: the shared marker only.
+        std::fs::write(redirected.join("cancelled"), "redirect\n").unwrap();
+
+        assert!(
+            run_was_interrupted(&interrupted),
+            "a stopped run must be recognizable from its own directory, with no \
+             process state involved"
+        );
+        assert!(
+            !run_was_interrupted(&redirected),
+            "a redirect writes `cancelled` for its own reasons; reading that as an \
+             interrupt is what broke the redirect path"
+        );
+        assert!(!run_was_interrupted(&untouched));
+
+        // Per-run: one run's record says nothing about its sibling. That is what
+        // keeps a stopped worker in a parallel batch from condemning one that
+        // finished correctly, and a long-lived TUI from condemning its next run.
+        assert!(run_was_interrupted(&interrupted) && !run_was_interrupted(&untouched));
+
+        // The record is core-owned, so a worker cannot forge or erase it through
+        // the normal artifact import path.
+        assert!(
+            MAIN_OWNED_RUN_ARTIFACT_NAMES.contains(&"stopped-reason"),
+            "the interrupt record must be core-owned like the other verdicts"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Issue #117: a serial worker could see its worktree, branch and baseline

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -460,3 +460,135 @@ fn a_result_written_before_the_interrupt_does_not_finish_the_task() {
          so the Ctrl-C looks like it completed the work:\n{queue}"
     );
 }
+
+/// Issue #110: the earlier attempt guarded finalization on a process-wide flag,
+/// which downgraded a passing REVIEW task to Partial — and Partial on a review
+/// reads as "the review failed", escalating to needs_user. The record is
+/// per-run and the state is Queued now, so an interrupted review is unfinished,
+/// not judged.
+#[test]
+fn an_interrupted_review_is_not_reported_as_a_failed_review() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let workspace = common::WorkspaceGuard::create(std::env::temp_dir().join(format!(
+        "yardlet-stop-review-{}-{nonce}",
+        std::process::id()
+    )));
+    let root = workspace.path().to_path_buf();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    // A review worker that writes a PASSING result and report, then keeps going.
+    let worker = root.join("fixture-review.sh");
+    let ids = root.join("worker-pid");
+    fs::write(
+        &worker,
+        "#!/bin/sh\n\
+         set -eu\n\
+         if [ \"${1:-}\" = \"--version\" ]; then\n\
+         \x20 printf 'fixture-review 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         ids=\"$2\"\n\
+         run_id=\"$(basename \"$run_dir\")\"\n\
+         cat >/dev/null\n\
+         printf 'fixture review handoff\\n' >\"$run_dir/handoff.md\"\n\
+         printf 'every criterion passed\\n' >\"$run_dir/report.md\"\n\
+         printf '{\"schema_version\":1,\"run_id\":\"%s\",\"task_id\":\"YARD-001\",\"status\":\"done\",\"compact_summary\":\"review passed\"}' \"$run_id\" >\"$run_dir/result.json\"\n\
+         printf '%s\\n' \"$$\" >\"$ids\"\n\
+         sleep 300\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&worker).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&worker, permissions).unwrap();
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-review\nsummary: interrupted review\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-review\nintent_id: intent-review\ntasks:\n  - id: YARD-001\n    title: interrupted review\n    state: queued\n    priority: 10\n    risk: low\n    kind: review\n    preferred_worker: fixture\n    acceptance: [an interrupted review is unfinished, not failed]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            worker.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(
+            fs::File::create(root.join("yardlet.err")).unwrap(),
+        ))
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let yardlet_pid = yardlet.id() as i32;
+    let mut yardlet = common::ChildGuard::new(yardlet);
+
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "the fixture review worker never started; yardlet said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+    assert_eq!(
+        unsafe { libc::kill(yardlet_pid, libc::SIGINT) },
+        0,
+        "could not signal Yardlet"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(40);
+    let mut exited = false;
+    while Instant::now() < deadline {
+        if matches!(yardlet.as_mut().try_wait(), Ok(Some(_))) {
+            exited = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        exited,
+        "Yardlet never finished after the interrupt; it said:\n{}",
+        fs::read_to_string(root.join("yardlet.err")).unwrap_or_default()
+    );
+
+    let queue = fs::read_to_string(root.join(".agents/work-queue.yaml")).unwrap_or_default();
+    assert!(
+        !queue.contains("state: done"),
+        "an interrupted review was recorded as finished:\n{queue}"
+    );
+    assert!(
+        !queue.contains("state: needs_user"),
+        "an interrupted review whose evidence PASSED was escalated as a failed \
+         review — the exact regression the process-flag guard caused:\n{queue}"
+    );
+    assert!(
+        !queue.contains("state: failed"),
+        "an interrupted review was recorded as a failure, which `run --auto` \
+         retries:\n{queue}"
+    );
+}


### PR DESCRIPTION
Addresses #110 — see "what is not verified" before merging.

## The shape that mattered

Round 4 of the review on #109 reproduced three routes where an interrupted run still recorded Done: serial failover, parallel, and `recover` after a failed queue save.

The last one is the root of the other two. The decision existed **only as a process flag**, so a later `recover` running in a different process had nothing to consult, and finalized `YARD-001 -> done` with no cancellation marker anywhere.

## Two records, because one file cannot answer both questions

| file | question | written by |
|---|---|---|
| `cancelled` | may this run be resumed? | a stop **and** `yardlet redirect` |
| `stopped-reason` | was the operator interrupting? | a stop only, core-owned |

Reusing `cancelled` alone is what made a redirect look like a process stop and broke `redirect_ignores_decoy_pid_and_signals_verified_worker` under load in an earlier round.

## Queued, and why not the alternatives

Both were tried and both were wrong:

- **Partial** is read as review failure for a review task — a review whose evidence all passed got escalated to `needs_user`.
- **Failed** is treated as transient by `run --auto`, which restarts exactly what the operator stopped.

**Queued** claims nothing, retries nothing on its own, and leaves the run's evidence and retained worktree to be picked up deliberately.

## What is verified

The record is durable, per-run, distinct from a redirect, and core-owned — a worker cannot forge or erase it through the artifact import path. And an interrupted **review** whose evidence all passed lands neither `done` nor `needs_user` nor `failed`, which is the regression the process-flag guard caused.

## What is NOT verified

**The finalization guard itself.** Disabling it leaves every test passing, because my fixtures reach the serial-initial path where the `cancelled` marker already prevents Done. I have not been able to build the failover, parallel, or failed-save fixtures the reviewer built in round 4.

So the guard is implemented against **their** reproduction, not mine. Stating it rather than implying coverage this does not have — the reviewer has built the fixture I could not on three separate rounds, and this is a fourth.

691 unit tests and all 30 targets green under `--all-features`; fmt and clippy clean.