### PR TITLE
feat(worker): generic prompt transport and a single invocability contract (V010-006 slice 1)

### DIFF
--- a/.agents/skills/readiness-1-1/SKILL.md
+++ b/.agents/skills/readiness-1-1/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: readiness-1-1
+description: readiness 계약 리뷰 시 여섯 공급자 1:1 대조
+source: learned
+---
+제네릭/내장 워커 실행 가능 판정을 리뷰할 때는 표시 문자열이 아니라 여섯 소비처가 모두 guard::probe/guard::invocation_contract의 같은 결과를 쓰는지 확인한다: (1) cli.rs worker status(probe+stages/verdict), (2) snapshot.rs TUI(probe→readiness.label + readiness_cache_key 캐시 무효화), (3) routing.rs resolve_order(probe().readiness==Ready), (4) planner.rs pick_ready_worker(동일), (5) guard.rs capability_readiness_projection + routing.rs ready_capabilities_from_projection(==Ready 필터), (6) workers/mod.rs spawn_internal의 invocation_contract 재확인. `grep -n 'probe(\|Readiness::Ready\|invocation_contract'`로 도달성을 판정하라.

--- a/README.ko.md
+++ b/README.ko.md
@@ -336,16 +336,22 @@ Enter/Space). 비활성화된 워커는 라우팅과 계획에서 건너뜁니�
 
 Codex와 Claude Code는 내장 어댑터를 가집니다. 다른 모든 구독 기반 CLI는
 `.agents/workers.yaml`만으로 추가할 수 있습니다. 호출 템플릿을 주면 Yardlet이 동일한
-계약(stdin으로 패킷 -> 결과 파일 출력)을 통해 그것을 구동합니다. 플레이스홀더:
-`{run_dir}`, `{model}`, `{effort}`, `{image}`.
+결과 파일 계약으로 그것을 구동합니다. 제네릭 워커는 활성 상태이고 실행 파일과 설정된
+오프라인 프로브가 동작하며, `supports_noninteractive`가 `true`,
+`output_contract`가 `files`이고, 프롬프트 전달이 유효하며, strict billing 정책이
+차단하지 않을 때만 실행 가능합니다. 라우팅, 계획, capability projection, 워커 상태,
+TUI는 모두 같은 판정을 사용합니다.
 
 ```yaml
 - id: mytool
   best_for: "..."            # 플래너 루브릭
   invocation:
-    command: mytool          # --version 지원 필요 (준비 상태 프로브)
+    command: mytool
     supports_noninteractive: true
-    args: ["run", "--json", "--out", "{run_dir}"]
+    output_contract: files
+    version_args: ["version", "--offline"] # 기본값: ["--version"]
+    prompt_transport: argument              # 기본값: stdin
+    args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
     sandbox_args: ["--sandbox"]        # 기본 접근 수준
     full_access_args: ["--yolo"]       # 풀 액세스가 허용될 때만
     model_args: ["--model", "{model}"] # 모델이 설정되면 추가됨
@@ -353,9 +359,18 @@ Codex와 Claude Code는 내장 어댑터를 가집니다. 다른 모든 구독 �
     image_args: ["-i", "{image}"]      # 첨부 이미지마다 반복됨
 ```
 
-워커는 워크스페이스에 파일을 쓸 수 있어야 합니다(그것이 결과가 돌아오는
-방식입니다). 그 서브프로세스 env는 프로필이 `pass_env`로 변수를 다시 옵트인하지
-않는 한 정화됩니다.
+기존 제네릭 프로필은 하위 호환됩니다. `prompt_transport`를 생략하면 전체 패킷을
+stdin으로 보내고, `version_args`를 생략하면 `--version`을 실행합니다. 인자 전달을
+사용하려면 `prompt_transport: argument`를 설정하고 `args`에 `{prompt}`를 정확히 한 번
+넣으세요. Yardlet은 셸 문자열을 만들지 않고 하나의 `Command` 인자로 치환하여 인자
+경계를 보존합니다. stdin 전달에는 `{prompt}`를 넣으면 안 됩니다. 그 밖의 호출
+플레이스홀더는 `{run_dir}`, `{model}`, `{effort}`, `{image}`입니다.
+
+워커는 실행 디렉터리에 `result.json`과 `handoff.md`를 작성해야 합니다. 실행 env는
+프로필이 `pass_env`로 변수를 다시 옵트인하지 않는 한 정화됩니다. 버전 프로브도 정화된
+환경에서 로컬로만 실행됩니다. 설정한 실행 파일과 프로브 인자를 네트워크나 공급자 호출
+없이 확인하지만 로그인 또는 API 인증까지 증명할 수는 없습니다. 따라서 실제 워커가
+시작될 때 인증이 실패할 수 있습니다.
 
 생태계의 에이전트들이 Yardlet의 공급 측입니다.
 [oh-my-pi](https://github.com/can1357/oh-my-pi)(`omp`), OpenCode, Gemini CLI,

--- a/README.md
+++ b/README.md
@@ -353,17 +353,23 @@ planning.
 
 Codex and Claude Code have built-in adapters. Any other subscription-backed
 CLI can be added in `.agents/workers.yaml` alone: give it an invocation
-template and Yardlet drives it through the same contract (packet on stdin →
-result files out). Placeholders: `{run_dir}`, `{model}`, `{effort}`,
-`{image}`.
+template and Yardlet drives it through the same result-file contract. Generic
+workers become invocable only when they are enabled, their executable and
+configured offline probe work, `supports_noninteractive` is `true`,
+`output_contract` is `files`, prompt delivery is valid, and strict billing
+policy does not block them. Routing, planning, capability projection, worker
+status, and the TUI all use that same decision.
 
 ```yaml
 - id: mytool
   best_for: "..."            # planner rubric
   invocation:
-    command: mytool          # must support --version (readiness probe)
+    command: mytool
     supports_noninteractive: true
-    args: ["run", "--json", "--out", "{run_dir}"]
+    output_contract: files
+    version_args: ["version", "--offline"] # default: ["--version"]
+    prompt_transport: argument              # default: stdin
+    args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
     sandbox_args: ["--sandbox"]        # default access level
     full_access_args: ["--yolo"]       # only when full access is granted
     model_args: ["--model", "{model}"] # added when a model is set
@@ -371,9 +377,21 @@ result files out). Placeholders: `{run_dir}`, `{model}`, `{effort}`,
     image_args: ["-i", "{image}"]      # repeated per attached image
 ```
 
-The worker must be able to write files in the workspace (that is how results
-come back); its subprocess env is sanitized unless the profile opts vars
-back in with `pass_env`.
+Existing generic profiles remain backward compatible: omitting
+`prompt_transport` sends the complete packet on stdin, and omitting
+`version_args` runs `--version`. For argument delivery, set
+`prompt_transport: argument` and put `{prompt}` exactly once in `args`.
+Yardlet substitutes it as one `Command` argument, preserving argument
+boundaries without constructing a shell string. Stdin delivery must not include
+`{prompt}`. The other invocation placeholders are `{run_dir}`, `{model}`,
+`{effort}`, and `{image}`.
+
+The worker must write `result.json` and `handoff.md` in the run directory. Its
+execution env is sanitized unless the profile opts variables back in with
+`pass_env`. The version probe is also sanitized and local-only: it verifies the
+configured executable and probe arguments without network or provider calls,
+but it cannot prove login or API authentication. Authentication can therefore
+still fail when the actual worker starts.
 
 The ecosystem's agents are Yardlet's supply side: terminal agents like
 [oh-my-pi](https://github.com/can1357/oh-my-pi) (`omp`), OpenCode, Gemini

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -22,7 +22,7 @@ pub enum Readiness {
     NotReady,
     /// The worker is configured but explicitly disabled in workers.yaml.
     Disabled,
-    /// Binary is present but its offline `--version` probe failed, so the
+    /// Binary is present but its configured offline version probe failed, so the
     /// resolved CLI or its runtime cannot be confirmed. Yardlet stops rather than
     /// guess (it never risks a billed call to verify auth).
     Ambiguous,
@@ -47,6 +47,9 @@ pub struct WorkerStatus {
     pub version: Option<String>,
     /// Names (never values) of billing env vars present in the parent process.
     pub billing_env_present: Vec<String>,
+    /// Static generic invocation contract failure. Kept separate so staged
+    /// status can report why no version subprocess was started.
+    pub contract_error: Option<String>,
     pub readiness: Readiness,
     pub detail: String,
 }
@@ -76,6 +79,24 @@ pub fn capability_readiness_projection(
             capabilities: profile.capabilities.clone(),
         })
         .collect()
+}
+
+/// Cache identity for the inputs that can change an offline readiness verdict.
+/// It contains configuration and billing-variable names/presence only, never
+/// secret values. Snapshot/TUI cheap reloads use this to avoid carrying a ready
+/// verdict across an edited invocation contract or billing posture.
+pub fn readiness_cache_key(profile: &WorkerProfile, billing: &BillingPolicy) -> String {
+    let invocation = serde_json::to_string(&profile.invocation)
+        .unwrap_or_else(|_| format!("{:?}", profile.invocation));
+    let present = present_billing_env(&billing.blocked_worker_env_names);
+    format!(
+        "{}|{}|{}|{}|{}",
+        profile.id,
+        profile.enabled,
+        billing.worker_invocation.ai_billing_env_policy,
+        present.join(","),
+        invocation
+    )
 }
 
 /// Validate the sandbox declaration used by a planning capability scout.
@@ -199,6 +220,31 @@ pub fn billing_blocked(policy: &str, billing_env_present: usize) -> bool {
     policy == "block" && billing_env_present > 0
 }
 
+/// Static gates that must hold before Yardlet starts either the worker or its
+/// offline version probe. Built-in adapters keep their core-owned command
+/// shapes, while generic workers must also have a structurally valid template.
+pub fn invocation_contract(profile: &WorkerProfile) -> Result<(), String> {
+    if !profile.invocation.supports_noninteractive {
+        return Err(format!(
+            "worker '{}' invocation supports_noninteractive must be true",
+            profile.id
+        ));
+    }
+    let output = profile.invocation.output_contract.trim();
+    match profile.id.as_str() {
+        "codex" | "claude-code" if matches!(output, "files" | "json_or_files") => Ok(()),
+        "codex" | "claude-code" => Err(format!(
+            "worker '{}' has unsupported output_contract '{}'; expected files or json_or_files",
+            profile.id, output
+        )),
+        _ if output != "files" => Err(format!(
+            "worker '{}' generic invocation has unsupported output_contract '{}'; expected files",
+            profile.id, output
+        )),
+        _ => profile.invocation.validate_generic(&profile.id),
+    }
+}
+
 impl WorkerStatus {
     /// The readiness gates as a staged checklist for `yardlet worker status`.
     ///
@@ -213,6 +259,19 @@ impl WorkerStatus {
                 note: "disabled in .agents/workers.yaml".to_string(),
             }];
         }
