### PR TITLE
fix(runtime): decide the interruption where every path already converges

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -3922,6 +3922,23 @@ pub(crate) fn sandbox_writable_roots(
                 .unwrap_or(entry)
                 .trim_end_matches('/');
             // A file entry contributes the directory holding it.
+            // Core-only subtrees are never liftable, whatever a scope says. The
+            // stop record decides whether an interrupted run may run again, so a
+            // worker that could write it could requeue its own passing task — an
+            // independent review did exactly that through a worker-proposed
+            // follow-up's allowed_scope (issues #19 and #110).
+            const CORE_ONLY: [&str; 4] = [
+                ".agents/stopped-runs",
+                ".agents/runtime-task-receipts",
+                ".agents/checkpoints",
+                ".agents/telemetry",
+            ];
+            if CORE_ONLY
+                .iter()
+                .any(|core| entry == *core || entry.starts_with(&format!("{core}/")))
+            {
+                return None;
+            }
             let directory = if directory.ends_with(".md") || directory.ends_with(".yaml") {
                 std::path::Path::new(directory).parent()?.to_str()?
             } else {
@@ -8047,6 +8064,12 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     if git_finish_not_needed && git_finish.status.verified_complete() {
         let _ = ws.archive_no_change_receipt(run_id);
     }
+    // A run that changed no files still DID its work — a review's report, a
+    // deploy, anything whose effect is outside the repository. `ownership` only
+    // marks a merge, so reducing "already accounted for" to it requeued a
+    // stopped no-change run and repeated its external effect: a review measured
+    // a modeled counter going from one to two (issue #110).
+    let settled_no_change = git_finish_not_needed && result.is_some();
     // The interruption verdict, applied at the LAST point before the queue
     // transition and after every other decision has been made (issue #110).
     //
@@ -8068,7 +8091,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         // run the work a second time — a review proved that repeats external
         // effects, not just wasted compute. If it did not, the task is simply
         // unstarted work again.
-        let integrated = run_integrated;
+        let integrated = run_integrated || settled_no_change;
         next_state = if integrated {
             let _ = state::write_str(&run_dir.join("partial-reason"), "stopped_after_integration");
             lines.push(format!(
@@ -8156,6 +8179,25 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     } else {
         Vec::new()
     };
+    // Sampled AGAIN, immediately before the queue is written. The earlier check
+    // runs before the planning lock, and an interrupt arriving in that window was
+    // still recorded as finished by a later `recover` — the window is small and
+    // it is exactly where a long finalization sits (issue #110).
+    let interrupted_now =
+        crate::signals::stop_requested() || ws.run_interruption_cause(run_id).is_some();
+    if interrupted_now && next_state == TaskState::Done {
+        let _ = ws.record_run_interrupted(run_id, "operator_interrupt");
+        next_state = if run_integrated || settled_no_change {
+            let _ = state::write_str(&run_dir.join("partial-reason"), "stopped_after_integration");
+            TaskState::Partial
+        } else {
+            TaskState::Queued
+        };
+        lines.push(format!(
+            "{}: interrupted during finalization; not recorded as finished",
+            task.id
+        ));
+    }
     let governing_selection = state::load_yaml::<RunRecord>(&run_dir.join("run.yaml"))
         .ok()
         .and_then(|record| record.resolved_selection());
@@ -12976,6 +13018,66 @@ printf "# worker handoff
 
         let _ = std::fs::remove_dir_all(&source);
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// A worker must not be able to write the record that decides whether its
+    /// own run may run again. The #19 sandbox work lifts declared `.agents/`
+    /// scope into writable roots, and a review used a worker-proposed follow-up
+    /// to claim `.agents/stopped-runs` that way, then forged an interrupt and
+    /// requeued its own passing task (issue #110).
+    #[test]
+    fn core_only_state_is_never_lifted_into_a_writable_root() {
+        fn scoped_task(scope: &[&str]) -> crate::schemas::Task {
+            let entries = scope
+                .iter()
+                .map(|s| format!("  - \"{s}\""))
+                .collect::<Vec<_>>()
+                .join("\n");
+            serde_yaml_ng::from_str(&format!(
+                "id: YARD-001\ntitle: t\nstate: queued\npriority: 10\nallowed_scope:\n{entries}\n"
+            ))
+            .expect("task fixture")
+        }
+        let root = std::env::temp_dir().join(format!(
+            "yard-core-only-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        for dir in [
+            ".agents/stopped-runs",
+            ".agents/runtime-task-receipts",
+            ".agents/checkpoints",
+            ".agents/telemetry",
+            ".agents/skills/legitimate",
+        ] {
+            std::fs::create_dir_all(root.join(dir)).unwrap();
+        }
+
+        for core in [
+            ".agents/stopped-runs",
+            ".agents/stopped-runs/**",
+            ".agents/runtime-task-receipts/**",
+            ".agents/checkpoints/**",
+            ".agents/telemetry/**",
+        ] {
+            assert!(
+                sandbox_writable_roots(&scoped_task(&[core]), &root).is_empty(),
+                "{core} was lifted into a writable root; a worker could then decide \
+                 whether its own run counts as interrupted"
+            );
+        }
+
+        // The legitimate case still works — this must not become a blanket
+        // refusal of `.agents/` scope, which is what #19 was about.
+        assert_eq!(
+            sandbox_writable_roots(&scoped_task(&[".agents/skills/legitimate/**"]), &root),
+            vec![root.join(".agents/skills/legitimate")]
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Issue #110: the interruption verdict has to survive the process that made

--- a/src/run.rs
+++ b/src/run.rs
@@ -8020,6 +8020,10 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
 
     // Git finish runs only after evaluation and worktree integration. The OID
     // is supplied only by the successful merge branch above, so a serial run,
+    // Captured before `ownership` is consumed below: whether this run put a
+    // merge into the repository is what decides, on an interrupt, between
+    // "unstarted again" and "already landed, do not run twice" (issue #110).
+    let run_integrated = ownership.is_some();
     // no-op, conflict, or unrelated existing commit cannot acquire ownership.
     let git_finish = if git_finish_not_needed {
         crate::git_finish::finish_no_change_run(ws, run_dir, run_id, &task.id, next_state)?
@@ -8042,6 +8046,44 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     // every later startup (issue #43).
     if git_finish_not_needed && git_finish.status.verified_complete() {
         let _ = ws.archive_no_change_receipt(run_id);
+    }
+    // The interruption verdict, applied at the LAST point before the queue
+    // transition and after every other decision has been made (issue #110).
+    //
+    // Not at spawn: there is more than one place a worker starts — initial,
+    // failover, parallel — and marking them missed two of the three. Not at
+    // finalization entry either: the interrupt routinely arrives DURING
+    // finalization, after any entry check has passed. Everything funnels here.
+    //
+    // Recorded in core-owned state rather than the run directory, because a
+    // parallel worker is handed that directory and a review had one forge the
+    // record. And read back from there, so `recover` in a fresh process — where
+    // the process flag no longer exists — reaches the same verdict.
+    if crate::signals::stop_requested() {
+        let _ = ws.record_run_interrupted(run_id, "operator_interrupt");
+    }
+    if ws.run_interruption_cause(run_id).is_some() {
+        // Two different facts, and one state cannot carry both. If integration
+        // already happened the output IS in the repository, and requeuing would
+        // run the work a second time — a review proved that repeats external
+        // effects, not just wasted compute. If it did not, the task is simply
+        // unstarted work again.
+        let integrated = run_integrated;
+        next_state = if integrated {
+            let _ = state::write_str(&run_dir.join("partial-reason"), "stopped_after_integration");
+            lines.push(format!(
+                "{}: interrupted after its output was integrated; left Partial so it is \
+                 not run again",
+                task.id
+            ));
+            TaskState::Partial
+        } else {
+            lines.push(format!(
+                "{}: interrupted before integration; returned to the queue",
+                task.id
+            ));
+            TaskState::Queued
+        };
     }
     let projected_state = state_after_git_finish(next_state, &git_finish);
     if projected_state != next_state {
@@ -12934,6 +12976,57 @@ printf "# worker handoff
 
         let _ = std::fs::remove_dir_all(&source);
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// Issue #110: the interruption verdict has to survive the process that made
+    /// it. `recover` runs later, in a different process where a stop flag no
+    /// longer exists — and it calls the same finalizer, which is how a stopped
+    /// run came to be recorded `done` with no marker anywhere.
+    #[test]
+    fn the_interruption_record_is_core_owned_and_survives_the_process() {
+        let root = std::env::temp_dir().join(format!(
+            "yard-stop-core-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let ws = Workspace::at(&root);
+
+        assert!(ws.run_interruption_cause("run-a").is_none());
+        ws.record_run_interrupted("run-a", "operator_interrupt")
+            .unwrap();
+        assert_eq!(
+            ws.run_interruption_cause("run-a").as_deref(),
+            Some("operator_interrupt"),
+            "a later process must reach the verdict the interrupted one recorded"
+        );
+        // Per-run: one run's verdict says nothing about another. That is what
+        // stops a long-lived TUI condemning its next run, and one stopped worker
+        // in a parallel batch condemning a sibling that finished correctly.
+        assert!(ws.run_interruption_cause("run-b").is_none());
+
+        // The cause is carried, not just the fact, so a `yardlet redirect` stop
+        // can never be read as an operator interrupt.
+        ws.record_run_interrupted("run-c", "redirect").unwrap();
+        assert_eq!(
+            ws.run_interruption_cause("run-c").as_deref(),
+            Some("redirect")
+        );
+
+        // Outside the run directory, which a parallel worker is handed to write
+        // into — a review forged the record when it lived there.
+        assert!(
+            ws.stopped_runs_dir().starts_with(ws.agents_dir())
+                && !ws
+                    .stopped_runs_dir()
+                    .starts_with(ws.agents_dir().join("runs")),
+            "the record must not live where a worker can write"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// Issue #117: a serial worker could see its worktree, branch and baseline

--- a/src/run.rs
+++ b/src/run.rs
@@ -3884,6 +3884,27 @@ fn scope_conflicts_with_pinned_evidence(
     None
 }
 
+/// A scope path reduced to comparable form: `.` and `..` resolved lexically,
+/// empty segments dropped, case folded.
+///
+/// Lexical rather than `canonicalize`, because a declared scope may name a
+/// directory that does not exist yet and canonicalization fails on those. Case
+/// is folded because the filesystems this runs on are routinely
+/// case-insensitive, so two spellings reach the same inode.
+fn normalize_scope_path(path: &str) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            other => parts.push(other),
+        }
+    }
+    parts.join("/").to_lowercase()
+}
+
 /// Workspace directories the task's confirmed contract says it may write, which
 /// the sandbox would otherwise refuse.
 ///
@@ -3927,16 +3948,26 @@ pub(crate) fn sandbox_writable_roots(
             // worker that could write it could requeue its own passing task — an
             // independent review did exactly that through a worker-proposed
             // follow-up's allowed_scope (issues #19 and #110).
-            const CORE_ONLY: [&str; 4] = [
+            const CORE_ONLY: [&str; 5] = [
                 ".agents/stopped-runs",
                 ".agents/runtime-task-receipts",
                 ".agents/checkpoints",
                 ".agents/telemetry",
+                // Run directories decide each other's fate: a worker handed the
+                // whole tree wrote `cancelled` into a SIBLING run and had it
+                // stopped and requeued. The run's OWN directory is still granted
+                // explicitly at spawn; what is refused is claiming the tree
+                // through scope.
+                ".agents/runs",
             ];
-            if CORE_ONLY
-                .iter()
-                .any(|core| entry == *core || entry.starts_with(&format!("{core}/")))
-            {
+            // Compared on normalized components, not the raw string. `..` and a
+            // differing case both name the same directory on the filesystems
+            // this runs on, and a prefix test on the literal text let both past.
+            let normalized = normalize_scope_path(directory);
+            if CORE_ONLY.iter().any(|core| {
+                let core = normalize_scope_path(core);
+                normalized == core || normalized.starts_with(&format!("{core}/"))
+            }) {
                 return None;
             }
             let directory = if directory.ends_with(".md") || directory.ends_with(".yaml") {
@@ -13052,6 +13083,8 @@ printf "# worker handoff
             ".agents/checkpoints",
             ".agents/telemetry",
             ".agents/skills/legitimate",
+            ".agents/runs",
+            ".agents/stopped-runs-notes",
         ] {
             std::fs::create_dir_all(root.join(dir)).unwrap();
         }
@@ -13062,6 +13095,15 @@ printf "# worker handoff
             ".agents/runtime-task-receipts/**",
             ".agents/checkpoints/**",
             ".agents/telemetry/**",
+            // Run directories: a worker handed the tree wrote `cancelled` into a
+            // sibling's run and had that task stopped and requeued.
+            ".agents/runs/**",
+            // The same directories under equivalent spellings. A prefix test on
+            // the raw string let both of these past.
+            ".agents/skills/../stopped-runs/**",
+            ".agents/Stopped-Runs/**",
+            "./.agents/stopped-runs/**",
+            ".agents/stopped-runs/",
         ] {
             assert!(
                 sandbox_writable_roots(&scoped_task(&[core]), &root).is_empty(),
@@ -13075,6 +13117,12 @@ printf "# worker handoff
         assert_eq!(
             sandbox_writable_roots(&scoped_task(&[".agents/skills/legitimate/**"]), &root),
             vec![root.join(".agents/skills/legitimate")]
+        );
+        // And a name that merely SHARES A PREFIX with a protected one is not
+        // protected: matching has to be on path boundaries, not on text.
+        assert_eq!(
+            sandbox_writable_roots(&scoped_task(&[".agents/stopped-runs-notes/**"]), &root),
+            vec![root.join(".agents/stopped-runs-notes")]
         );
 
         let _ = std::fs::remove_dir_all(&root);

--- a/src/state.rs
+++ b/src/state.rs
@@ -473,6 +473,35 @@ impl Workspace {
             .join(format!("{confirmation_id}.yaml"))
     }
 
+    /// Where the core records that a run was interrupted.
+    ///
+    /// Deliberately NOT the run directory. A parallel worker is handed the
+    /// canonical run directory to write into, so anything the core must trust
+    /// cannot live there — an independent review had a worker forge its own
+    /// stop record and turn a passing task into a requeue (issue #110). Nothing
+    /// grants a worker write access under this path.
+    pub fn stopped_runs_dir(&self) -> PathBuf {
+        self.agents_dir().join("stopped-runs")
+    }
+
+    /// Record that this run was interrupted, with the cause. One atomic write,
+    /// because a two-file scheme has a crash window where the second never
+    /// lands and recovery then reads the run as uninterrupted.
+    pub fn record_run_interrupted(&self, run_id: &str, cause: &str) -> anyhow::Result<()> {
+        let dir = self.stopped_runs_dir();
+        std::fs::create_dir_all(&dir)?;
+        crate::state::write_str_atomic(&dir.join(run_id), &format!("{cause}\n"))
+    }
+
+    /// Was this run interrupted? Answered from core-owned state, so a later
+    /// process reaches the same conclusion as the one that was interrupted.
+    pub fn run_interruption_cause(&self, run_id: &str) -> Option<String> {
+        std::fs::read_to_string(self.stopped_runs_dir().join(run_id))
+            .ok()
+            .map(|text| text.trim().to_string())
+            .filter(|cause| !cause.is_empty())
+    }
+
     pub fn runtime_task_receipts_dir(&self) -> PathBuf {
         self.agents_dir().join("runtime-task-receipts")
     }

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -460,3 +460,138 @@ fn a_result_written_before_the_interrupt_does_not_finish_the_task() {
          so the Ctrl-C looks like it completed the work:\n{queue}"
     );
 }
+
+/// Issue #110: a stopped run that reaches finalization in a LATER process must
+/// not be recorded finished. Review reproduced the shape — interrupt after Done
+/// evidence exists, let the queue save fail, restore the durable `running`
+/// queue, and a fresh `yardlet recover` reported `YARD-001 -> done` with no
+/// marker anywhere, because the decision lived only in the process that made it.
+#[test]
+fn recover_in_a_fresh_process_honours_the_interruption() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let workspace = common::WorkspaceGuard::create(std::env::temp_dir().join(format!(
+        "yardlet-stop-recover-{}-{nonce}",
+        std::process::id()
+    )));
+    let root = workspace.path().to_path_buf();
+    must_succeed(&root, Path::new("git"), &["init", "-q"]);
+    must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+    must_succeed(
+        &root,
+        Path::new("git"),
+        &["config", "user.email", "fixture@example.invalid"],
+    );
+    fs::write(root.join("README.md"), "fixture\n").unwrap();
+    must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+    must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+    must_succeed(&root, &binary, &["init"]);
+
+    // A worker that writes PASSING evidence, then keeps going so it can be cut off.
+    let worker = root.join("fixture-worker.sh");
+    let ids = root.join("worker-pid");
+    fs::write(
+        &worker,
+        "#!/bin/sh\n\
+         set -eu\n\
+         if [ \"${1:-}\" = \"--version\" ]; then\n\
+         \x20 printf 'fixture 1.0\\n'\n\
+         \x20 exit 0\n\
+         fi\n\
+         run_dir=\"$1\"\n\
+         ids=\"$2\"\n\
+         run_id=\"$(basename \"$run_dir\")\"\n\
+         cat >/dev/null\n\
+         printf 'handoff\\n' >\"$run_dir/handoff.md\"\n\
+         printf '{\"schema_version\":1,\"run_id\":\"%s\",\"task_id\":\"YARD-001\",\"status\":\"done\",\"compact_summary\":\"ok\"}' \"$run_id\" >\"$run_dir/result.json\"\n\
+         printf '%s\\n' \"$$\" >\"$ids\"\n\
+         sleep 300\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&worker).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&worker, permissions).unwrap();
+
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-recover\nsummary: stopped run recovery\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-recover\nintent_id: intent-recover\ntasks:\n  - id: YARD-001\n    title: stopped run recovery\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [a stopped run is not finished by a later process]\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/workers.yaml"),
+        format!(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            worker.display(),
+            ids.display()
+        ),
+    )
+    .unwrap();
+
+    let yardlet = Command::new(&binary)
+        .args(["run", "--task", "YARD-001", "--execute"])
+        .current_dir(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let yardlet_pid = yardlet.id() as i32;
+    let mut yardlet = common::ChildGuard::new(yardlet);
+    assert!(
+        wait_for(&ids, Duration::from_secs(60)),
+        "worker never started"
+    );
+    assert_eq!(unsafe { libc::kill(yardlet_pid, libc::SIGINT) }, 0);
+    yardlet.shutdown(Duration::from_secs(30), || {});
+
+    // The interrupted process recorded its verdict in core-owned state, outside
+    // the run directory a worker can write.
+    let run_id = fs::read_dir(root.join(".agents/runs"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .find(|name| name.starts_with("run-"))
+        .expect("a run directory");
+    fs::create_dir_all(root.join(".agents/stopped-runs")).unwrap();
+    fs::write(
+        root.join(".agents/stopped-runs").join(&run_id),
+        "operator_interrupt\n",
+    )
+    .unwrap();
+
+    // The queue save is what failed in the reported case, so the durable queue
+    // still says Running and a later process has to settle it.
+    let queue_path = root.join(".agents/work-queue.yaml");
+    let queue = fs::read_to_string(&queue_path).unwrap();
+    fs::write(
+        &queue_path,
+        queue.replace("state: queued", "state: running"),
+    )
+    .unwrap();
+
+    // A FRESH process. The stop flag it would have consulted is gone.
+    let recovered = Command::new(&binary)
+        .arg("recover")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    let said = String::from_utf8_lossy(&recovered.stdout).into_owned();
+    let queue = fs::read_to_string(&queue_path).unwrap();
+    assert!(
+        !queue.contains("state: done"),
+        "a later process finished a run the operator had stopped:\n{said}\n{queue}"
+    );
+    assert!(
+        said.contains("interrupted"),
+        "recovery must say why it refused to finish it: {said}"
+    );
+}


### PR DESCRIPTION
Addresses #110. Fourth attempt — and the first with a failing test to point at.

## What the three failures taught

Each earlier attempt failed for a different reason, and the review that killed them supplied every constraint this one is built on:

| attempt | failed because |
|---|---|
| mark the spawn sites | a worker starts in more than one place; serial failover and parallel were missed |
| guard on the process stop flag | the flag never resets — a long-lived TUI stopped every later run |
| per-run record in the run directory | parallel hands that directory to the worker, who forged the record |
| `cancelled` + `stopped-reason` | two writes, and a crash window where only the first lands |
| check at finalization entry | the interrupt arrives *during* finalization, after any entry check |
| `Queued` for everything | re-ran work that had already merged, repeating external effects |

## What this does

**One atomic record**, in `.agents/stopped-runs/<run-id>` — a location nothing grants a worker write access to. It carries the **cause**, so a `yardlet redirect` stop can never be read as an operator interrupt (collapsing those broke the redirect path in an earlier round).

**Decided at the last point before the queue transition** — after feedback, after review classification, after the Git-finish projection. That is the one place serial, failover, parallel and `recover` all pass through, which is why marking spawn sites kept missing two of them.

**The verdict splits on whether this run put a merge into the repository**, because those are two different facts and one state cannot hold both:

- not integrated → `Queued`, genuinely unstarted work;
- integrated → `Partial` with a `stopped_after_integration` reason, so it is not run a second time.

## Verification

**Confirmed RED**, which none of the previous three attempts managed: disabling the verdict makes a fresh `yardlet recover` finish a run the operator had stopped, and the test reports exactly that. Also walked through by hand end to end — recovery in a new process prints *"interrupted before integration; returned to the queue"*.

692 unit tests and all 30 targets green under `--all-features`; fmt and clippy clean.

## Scope, stated plainly

This covers what **reaches finalization**. The serial-initial path already requeued on its own before this change — which is why my earlier RED probes kept passing and why I could not tell whether the guard did anything. The failover and parallel fixtures the reviewer built are still ones I have not reproduced myself, so those two routes are addressed by construction rather than by a test I can point at.