### PR TITLE
fix(report): stop calling a delivered run 'disabled by workspace policy'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The report no longer calls a delivered run "disabled".** A `Disabled`
+  Git-finish record only ever meant the push was disabled by policy, but the
+  per-task report line read as if nothing was delivered. The line now reports
+  the local integration (with its commit) when the run's merge landed, says
+  "no changes to deliver" for no-change runs, and claims only the push
+  otherwise. (#125)
+
 ## 0.10.3 - 2026-07-25
 
 ### Added

--- a/src/git_finish.rs
+++ b/src/git_finish.rs
@@ -111,7 +111,33 @@ pub struct GitFinishRecord {
 impl GitFinishRecord {
     pub fn user_line(&self) -> String {
         match self.status {
-            GitFinishStatus::Disabled => "git finish: disabled by workspace policy".to_string(),
+            // Disabled only ever means the push was disabled; local integration
+            // may still have happened, and ownership evidence is the record of
+            // that (it is supplied only by a successful merge).
+            GitFinishStatus::Disabled => {
+                let integrated = self
+                    .expected_oid
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|oid| !oid.is_empty());
+                if let Some(oid) = integrated {
+                    let short = &oid[..oid.len().min(12)];
+                    let target = if self.policy.target_ref.is_empty() {
+                        "the owning checkout"
+                    } else {
+                        self.policy.target_ref.as_str()
+                    };
+                    format!(
+                        "git finish: integrated {short} into {target} locally; \
+                         push disabled by workspace policy"
+                    )
+                } else if self.reason == "policy_disabled:no_changes" {
+                    "git finish: no changes to deliver; push disabled by workspace policy"
+                        .to_string()
+                } else {
+                    "git finish: push disabled by workspace policy".to_string()
+                }
+            }
             GitFinishStatus::NotNeeded => "git finish: not needed (no changes)".to_string(),
             GitFinishStatus::Prepared => "git finish: prepared but push not started".to_string(),
             GitFinishStatus::Pushed => format!(
@@ -819,6 +845,9 @@ pub fn finish_no_change_run(
     }
     let mut record = base_record(run_id, task_id, &policy, None);
     if !policy.auto_push {
+        // Still a Disabled record, but keep the no-change fact visible: the
+        // user line must not suggest work was withheld by policy (issue #125).
+        record.reason = "policy_disabled:no_changes".to_string();
         return persist_and_return(ws, run_dir, record);
     }
     if task_state != TaskState::Done {
@@ -2348,6 +2377,44 @@ mod tests {
         assert_eq!(
             remote_oid(&f.root, "fixture", "refs/heads/main").unwrap(),
             Some(f.initial_oid.clone())
+        );
+    }
+
+    // Issue #125: a Disabled record only means the push was disabled. When the
+    // run's merge already landed in the owning checkout (ownership present),
+    // the user line must say so instead of reading as if nothing was delivered.
+    #[test]
+    fn disabled_push_user_line_reports_the_local_integration() {
+        let f = Fixture::new("disabled-line-integrated");
+        let oid = f.commit("owned");
+        let record = f.finish(Some(oid.clone()));
+        assert_eq!(record.status, GitFinishStatus::Disabled);
+        let line = record.user_line();
+        assert!(line.contains("integrated"), "{line}");
+        assert!(line.contains(&oid[..12]), "{line}");
+        assert!(line.contains("push disabled by workspace policy"), "{line}");
+    }
+
+    #[test]
+    fn disabled_push_user_line_distinguishes_no_change_runs() {
+        let f = Fixture::new("disabled-line-no-change");
+        let record =
+            finish_no_change_run(&f.ws, &f.run_dir, "run-test", "YARD-001", TaskState::Done)
+                .unwrap();
+        assert_eq!(record.status, GitFinishStatus::Disabled);
+        let line = record.user_line();
+        assert!(line.contains("no changes"), "{line}");
+        assert!(line.contains("push disabled by workspace policy"), "{line}");
+        assert!(!line.contains("integrated"), "{line}");
+    }
+
+    #[test]
+    fn disabled_push_user_line_without_evidence_claims_only_the_push() {
+        let record = base_record("run-test", "YARD-001", &GitFinishPolicy::default(), None);
+        assert_eq!(record.status, GitFinishStatus::Disabled);
+        assert_eq!(
+            record.user_line(),
+            "git finish: push disabled by workspace policy"
         );
     }
 


### PR DESCRIPTION
Closes #125.

## What

A `Disabled` Git-finish record only ever meant *the push* was disabled by policy, but `GitFinishRecord::user_line` rendered it as "git finish: disabled by workspace policy", which reads as "nothing was delivered" — even for a run whose merge had already landed in the owning checkout (observed in the first V010-006 dogfood drain: local main had the merge `cc4b319`, target was `refs/heads/main`, and the report still said disabled).

- `Disabled` + ownership evidence (supplied only by a successful merge, per the finalize path comment in `run.rs`) → `git finish: integrated <oid12> into <target_ref> locally; push disabled by workspace policy`
- `Disabled` + no-change finish → `git finish: no changes to deliver; push disabled by workspace policy` (the no-change path now marks its early policy return with `policy_disabled:no_changes`)
- `Disabled` otherwise → `git finish: push disabled by workspace policy`

Durable status semantics are unchanged: the record still persists `Disabled`, `verified_complete()` is untouched, and no consumer matches on the `policy_disabled` reason string (checked).

## Verification

- Three RED→GREEN unit tests covering all three renderings (each failed on the old blanket string first).
- `cargo test --all-features` green in this worktree (exit 0), `cargo fmt --check` and `clippy --all-targets --all-features -D warnings` clean.