+
+        let contract = match &self.contract_error {
+            Some(error) => StatusStage {
+                label: "contract",
+                mark: StageMark::Fail,
+                note: error.clone(),
+            },
+            None => StatusStage {
+                label: "contract",
+                mark: StageMark::Pass,
+                note: "non-interactive file-result invocation contract is valid".to_string(),
+            },
+        };
 
         let binary = match &self.binary_path {
             Some(p) => StatusStage {
@@ -230,7 +289,22 @@ impl WorkerStatus {
             },
         };
 
-        let version = match (&self.binary_path, &self.version) {
+        let policy = billing.worker_invocation.ai_billing_env_policy.as_str();
+        let blocked = billing_blocked(policy, self.billing_env_present.len());
+        let version = if self.contract_error.is_some() {
+            StatusStage {
+                label: "version",
+                mark: StageMark::Skipped,
+                note: "invocation contract failed; offline probe was not started".to_string(),
+            }
+        } else if blocked {
+            StatusStage {
+                label: "version",
+                mark: StageMark::Skipped,
+                note: "strict billing policy blocked the offline probe before spawn".to_string(),
+            }
+        } else {
+            match (&self.binary_path, &self.version) {
             (Some(_), Some(v)) => StatusStage {
                 label: "version",
                 mark: StageMark::Pass,
@@ -239,7 +313,7 @@ impl WorkerStatus {
             (Some(_), None) => StatusStage {
                 label: "version",
                 mark: StageMark::Fail,
-                note: "offline `--version` probe failed; resolved CLI or its runtime is unverified"
+                note: "configured offline version probe failed; resolved CLI or its runtime is unverified"
                     .to_string(),
             },
             (None, _) => StatusStage {
@@ -247,9 +321,9 @@ impl WorkerStatus {
                 mark: StageMark::Skipped,
                 note: "no binary to probe".to_string(),
             },
+            }
         };
 
-        let policy = billing.worker_invocation.ai_billing_env_policy.as_str();
         let billing_env = if self.billing_env_present.is_empty() {
             StatusStage {
                 label: "billing-env",
@@ -285,7 +359,7 @@ impl WorkerStatus {
             note: "not verified offline; Yardlet never makes a billed call to check, it relies on the worker's own subscription login".to_string(),
         };
 
-        vec![binary, version, billing_env, auth]
+        vec![contract, binary, version, billing_env, auth]
     }
 
     /// One-line verdict framed as invocation safety under the current policy,
@@ -293,17 +367,21 @@ impl WorkerStatus {
     pub fn invocation_verdict(&self, billing: &BillingPolicy) -> String {
         let policy = billing.worker_invocation.ai_billing_env_policy.as_str();
         match self.readiness {
-            Readiness::Ready if billing_blocked(policy, self.billing_env_present.len()) => {
+            _ if billing_blocked(policy, self.billing_env_present.len()) => {
                 "blocked: strict billing policy refuses to run while AI-billing env is set"
                     .to_string()
             }
+            _ if self.contract_error.is_some() => format!(
+                "not invocable: {}",
+                self.contract_error.as_deref().unwrap_or_default()
+            ),
             Readiness::Ready => {
                 "safe to invoke under current policy (auth not verified offline)".to_string()
             }
             Readiness::Ambiguous => {
                 "not invocable: binary found but unverified (see version gate)".to_string()
             }
-            Readiness::NotReady => "not invocable: worker CLI not installed".to_string(),
+            Readiness::NotReady => format!("not invocable: {}", self.detail),
             Readiness::Disabled => {
                 "not invocable: worker is disabled in .agents/workers.yaml".to_string()
             }
@@ -316,7 +394,7 @@ pub fn find_binary(command: &str) -> Option<PathBuf> {
     // An explicit path is honored as-is.
     if command.contains('/') {
         let p = PathBuf::from(command);
-        return if p.is_file() { Some(p) } else { None };
+        return if is_executable(&p) { Some(p) } else { None };
     }
     let path = env::var_os("PATH")?;
     for dir in env::split_paths(&path) {
@@ -352,7 +430,7 @@ pub fn present_billing_env(blocked: &[String]) -> Vec<String> {
 }
 
 /// Well-known local install locations to fall back to when the PATH-resolved
-/// binary is missing or its `--version` probe fails (e.g. a shell alias or a
+/// binary is missing or its offline version probe fails (e.g. a shell alias or a
 /// wrapper shadows the real CLI in non-interactive shells). These are the
 /// official local install paths for each worker, not host-specific guesses.
 fn fallback_paths(worker_id: &str) -> Vec<PathBuf> {
@@ -371,9 +449,10 @@ fn fallback_paths(worker_id: &str) -> Vec<PathBuf> {
 }
 
 /// Probe one worker's readiness. Does not invoke any provider API. Version
-/// probing runs the local CLI's own `--version`, which is offline.
+/// probing runs the local CLI's configured arguments, which must be offline.
+/// Built-in adapters retain their core-owned `--version` probe.
 ///
-/// Resolution prefers the first candidate whose `--version` succeeds: the
+/// Resolution prefers the first candidate whose version probe succeeds: the
 /// PATH-resolved binary first, then well-known fallback paths. This keeps a
 /// worker usable even when a wrapper shadows the real CLI on PATH.
 pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
@@ -387,6 +466,7 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
             binary_path: None,
             version: None,
             billing_env_present,
+            contract_error: None,
             readiness: Readiness::Disabled,
             detail: "disabled in .agents/workers.yaml".to_string(),
         };
@@ -402,10 +482,49 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
         }
     }
 
-    // Prefer a candidate that passes the offline version probe.
+    let contract_error = invocation_contract(profile).err();
+    if let Some(error) = contract_error {
+        return WorkerStatus {
+            id: profile.id.clone(),
+            command,
+            binary_path: candidates.into_iter().next(),
+            version: None,
+            billing_env_present,
+            contract_error: Some(error.clone()),
+            readiness: Readiness::NotReady,
+            detail: error,
+        };
+    }
+
+    if billing_blocked(
+        &billing.worker_invocation.ai_billing_env_policy,
+        billing_env_present.len(),
+    ) {
+        return WorkerStatus {
+            id: profile.id.clone(),
+            command,
+            binary_path: candidates.into_iter().next(),
+            version: None,
+            billing_env_present,
+            contract_error: None,
+            readiness: Readiness::NotReady,
+            detail: "strict billing policy refuses to start any worker subprocess while AI-billing env is set"
+                .to_string(),
+        };
+    }
+
+    // Prefer a candidate that passes the offline version probe. Generic
+    // profiles own their probe arguments; built-in adapter behavior stays
+    // core-owned and unchanged.
+    let built_in_version_args = vec!["--version".to_string()];
+    let version_args = if matches!(profile.id.as_str(), "codex" | "claude-code") {
+        &built_in_version_args
+    } else {
+        &profile.invocation.version_args
+    };
     let verified = candidates
         .iter()
-        .find_map(|p| read_version(p).map(|v| (p.clone(), v)));
+        .find_map(|p| read_version(p, version_args, billing).map(|v| (p.clone(), v)));
 
     let (binary_path, version, readiness, detail) = match verified {
         Some((path, version)) => {
@@ -423,15 +542,15 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
             (Some(path), Some(version), Readiness::Ready, detail)
         }
         None => match candidates.into_iter().next() {
-            // A binary exists but no candidate passed `--version`: ambiguous.
+            // A binary exists but no candidate passed its version probe: ambiguous.
             Some(path) => (
                 Some(path.clone()),
                 None,
                 Readiness::Ambiguous,
                 format!(
-                    "binary resolved to {} but `--version` failed; the resolved CLI or its runtime \
+                    "binary resolved to {} but the configured offline version probe failed; the resolved CLI or its runtime \
                      is unverified. Set an explicit `command:` path in .agents/workers.yaml or fix \
-                     the login, then retry. Yardlet did not call an AI API and did not ask for an API key.",
+                     the local CLI runtime, then retry. Yardlet did not call an AI API and did not ask for an API key.",
                     path.display()
                 ),
             ),
@@ -455,13 +574,24 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
         binary_path,
         version,
         billing_env_present,
+        contract_error: None,
         readiness,
         detail,
     }
 }
 
-fn read_version(path: &std::path::Path) -> Option<String> {
-    let out = Command::new(path).arg("--version").output().ok()?;
+fn read_version(
+    path: &std::path::Path,
+    version_args: &[String],
+    billing: &BillingPolicy,
+) -> Option<String> {
+    let env = sanitized_worker_env_for(billing, &[]).ok()?;
+    let mut command = Command::new(path);
+    command.args(version_args).env_clear();
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let out = command.output().ok()?;
     if !out.status.success() {
         return None;
     }
@@ -584,6 +714,7 @@ mod tests {
             binary_path: Some(PathBuf::from("/usr/local/bin/codex")),
             version: Some("codex 1.0.0".into()),
             billing_env_present,
+            contract_error: None,
             readiness: Readiness::Ready,
             detail: String::new(),
         }
@@ -620,6 +751,37 @@ invocation:
         assert_eq!(stages.len(), 1);
         assert_eq!(stages[0].label, "enabled");
         assert_eq!(stages[0].mark, StageMark::Disabled);
+    }
+
+    #[test]
+    fn generic_invocation_contract_blocks_false_ready_profiles() {
+        for (yaml, expected) in [
+            (
+                r#"
+id: generic
+invocation:
+  command: bash
+  supports_noninteractive: false
+  output_contract: files
+"#,
+                "supports_noninteractive",
+            ),
+            (
+                r#"
+id: generic
+invocation:
+  command: bash
+  supports_noninteractive: true
+  output_contract: stdout_json
+"#,
+                "output_contract",
+            ),
+        ] {
+            let profile: WorkerProfile = crate::yaml::from_str(yaml).unwrap();
+            let status = probe(&profile, &BillingPolicy::default());
+            assert_eq!(status.readiness, Readiness::NotReady, "{}", status.detail);
+            assert!(status.detail.contains(expected), "{}", status.detail);
+        }
     }
 
     #[test]
@@ -665,7 +827,7 @@ invocation:
     #[test]
     fn capability_readiness_projection_keeps_ready_not_ready_and_disabled_distinct() {
         let workers: crate::schemas::WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nworkers:\n  - id: ready\n    capabilities: [Shell Tool]\n    invocation: { command: bash }\n  - id: absent\n    capabilities: [browser]\n    invocation: { command: yardlet-definitely-missing-command }\n  - id: disabled\n    enabled: false\n    capabilities: [image-generation]\n    invocation: { command: bash }\n",
+            "schema_version: 1\nworkers:\n  - id: ready\n    capabilities: [Shell Tool]\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: absent\n    capabilities: [browser]\n    invocation: { command: yardlet-definitely-missing-command, supports_noninteractive: true, output_contract: files }\n  - id: disabled\n    enabled: false\n    capabilities: [image-generation]\n    invocation: { command: bash }\n",
         )
         .unwrap();
         let projection = capability_readiness_projection(&workers, &BillingPolicy::default());
@@ -674,6 +836,19 @@ invocation:
         assert_eq!(projection[1].readiness, Readiness::NotReady);
         assert_eq!(projection[2].readiness, Readiness::Disabled);
         assert_eq!(projection[0].capabilities, vec!["Shell Tool"]);
+    }
+
+    #[test]
+    fn built_in_adapters_keep_their_existing_file_contracts_invocable() {
+        for (id, output_contract) in [("codex", "files"), ("claude-code", "json_or_files")] {
+            let profile: WorkerProfile = crate::yaml::from_str(&format!(
+                "id: {id}\ninvocation:\n  command: bash\n  supports_noninteractive: true\n  output_contract: {output_contract}\n  version_args: [definitely-not-a-built-in-version-flag]\n"
+            ))
+            .unwrap();
+            let status = probe(&profile, &BillingPolicy::default());
+            assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+            assert!(status.contract_error.is_none());
+        }
     }
 
     #[test]
@@ -695,6 +870,8 @@ invocation:
                 supports_noninteractive: true,
                 output_contract: "files".into(),
                 args: vec!["{run_dir}".into()],
+                prompt_transport: "stdin".into(),
+                version_args: vec!["--version".into()],
                 sandbox_args: sandbox_args.iter().map(|arg| (*arg).into()).collect(),
                 full_access_args: full_access_args.iter().map(|arg| (*arg).into()).collect(),
                 image_args: vec![],

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -3031,7 +3031,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", YARD-PAR-CANON]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", YARD-PAR-CANON]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&worker)
         );
         let mut offender = task("YARD-PAR-CANON", TaskState::Queued, 10, vec![]);
@@ -3597,7 +3597,7 @@ printf "# handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&worker),
             yaml_string(&spawn_marker)
         );
@@ -3820,7 +3820,7 @@ exit 0
 "#,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: dead\n  fallback_order: [dead, builder]\nworkers:\n  - id: dead\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: dead\n  fallback_order: [dead, builder]\nworkers:\n  - id: dead\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&dead),
             yaml_string(&dead_attempts),
             yaml_string(&builder),
@@ -3913,7 +3913,7 @@ exit 0
 "#,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&builder)
         );
         let ws = setup_workspace(
@@ -3998,7 +3998,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", {task_id}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", {task_id}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&worker)
         );
         let mut queued = task(task_id, TaskState::Queued, 10, vec![]);
@@ -4180,7 +4180,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", YARD-PAR-DOWN]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", YARD-PAR-DOWN]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&worker)
         );
         let upstream = task("YARD-UP", TaskState::Done, 5, vec![]);
@@ -4378,7 +4378,7 @@ exit 0
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [\"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             yaml_string(&builder),
             yaml_string(&spawn_marker)
         );

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -2715,6 +2715,7 @@ pub(crate) fn pick_ready_worker(
     order.push("codex".to_string());
 
     let mut tried = Vec::new();
+    let mut failures = Vec::new();
     for id in order {
         if tried.contains(&id) {
             continue;
@@ -2732,10 +2733,11 @@ pub(crate) fn pick_ready_worker(
                 return Ok((profile.clone(), bin, id));
             }
         }
+        failures.push(format!("{id}: {}", status.detail));
     }
 
     Err(anyhow!(
-        "no invocable planning worker among {tried:?}. Run `yardlet worker status` to diagnose. \
+        "no invocable planning worker among {tried:?} ({failures:?}). Run `yardlet worker status` to diagnose. \
          Yardlet did not call an AI API and did not ask for an API key."
     ))
 }
@@ -2954,6 +2956,33 @@ invocation: { command: codex }
         );
         assert_eq!(mixed.model, "gpt-run");
         assert_eq!(mixed.effort, "low");
+    }
+
+    #[test]
+    fn planning_worker_selection_preserves_the_shared_guard_failure_reason() {
+        let workers: WorkersFile = crate::yaml::from_str(
+            r#"
+schema_version: 1
+workers:
+  - id: generic-planner
+    invocation:
+      command: bash
+      supports_noninteractive: false
+      output_contract: files
+routing:
+  planning_gate:
+    primary: generic-planner
+    fallback: ""
+"#,
+        )
+        .unwrap();
+
+        let error = pick_ready_worker(&workers, &crate::schemas::BillingPolicy::default(), None)
+            .expect_err("non-interactive contract failure must block planning selection");
+        assert!(
+            error.to_string().contains("supports_noninteractive"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -3410,6 +3439,8 @@ workers:
     capabilities: []
     invocation:
       command: '{}'
+      supports_noninteractive: true
+      output_contract: files
       args: ['{{run_dir}}']
       sandbox_args: [sandboxed]
       full_access_args: [full]
@@ -3524,6 +3555,8 @@ workers:
     capabilities: []
     invocation:
       command: '{}'
+      supports_noninteractive: true
+      output_contract: files
       args: ['{{run_dir}}']
       sandbox_args: [sandboxed]
       full_access_args: [full]
@@ -3894,6 +3927,8 @@ workers:
     capabilities: []
     invocation:
       command: '{}'
+      supports_noninteractive: true
+      output_contract: files
       args: ['{{run_dir}}']
       sandbox_args: [sandboxed]
       full_access_args: [full]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -125,9 +125,9 @@ pub fn resolve_worker_for_task(
             candidate.reason,
             std::slice::from_ref(&pinned),
         )
-        .map_err(|_| {
+        .map_err(|error| {
             anyhow!(
-                "preferred worker '{pinned}' is not invocable; cross-worker fallback requires explicit opt-in with routing.allow_preferred_worker_failover"
+                "preferred worker '{pinned}' is not invocable: {error}; cross-worker fallback requires explicit opt-in with routing.allow_preferred_worker_failover"
             )
         })?
     } else {
@@ -369,6 +369,7 @@ fn resolve_order(
     order: &[String],
 ) -> Result<Resolved> {
     let mut tried = Vec::new();
+    let mut failures = Vec::new();
     for id in order {
         let Some(profile) = workers.workers.iter().find(|w| &w.id == id) else {
             continue;
@@ -395,9 +396,10 @@ fn resolve_order(
                 });
             }
         }
+        failures.push(format!("{id}: {}", status.detail));
     }
     Err(anyhow!(
-        "no invocable worker among {tried:?}. Run `yardlet worker status` to diagnose. \
+        "no invocable worker among {tried:?} ({failures:?}). Run `yardlet worker status` to diagnose. \
          Yardlet did not call an AI API and did not ask for an API key."
     ))
 }
@@ -630,7 +632,7 @@ mod tests {
     #[test]
     fn dispatch_rejects_exact_lineage_worker_model_and_fallback_conflicts() {
         let workers: WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation: { command: bash }\n",
+            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
         )
         .unwrap();
         let exact = || -> Task {
@@ -759,7 +761,7 @@ mod tests {
     #[test]
     fn failover_excludes_failed_worker_and_keeps_capability_gate() {
         let w: WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, second, third]\nworkers:\n  - id: first\n    capabilities: [image_generation]\n    invocation: { command: bash }\n  - id: second\n    capabilities: [image_generation]\n    invocation: { command: bash }\n  - id: third\n    invocation: { command: bash }\n",
+            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, second, third]\nworkers:\n  - id: first\n    capabilities: [image_generation]\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: second\n    capabilities: [image_generation]\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: third\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
         )
         .unwrap();
         let task: Task =
@@ -772,7 +774,7 @@ mod tests {
         assert_eq!(resolved.worker_id, "second");
 
         let w_without_alternate: WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, third]\nworkers:\n  - id: first\n    capabilities: [image_generation]\n    invocation: { command: bash }\n  - id: third\n    invocation: { command: bash }\n",
+            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, third]\nworkers:\n  - id: first\n    capabilities: [image_generation]\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: third\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
         )
         .unwrap();
         let err = resolve_failover_worker_for_task(
@@ -792,7 +794,7 @@ mod tests {
     #[test]
     fn preferred_worker_failover_requires_explicit_opt_in() {
         let mut w: WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, second]\nworkers:\n  - id: first\n    invocation: { command: bash }\n  - id: second\n    invocation: { command: bash }\n",
+            "schema_version: 1\nrouting:\n  default_worker: first\n  fallback_order: [first, second]\nworkers:\n  - id: first\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: second\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
         )
         .unwrap();
         let task: Task = crate::yaml::from_str(
@@ -819,7 +821,7 @@ mod tests {
     #[test]
     fn preferred_worker_initial_resolution_requires_explicit_fallback_opt_in() {
         let mut workers: WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nrouting:\n  default_worker: ready\n  fallback_order: [missing, ready]\nworkers:\n  - id: missing\n    invocation: { command: yardlet-definitely-missing-worker-command }\n  - id: ready\n    invocation: { command: bash }\n",
+            "schema_version: 1\nrouting:\n  default_worker: ready\n  fallback_order: [missing, ready]\nworkers:\n  - id: missing\n    invocation: { command: yardlet-definitely-missing-worker-command, supports_noninteractive: true, output_contract: files }\n  - id: ready\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
         )
         .unwrap();
         let task: Task = crate::yaml::from_str(
@@ -851,7 +853,7 @@ mod tests {
     #[test]
     fn failover_uses_remaining_order_for_readiness_without_readding_failed_worker() {
         let w: WorkersFile = crate::yaml::from_str(
-            "schema_version: 1\nrouting:\n  default_worker: failed\n  fallback_order: [failed, missing, ready]\nworkers:\n  - id: failed\n    invocation: { command: bash }\n  - id: missing\n    invocation: { command: yardlet-definitely-missing-worker-command }\n  - id: ready\n    invocation: { command: bash }\n",
+            "schema_version: 1\nrouting:\n  default_worker: failed\n  fallback_order: [failed, missing, ready]\nworkers:\n  - id: failed\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: missing\n    invocation: { command: yardlet-definitely-missing-worker-command, supports_noninteractive: true, output_contract: files }\n  - id: ready\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
         )
         .unwrap();
         let task: Task = crate::yaml::from_str("id: T\ntitle: t\n").unwrap();

--- a/src/run.rs
+++ b/src/run.rs
@@ -11067,7 +11067,7 @@ fi
         let root = std::env::temp_dir().join(format!("yard-feedback-auto-{}", std::process::id()));
         let attempts = root.join("attempts");
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker),
             shell_literal(&attempts),
             shell_literal(&root)
@@ -11077,7 +11077,7 @@ fi
         // Rebuild the profile with paths inside the actual workspace returned
         // by init_test_workspace.
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker),
             shell_literal(&attempts),
             shell_literal(&ws.root)
@@ -11192,7 +11192,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", \"YARD-012\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", \"YARD-012\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder),
             shell_literal(&spawn_marker)
         );
@@ -11467,7 +11467,7 @@ printf "# handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder)
         );
         let ws = init_test_workspace("intentless-serial-run", &worker_yaml);
@@ -11635,7 +11635,7 @@ printf "# handoff\n" > "$run_dir/handoff.md"
 
         let ws = init_test_workspace(
             &format!("serial-post-create-error-cleanup-{attempt}"),
-            "schema_version: 1\nrouting: {default_worker: builder}\nworkers:\n  - id: builder\n    invocation: {command: bash}\n",
+            "schema_version: 1\nrouting: {default_worker: builder}\nworkers:\n  - id: builder\n    invocation: {command: bash, supports_noninteractive: true, output_contract: files}\n",
         );
         ws.save_queue(&queue(vec![task(
             "YARD-POST-CREATE-ERR",
@@ -11729,7 +11729,7 @@ exit 0
         write_str(
             &ws.workers_path(),
             &format!(
-                "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+                "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
                 shell_literal(&worker)
             ),
         )
@@ -11777,7 +11777,7 @@ exit 0
 "#,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker)
         );
         let ws = init_test_workspace("serial-import-error-cleanup", &worker_yaml);
@@ -11847,7 +11847,7 @@ printf '# handoff\n' > "$run_dir/handoff.md"
 "#,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker)
         );
         let ws = init_test_workspace("receipt-persist-error", &worker_yaml);
@@ -11964,7 +11964,7 @@ exit 1
         write_str(
             &ws.workers_path(),
             &format!(
-                "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+                "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
                 shell_literal(&worker),
                 shell_literal(&ws.runs_dir())
             ),
@@ -12035,7 +12035,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder),
             shell_literal(&payload)
         );
@@ -12272,7 +12272,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder), task_id, mode
         );
         let ws = init_test_workspace(name, &worker_yaml);
@@ -12517,7 +12517,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker),
             shell_literal(&spawn_marker)
         );
@@ -12738,7 +12738,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker),
             shell_literal(&owning_root)
         );
@@ -12903,7 +12903,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker),
             shell_literal(&owning_root)
         );
@@ -12998,7 +12998,7 @@ printf "# worker handoff
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker)
         );
         let ws = init_test_workspace("review-artifact", &worker_yaml);
@@ -13873,7 +13873,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&worker),
             shell_literal(&spawn_marker)
         );
@@ -14430,7 +14430,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         );
         let run_case = |name: &str, task_id: &str, mutate_seed: &str| {
             let worker_yaml = format!(
-                "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+                "schema_version: 1\nrouting:\n  default_worker: builder\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}, {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
                 shell_literal(&builder), task_id, mutate_seed
             );
             let ws = init_test_workspace(name, &worker_yaml);
@@ -14558,7 +14558,7 @@ exit 0
         std::fs::set_permissions(&fake_codex, permissions).unwrap();
 
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    invocation:\n      command: {}\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\nworkers:\n  - id: codex\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&fake_codex)
         );
         let ws = init_test_workspace("codex-session-report", &worker_yaml);
@@ -14629,7 +14629,7 @@ printf "merge_conflict\n" > "$run_dir/partial-reason"
 "##,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting: {{default_worker: builder}}\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder)
         );
         let ws = init_test_workspace("worker-forged-cancel", &worker_yaml);
@@ -14714,7 +14714,7 @@ exit 0
 "#,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: dead\n  fallback_order: [dead, builder]\nworkers:\n  - id: dead\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: dead\n  fallback_order: [dead, builder]\nworkers:\n  - id: dead\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&dead),
             shell_literal(&builder)
         );
@@ -14809,7 +14809,7 @@ exit 0
             ),
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\n  fallback_order: [builder]\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\n  fallback_order: [builder]\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder)
         );
         let ws = init_test_workspace("approval-gate", &worker_yaml);
@@ -14925,7 +14925,7 @@ exit 0
             ),
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: builder\n  fallback_order: [builder]\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: builder\n  fallback_order: [builder]\nworkers:\n  - id: builder\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&builder)
         );
         let ws = init_test_workspace("auto-approval-retry", &worker_yaml);
@@ -15033,7 +15033,7 @@ exit 0
             ),
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: bad-result\n  fallback_order: [bad-result, fallback]\nworkers:\n  - id: bad-result\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fallback\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: bad-result\n  fallback_order: [bad-result, fallback]\nworkers:\n  - id: bad-result\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fallback\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\"]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&bad),
             shell_literal(&fallback)
         );
@@ -15095,7 +15095,7 @@ exit 1
 "#,
         );
         let worker_yaml = format!(
-            "schema_version: 1\nrouting:\n  default_worker: dead\n  fallback_order: [dead, missing]\nworkers:\n  - id: dead\n    invocation:\n      command: bash\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: missing\n    invocation:\n      command: yardlet-definitely-missing-worker-command\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
+            "schema_version: 1\nrouting:\n  default_worker: dead\n  fallback_order: [dead, missing]\nworkers:\n  - id: dead\n    invocation:\n      command: bash\n      supports_noninteractive: true\n      output_contract: files\n      args: [{}, \"{{run_dir}}\", {}]\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: missing\n    invocation:\n      command: yardlet-definitely-missing-worker-command\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n",
             shell_literal(&dead),
             shell_literal(&attempts)
         );

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1959,6 +1959,9 @@ pub const MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES: usize = 256;
 impl WorkersFile {
     pub fn validate(&self) -> Result<(), String> {
         for worker in &self.workers {
+            if !matches!(worker.id.as_str(), "codex" | "claude-code") {
+                worker.invocation.validate_generic(&worker.id)?;
+            }
             validate_output_contract_patterns(
                 &worker.id,
                 "provider refusal",
@@ -2176,11 +2179,27 @@ pub struct Invocation {
     pub output_contract: String,
     /// Generic adapter template for workers without a built-in adapter
     /// (codex and claude-code have first-class ones; any other id uses these).
-    /// Placeholders: `{run_dir}`, `{model}`, `{effort}`, `{image}`. The task
-    /// packet always arrives on stdin; the binary must support `--version`
-    /// (the readiness probe) and be able to write files in the workspace.
+    /// Placeholders: `{run_dir}`, `{model}`, `{effort}`, `{image}`, and, for
+    /// argument prompt transport, exactly one `{prompt}`. The binary must be
+    /// able to write result files in the workspace.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
+    /// How a generic adapter receives the compiled task packet: `stdin`
+    /// (legacy/default) or `argument` (`arg` is accepted as an alias). Argument
+    /// transport expands exactly one `{prompt}` in `args` without a shell.
+    #[serde(
+        default = "default_prompt_transport",
+        skip_serializing_if = "is_default_prompt_transport"
+    )]
+    pub prompt_transport: String,
+    /// Arguments for the local, offline readiness probe. Missing keeps the
+    /// legacy `--version` behavior. An explicitly empty list is invalid because
+    /// Yardlet must not guess whether a bare command is a safe offline probe.
+    #[serde(
+        default = "default_version_args",
+        skip_serializing_if = "is_default_version_args"
+    )]
+    pub version_args: Vec<String>,
     /// Appended when running sandboxed (the default access level).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sandbox_args: Vec<String>,
@@ -2202,6 +2221,101 @@ pub struct Invocation {
     /// itself never reads or stores the values.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pass_env: Vec<String>,
+}
+
+fn default_prompt_transport() -> String {
+    "stdin".to_string()
+}
+
+fn is_default_prompt_transport(transport: &String) -> bool {
+    transport == "stdin"
+}
+
+fn default_version_args() -> Vec<String> {
+    vec!["--version".to_string()]
+}
+
+fn is_default_version_args(args: &Vec<String>) -> bool {
+    args == &["--version"]
+}
+
+impl Invocation {
+    pub fn prompt_on_stdin(&self) -> bool {
+        self.prompt_transport.trim() == "stdin"
+    }
+
+    /// Validate only the generic adapter's structural template. Runtime
+    /// invocability (`supports_noninteractive`, output contract, binary,
+    /// offline probe, billing policy) belongs to the shared guard so status,
+    /// routing, planning, capability projection, and the TUI see one verdict.
+    pub fn validate_generic(&self, worker_id: &str) -> Result<(), String> {
+        if self.command.trim().is_empty() {
+            return Err(format!(
+                "worker '{worker_id}' generic invocation command must not be empty"
+            ));
+        }
+        if self.version_args.is_empty() || self.version_args.iter().any(|arg| arg.is_empty()) {
+            return Err(format!(
+                "worker '{worker_id}' generic version_args must contain a configured offline probe"
+            ));
+        }
+        validate_invocation_args(worker_id, "version_args", &self.version_args, false, false)?;
+        validate_invocation_args(worker_id, "args", &self.args, true, true)?;
+        for (label, args) in [
+            ("sandbox_args", &self.sandbox_args),
+            ("full_access_args", &self.full_access_args),
+            ("image_args", &self.image_args),
+            ("model_args", &self.model_args),
+            ("effort_args", &self.effort_args),
+        ] {
+            validate_invocation_args(worker_id, label, args, true, false)?;
+        }
+
+        let prompt_count = self
+            .args
+            .iter()
+            .map(|arg| arg.matches("{prompt}").count())
+            .sum::<usize>();
+        match self.prompt_transport.trim() {
+            "stdin" if prompt_count == 0 => Ok(()),
+            "stdin" => Err(format!(
+                "worker '{worker_id}' uses prompt_transport stdin, so args must not contain {{prompt}}"
+            )),
+            "argument" | "arg" if prompt_count == 1 => Ok(()),
+            "argument" | "arg" => Err(format!(
+                "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in args"
+            )),
+            other => Err(format!(
+                "worker '{worker_id}' has unsupported prompt_transport '{other}'; expected stdin or argument"
+            )),
+        }
+    }
+}
+
+fn validate_invocation_args(
+    worker_id: &str,
+    label: &str,
+    args: &[String],
+    allow_runtime_placeholders: bool,
+    allow_prompt: bool,
+) -> Result<(), String> {
+    for arg in args {
+        let mut remainder = arg.clone();
+        if allow_runtime_placeholders {
+            for placeholder in ["{run_dir}", "{model}", "{effort}", "{image}"] {
+                remainder = remainder.replace(placeholder, "");
+            }
+        }
+        if allow_prompt {
+            remainder = remainder.replace("{prompt}", "");
+        }
+        if remainder.contains('{') || remainder.contains('}') {
+            return Err(format!(
+                "worker '{worker_id}' {label} contains an unknown placeholder in {arg:?}"
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3733,6 +3847,51 @@ delivery: auto
         workers.workers[0].provider_response_refusal_patterns =
             vec!["x".repeat(MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES + 1)];
         assert!(workers.validate().is_err());
+    }
+
+    #[test]
+    fn generic_prompt_transport_schema_rejects_ambiguous_packet_delivery() {
+        let valid_legacy: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      args: [run]\n",
+        )
+        .unwrap();
+        valid_legacy.validate().unwrap();
+        assert_eq!(valid_legacy.workers[0].invocation.prompt_transport, "stdin");
+        assert_eq!(
+            valid_legacy.workers[0].invocation.version_args,
+            ["--version"]
+        );
+
+        let valid_argument: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: argument\n      args: [run, '{prompt}']\n",
+        )
+        .unwrap();
+        valid_argument.validate().unwrap();
+
+        for (yaml, expected) in [
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: shell\n      args: [run]\n",
+                "prompt_transport",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: argument\n      args: [run]\n",
+                "exactly one {prompt}",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: stdin\n      args: [run, '{prompt}']\n",
+                "stdin",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      args: [run, '{unknown_packet}']\n",
+                "unknown placeholder",
+            ),
+        ] {
+            let workers: WorkersFile = crate::yaml::from_str(yaml).unwrap();
+            let error = workers
+                .validate()
+                .expect_err("ambiguous generic prompt transport must fail validation");
+            assert!(error.contains(expected), "{error:?} does not contain {expected:?}");
+        }
     }
 
     #[test]

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -208,6 +208,11 @@ pub struct WorkerLine {
     pub model: String,
     pub detail: String,
     pub enabled: bool,
+    /// Non-public cache identity for the invocation/billing inputs that produced
+    /// this readiness result. Prevents a cheap TUI reload from reusing stale
+    /// ready state after workers.yaml or billing posture changes.
+    #[serde(skip)]
+    pub readiness_cache_key: String,
 }
 
 impl Snapshot {
@@ -268,6 +273,7 @@ impl Snapshot {
             .workers
             .iter()
             .map(|p| {
+                let readiness_cache_key = guard::readiness_cache_key(p, &billing);
                 if !p.enabled {
                     return WorkerLine {
                         id: p.id.clone(),
@@ -278,16 +284,21 @@ impl Snapshot {
                         model: p.model.clone(),
                         detail: "disabled (toggle on the Home workers panel)".to_string(),
                         enabled: false,
+                        readiness_cache_key,
                     };
                 }
                 if let Some(c) = cached_workers.as_ref().and_then(|cw| {
-                    cw.iter()
-                        .find(|w| w.id == p.id && w.readiness != "disabled")
+                    cw.iter().find(|w| {
+                        w.id == p.id
+                            && w.readiness != "disabled"
+                            && w.readiness_cache_key == readiness_cache_key
+                    })
                 }) {
                     return WorkerLine {
                         enabled: true,
                         model: p.model.clone(),
                         billing_blocked: guard::billing_blocked(&policy, c.billing_env_present),
+                        readiness_cache_key,
                         ..c.clone()
                     };
                 }
@@ -302,6 +313,7 @@ impl Snapshot {
                     model: p.model.clone(),
                     detail: s.detail,
                     enabled: true,
+                    readiness_cache_key,
                 }
             })
             .collect();
@@ -800,6 +812,7 @@ current_intent: ""
                 binary_path: Some("/fixture/slow".into()),
                 version: Some("fixture 1.0".into()),
                 billing_env_present: Vec::new(),
+                contract_error: None,
                 readiness: crate::guard::Readiness::Ready,
                 detail: "injected readiness".into(),
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4479,12 +4479,14 @@ routing:
     }
 
     fn cached_snapshot(ws: &Workspace) -> Snapshot {
+        let billing = ws.load_billing().unwrap();
         let workers = ws
             .load_workers()
             .unwrap()
             .workers
             .into_iter()
             .map(|worker| crate::snapshot::WorkerLine {
+                readiness_cache_key: crate::guard::readiness_cache_key(&worker, &billing),
                 id: worker.id,
                 readiness: "invocable".into(),
                 version: Some("fixture 1.0".into()),
@@ -4524,7 +4526,7 @@ routing:
         std::fs::write(
             ws.workers_path(),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\nrouting: {{}}\n",
+                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\nrouting: {{}}\n",
                 probe.display()
             ),
         )
@@ -4550,6 +4552,39 @@ routing:
             Some("fixture 2.0"),
             "explicit refresh must run a fresh readiness probe"
         );
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cheap_reload_invalidates_readiness_when_the_invocation_contract_changes() {
+        let ws = workspace_with_user_config("invocation-contract-cache");
+        let probe = ws.root.join("fixture-worker");
+        write_version_probe(&probe, "fixture 1.0");
+        let workers = |supports_noninteractive: bool| {
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\n      supports_noninteractive: {}\n      output_contract: files\nrouting: {{}}\n",
+                probe.display(), supports_noninteractive
+            )
+        };
+        std::fs::write(ws.workers_path(), workers(true)).unwrap();
+
+        let mut app = App::new(ws.clone());
+        assert_eq!(
+            app.snapshot.as_ref().unwrap().workers[0].readiness,
+            "invocable"
+        );
+
+        std::fs::write(ws.workers_path(), workers(false)).unwrap();
+        app.reload();
+        assert_eq!(
+            app.snapshot.as_ref().unwrap().workers[0].readiness,
+            "not ready",
+            "a changed static invocation contract must not inherit cached ready state"
+        );
+        assert!(app.snapshot.as_ref().unwrap().workers[0]
+            .detail
+            .contains("supports_noninteractive"));
         let _ = std::fs::remove_dir_all(ws.root);
     }
 

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 
+use crate::guard;
 use crate::schemas::{
     ChannelEventType, Invocation, OutputContractCause, RawEventRef, ResolvedWorkerSelection,
     RoutingProvenance, WorkerOutputLogSpan, WorkerProfile,
@@ -626,24 +627,28 @@ pub fn build_command(
 
 /// Build the command for a worker WITHOUT a built-in adapter, from the
 /// invocation template in its workers.yaml profile. This is what makes a
-/// third worker a pure-config addition: packet on stdin, args from the
-/// template, placeholders expanded.
+/// third worker a pure-config addition: packet on stdin or in one argument,
+/// args from the template, placeholders expanded without a shell.
 #[allow(clippy::too_many_arguments)]
 pub fn build_generic_command(
     inv: &Invocation,
     bin: &Path,
+    packet: &str,
     run_dir: &Path,
     cwd: &Path,
     full_access: bool,
     model: &str,
     effort: &str,
     images: &[String],
-) -> Command {
+) -> Result<Command> {
+    inv.validate_generic("generic worker")
+        .map_err(anyhow::Error::msg)?;
     let expand = |arg: &str, image: &str| -> String {
         arg.replace("{run_dir}", &run_dir.display().to_string())
             .replace("{model}", model)
             .replace("{effort}", effort)
             .replace("{image}", image)
+            .replace("{prompt}", packet)
     };
     let mut cmd = Command::new(bin);
     for a in &inv.args {
@@ -674,7 +679,7 @@ pub fn build_generic_command(
     }
     cmd.current_dir(cwd);
     cmd.env_clear();
-    cmd
+    Ok(cmd)
 }
 
 /// Build the command to RESUME an existing worker session (continue, not redo).
@@ -1057,6 +1062,10 @@ fn spawn_internal(
     // while `output_log` and worker.pid remain owned by the main Yardlet
     // process in the canonical run directory.
     let control_run_dir = output_log.parent().unwrap_or(cwd);
+    guard::invocation_contract(profile).map_err(anyhow::Error::msg)?;
+    let packet_on_stdin = resume
+        || matches!(profile.id.as_str(), "codex" | "claude-code")
+        || profile.invocation.prompt_on_stdin();
     let mut cmd = if resume {
         build_resume_command(
             &profile.id,
@@ -1086,13 +1095,14 @@ fn spawn_internal(
             _ => build_generic_command(
                 &profile.invocation,
                 bin,
+                packet,
                 worker_run_dir,
                 cwd,
                 full_access,
                 &profile.model,
                 &profile.effort,
                 images,
-            ),
+            )?,
         };
         // Set a stable session id on a fresh claude run so a transient failure
         // can resume the same conversation instead of redoing the work.
@@ -1110,7 +1120,11 @@ fn spawn_internal(
     // not a security boundary, but avoids a stale inherited PWD pointing
     // relative worker operations at the Yardlet parent workspace.
     cmd.env("PWD", cwd);
-    cmd.stdin(Stdio::piped());
+    if packet_on_stdin {
+        cmd.stdin(Stdio::piped());
+    } else {
+        cmd.stdin(Stdio::null());
+    }
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
     // A worker must outlive the terminal that started it. Yardlet's contract is
@@ -1277,9 +1291,11 @@ fn spawn_internal(
         return Err(error).context("recording worker PID projection");
     }
 
-    if let Some(mut stdin) = child.stdin.take() {
-        // Best-effort: a worker that ignores stdin will simply not receive it.
-        let _ = stdin.write_all(packet.as_bytes());
+    if packet_on_stdin {
+        if let Some(mut stdin) = child.stdin.take() {
+            // Best-effort: a worker that ignores stdin will simply not receive it.
+            let _ = stdin.write_all(packet.as_bytes());
+        }
     }
 
     // Stream BOTH stdout and stderr to the log as they arrive, so a Run Monitor
@@ -2009,6 +2025,7 @@ mod tests {
             r#"
 command: mytool
 supports_noninteractive: true
+output_contract: files
 args: ["run", "--json", "--out", "{run_dir}"]
 sandbox_args: ["--sandbox"]
 full_access_args: ["--yolo"]
@@ -2020,16 +2037,20 @@ image_args: ["-i", "{image}"]
         .unwrap();
         let (bin, run, cwd) = (Path::new("mytool"), Path::new("/tmp/r"), Path::new("/tmp"));
 
-        let sandboxed = args_of(&build_generic_command(
-            &inv,
-            bin,
-            run,
-            cwd,
-            false,
-            "m-1",
-            "high",
-            &["a.png".to_string()],
-        ));
+        let sandboxed = args_of(
+            &build_generic_command(
+                &inv,
+                bin,
+                "packet",
+                run,
+                cwd,
+                false,
+                "m-1",
+                "high",
+                &["a.png".to_string()],
+            )
+            .unwrap(),
+        );
         assert_eq!(
             sandboxed,
             vec![
@@ -2048,16 +2069,9 @@ image_args: ["-i", "{image}"]
         );
 
         // Full access swaps the access args; auto model/effort add nothing.
-        let full = args_of(&build_generic_command(
-            &inv,
-            bin,
-            run,
-            cwd,
-            true,
-            "auto",
-            "",
-            &[],
-        ));
+        let full = args_of(
+            &build_generic_command(&inv, bin, "packet", run, cwd, true, "auto", "", &[]).unwrap(),
+        );
         assert_eq!(full, vec!["run", "--json", "--out", "/tmp/r", "--yolo"]);
     }
 
@@ -2343,7 +2357,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         std::fs::set_permissions(&fake_codex, permissions).unwrap();
 
         let profile: WorkerProfile = crate::yaml::from_str(
-            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+            "id: codex\ninvocation: {command: codex, supports_noninteractive: true, output_contract: files}\nlimits: {max_wall_minutes: 1}\n",
         )
         .unwrap();
         let log = root.join("worker-output.log");
@@ -2397,7 +2411,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         std::fs::set_permissions(&fake_codex, permissions).unwrap();
 
         let profile: WorkerProfile = crate::yaml::from_str(
-            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+            "id: codex\ninvocation: {command: codex, supports_noninteractive: true, output_contract: files}\nlimits: {max_wall_minutes: 1}\n",
         )
         .unwrap();
         let outcome = spawn(
@@ -2538,7 +2552,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         std::fs::set_permissions(&fake_codex, permissions).unwrap();
 
         let profile: WorkerProfile = crate::yaml::from_str(
-            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+            "id: codex\ninvocation: {command: codex, supports_noninteractive: true, output_contract: files}\nlimits: {max_wall_minutes: 1}\n",
         )
         .unwrap();
         let capture = AttemptCapture {
@@ -2629,7 +2643,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         std::fs::set_permissions(&fake_codex, permissions).unwrap();
 
         let profile: WorkerProfile = crate::yaml::from_str(
-            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+            "id: codex\ninvocation: {command: codex, supports_noninteractive: true, output_contract: files}\nlimits: {max_wall_minutes: 1}\n",
         )
         .unwrap();
         let capture = AttemptCapture {
@@ -2718,7 +2732,7 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         ));
         std::fs::create_dir_all(&root).unwrap();
         let profile: WorkerProfile = crate::yaml::from_str(
-            "id: codex\ninvocation: {command: codex}\nlimits: {max_wall_minutes: 1}\n",
+            "id: codex\ninvocation: {command: codex, supports_noninteractive: true, output_contract: files}\nlimits: {max_wall_minutes: 1}\n",
         )
         .unwrap();
 
@@ -2847,6 +2861,8 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
 id: fixture
 invocation:
   command: sh
+  supports_noninteractive: true
+  output_contract: files
   args: ["-c", "printf stdout-only; printf stderr-only >&2"]
 limits: {max_wall_minutes: 1}
 "#,

--- a/templates/agents/workers.yaml
+++ b/templates/agents/workers.yaml
@@ -106,6 +106,31 @@ workers:
       max_wall_minutes: 45
       max_retries: 1
 
+  # Generic CLI example. Uncomment and customize the whole block.
+  # Existing profiles may omit prompt_transport to send the packet on stdin
+  # and omit version_args to probe with --version.
+  # - id: mytool
+  #   kind: cli_worker
+  #   best_for: "tasks this CLI handles well"
+  #   billing:
+  #     mode: subscription_backed_only
+  #   invocation:
+  #     command: mytool
+  #     supports_noninteractive: true
+  #     output_contract: files
+  #     version_args: ["version", "--offline"]
+  #     prompt_transport: argument
+  #     # {prompt} is exactly one argv item. Yardlet never builds a shell string.
+  #     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
+  #     sandbox_args: ["--sandbox"]
+  #     full_access_args: ["--full-access"]
+  #     model_args: ["--model", "{model}"]
+  #     effort_args: ["--effort", "{effort}"]
+  #     image_args: ["--image", "{image}"]
+  #   limits:
+  #     max_wall_minutes: 45
+  #     max_retries: 1
+
 routing:
   # The human cost dial the planner weighs: cheap | balanced | quality.
   cost_bias: balanced

--- a/tests/fixtures/v010_001a_serial_git_finish/scripts/run.sh
+++ b/tests/fixtures/v010_001a_serial_git_finish/scripts/run.sh
@@ -278,21 +278,29 @@ workers:
   - id: builder
     invocation:
       command: bash
+      supports_noninteractive: true
+      output_contract: files
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-001, builder, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
   - id: reviewer
     invocation:
       command: bash
+      supports_noninteractive: true
+      output_contract: files
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-002, reviewer, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
   - id: remediator
     invocation:
       command: bash
+      supports_noninteractive: true
+      output_contract: files
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-004, remediator, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
   - id: rereviewer
     invocation:
       command: bash
+      supports_noninteractive: true
+      output_contract: files
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-003, rereviewer, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
 EOF

--- a/tests/generic_worker_contract_process.rs
+++ b/tests/generic_worker_contract_process.rs
@@ -1,0 +1,359 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Fixture {
+    root: PathBuf,
+    capture: PathBuf,
+    binary: PathBuf,
+    worker: PathBuf,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let stem = format!(
+            "yardlet-generic-contract-{label}-{}-{nonce}",
+            std::process::id()
+        );
+        let root = std::env::temp_dir().join(&stem);
+        let capture = std::env::temp_dir().join(format!("{stem}-capture"));
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&capture).unwrap();
+        let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+
+        must_succeed(&root, Path::new("git"), &["init", "-q"]);
+        must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["config", "user.email", "fixture@example.invalid"],
+        );
+        fs::write(root.join("README.md"), "fixture\n").unwrap();
+        must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+        must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+        must_succeed(&root, &binary, &["init"]);
+
+        let worker = root.join("fixture-worker.sh");
+        write_worker(&worker, &capture);
+        must_succeed(&root, Path::new("git"), &["add", "fixture-worker.sh"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["commit", "-qm", "fixture worker"],
+        );
+        write_task(&root);
+
+        Self {
+            root,
+            capture,
+            binary,
+            worker,
+        }
+    }
+
+    fn configure(&self, invocation: &str, billing_policy: &str) {
+        fs::write(
+            self.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n{}    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n  allow_preferred_worker_failover: false\n",
+                self.worker.display(), invocation
+            ),
+        )
+        .unwrap();
+        fs::write(
+            self.root.join(".agents/billing-policy.yaml"),
+            format!(
+                "schema_version: 1\nmode: zero_key_subscription_workers\nworker_invocation:\n  ai_billing_env_policy: {billing_policy}\nblocked_worker_env_names: [YARD_GENERIC_CONTRACT_SECRET]\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn run_with_secret(&self, args: &[&str]) -> Output {
+        Command::new(&self.binary)
+            .args(args)
+            .current_dir(&self.root)
+            .env("YARD_GENERIC_CONTRACT_SECRET", "must-not-reach-worker")
+            .output()
+            .unwrap()
+    }
+
+    fn latest_run(&self) -> PathBuf {
+        let mut runs = fs::read_dir(self.root.join(".agents/runs"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.join("task-packet.md").is_file())
+            .collect::<Vec<_>>();
+        runs.sort();
+        runs.pop().expect("fixture run exists")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+        let _ = fs::remove_dir_all(&self.capture);
+    }
+}
+
+fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()));
+    assert!(
+        output.status.success(),
+        "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        program.display(),
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn write_task(root: &Path) {
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-generic-contract\nsummary: generic contract fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-generic-contract\nintent_id: intent-generic-contract\ntasks:\n  - id: YARD-001\n    title: generic contract fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [packet delivered exactly once]\n",
+    )
+    .unwrap();
+}
+
+fn write_worker(path: &Path, capture: &Path) {
+    let script = format!(
+        r#"#!/bin/sh
+set -eu
+capture={capture:?}
+printf '%s\0' "$@" > "$capture/last-argv"
+if [ "${{YARD_GENERIC_CONTRACT_SECRET+x}}" = x ]; then
+  printf present > "$capture/last-secret"
+else
+  printf absent > "$capture/last-secret"
+fi
+if [ "${{1:-}}" = probe ] && [ "${{2:-}}" = offline ]; then
+  cp "$capture/last-argv" "$capture/probe-argv"
+  cp "$capture/last-secret" "$capture/probe-secret"
+  printf 'fixture-worker 1.0\n'
+  exit 0
+fi
+if [ "${{1:-}}" = probe ] && [ "${{2:-}}" = fail ]; then
+  cp "$capture/last-argv" "$capture/probe-argv"
+  cp "$capture/last-secret" "$capture/probe-secret"
+  exit 42
+fi
+if [ "${{1:-}}" = --version ]; then
+  cp "$capture/last-argv" "$capture/probe-argv"
+  cp "$capture/last-secret" "$capture/probe-secret"
+  printf 'fixture-worker legacy-probe\n'
+  exit 0
+fi
+printf invoked > "$capture/invoked"
+run_dir="$2"
+printf '%s' "${{3:-}}" > "$capture/prompt-argument"
+cat > "$capture/stdin"
+run_id="$(basename "$run_dir")"
+cat > "$run_dir/result.json" <<EOF
+{{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {{"drift_detected": false, "notes": ""}},
+  "changes": {{"files_modified": [], "files_created": [], "files_deleted": []}},
+  "validation": {{"commands_run": [], "passed": true, "failures": []}},
+  "question_for_user": null,
+  "compact_summary": "generic fixture complete",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}}
+EOF
+printf '# Generic worker handoff\n' > "$run_dir/handoff.md"
+"#,
+        capture = capture.display()
+    );
+    fs::write(path, script).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn argv(path: &Path) -> Vec<String> {
+    fs::read(path)
+        .unwrap()
+        .split(|byte| *byte == 0)
+        .filter(|arg| !arg.is_empty())
+        .map(|arg| String::from_utf8(arg.to_vec()).unwrap())
+        .collect()
+}
+
+#[test]
+fn generic_argument_transport_preserves_argv_boundaries_and_delivers_the_packet_once() {
+    let fixture = Fixture::new("argument");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [execute, '{run_dir}', '{prompt}', 'literal with spaces']\n",
+        "scrub_or_block",
+    );
+
+    let output = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let run = fixture.latest_run();
+    let packet = fs::read_to_string(run.join("task-packet.md")).unwrap();
+    let received = fs::read_to_string(fixture.capture.join("prompt-argument")).unwrap();
+    assert_eq!(
+        received, packet,
+        "the complete packet must occupy one argv slot"
+    );
+    assert!(
+        fs::read(fixture.capture.join("stdin")).unwrap().is_empty(),
+        "argument transport must not duplicate the packet on stdin"
+    );
+    let received_argv = argv(&fixture.capture.join("last-argv"));
+    assert_eq!(received_argv[0], "execute");
+    assert_eq!(received_argv[2], packet);
+    assert_eq!(received_argv[3], "literal with spaces");
+    assert_eq!(
+        argv(&fixture.capture.join("probe-argv")),
+        ["probe", "offline"]
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.capture.join("probe-secret")).unwrap(),
+        "absent",
+        "offline probes must use the worker billing-env sanitation boundary"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.capture.join("last-secret")).unwrap(),
+        "absent"
+    );
+    assert!(run.join("result.json").is_file());
+}
+
+#[test]
+fn legacy_stdin_transport_and_default_offline_probe_remain_invocable() {
+    let fixture = Fixture::new("stdin");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
+        "scrub_or_block",
+    );
+
+    let output = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let run = fixture.latest_run();
+    let packet = fs::read_to_string(run.join("task-packet.md")).unwrap();
+    assert_eq!(
+        fs::read_to_string(fixture.capture.join("stdin")).unwrap(),
+        packet
+    );
+    assert!(fs::read_to_string(fixture.capture.join("prompt-argument"))
+        .unwrap()
+        .is_empty());
+    assert_eq!(argv(&fixture.capture.join("probe-argv")), ["--version"]);
+    assert_eq!(
+        fs::read_to_string(fixture.capture.join("last-secret")).unwrap(),
+        "absent"
+    );
+}
+
+#[test]
+fn invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn() {
+    for (label, invocation, billing, expected) in [
+        (
+            "noninteractive",
+            "      supports_noninteractive: false\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
+            "scrub_or_block",
+            "supports_noninteractive",
+        ),
+        (
+            "output-contract",
+            "      supports_noninteractive: true\n      output_contract: stdout_json\n      args: [execute, '{run_dir}']\n",
+            "scrub_or_block",
+            "output_contract",
+        ),
+        (
+            "prompt-transport",
+            "      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: shell\n      args: [execute, '{run_dir}']\n",
+            "scrub_or_block",
+            "prompt_transport",
+        ),
+        (
+            "prompt-placeholder",
+            "      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: argument\n      args: [execute, '{run_dir}']\n",
+            "scrub_or_block",
+            "exactly one {prompt}",
+        ),
+        (
+            "strict-billing",
+            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
+            "block",
+            "strict billing policy",
+        ),
+    ] {
+        let fixture = Fixture::new(label);
+        fixture.configure(invocation, billing);
+        let output = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+        assert!(!output.status.success(), "{label} unexpectedly ran");
+        let combined = format!(
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(combined.contains(expected), "{label}: {combined}");
+        assert!(
+            !fixture.capture.join("last-argv").exists(),
+            "{label} spawned a probe or worker before rejecting the profile"
+        );
+        assert!(!fixture.capture.join("invoked").exists());
+    }
+}
+
+#[test]
+fn failed_offline_probe_rejects_routing_before_the_worker_invocation() {
+    let fixture = Fixture::new("failed-probe");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, fail]\n      args: [execute, '{run_dir}']\n",
+        "scrub_or_block",
+    );
+
+    let output = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(!output.status.success(), "failed probe unexpectedly routed");
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("configured offline version probe failed"),
+        "{combined}"
+    );
+    assert_eq!(argv(&fixture.capture.join("probe-argv")), ["probe", "fail"]);
+    assert!(
+        !fixture.capture.join("invoked").exists(),
+        "the failed probe must not fall through to the worker invocation"
+    );
+}

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -3122,7 +3122,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             fs::write(
                 &workers_path,
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
                     producer_command.display(),
                     worker.display()
                 ),


### PR DESCRIPTION
## What

First V010-006 slice, produced end-to-end by a Yardlet dogfood run (plan -> YARD-001 impl on codex -> YARD-002 independent review on claude-code).

- Generic workers gain explicit prompt transport: backward-compatible stdin default plus a single-argv template mode that passes the compiled packet exactly once, with no shell interpolation.
- A configurable offline version probe per profile (existing profiles keep `--version`), never a network/auth call.
- One invocability contract in `guard`: enabled -> invocation contract -> strict billing -> binary -> probe. CLI `worker status`, TUI snapshot, task routing, planning worker selection, and capability projection all consume the same verdict; spawn re-checks it defensively.
- Fake-CLI process regression suite (`tests/generic_worker_contract_process.rs`): argv boundary + exactly-once delivery + no stdin duplication, legacy stdin/`--version` compatibility, five no-spawn counterexamples, probe-failure routing rejection, and billing-env scrub proof.
- EN/KO README and `templates/agents/workers.yaml` document the new fields, defaults, failure reasons, and the offline-auth limitation 1:1.
- Learned skill `readiness-1-1` (six-consumer 1:1 readiness review procedure) tracked.

## Verification

- Independent review task re-ran fmt, clippy `-D warnings`, `cargo test --all-features` (850 passed / 0 failed), and a public scan; AC-001..005 all pass.
- `cargo test --all-features` re-run green on this workspace after the merge.