### PR TITLE
fix(guard): make sandboxed access a fail-closed contract for generic workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Changed
+
+- **`sandboxed` access is no longer an unverified claim for generic workers.**
+  Built-in adapters keep their core-owned, enforced sandbox flags. A generic
+  worker's sandbox was only ever its profile's own declaration, and a profile
+  with empty `sandbox_args` ran unbounded while the workspace believed writes
+  were bounded. The shared invocability verdict now fails closed: under
+  `sandboxed` access a generic profile must declare a real sandbox contract
+  (non-empty `sandbox_args`, distinct from `full_access_args`, no elevation
+  markers or unknown placeholders), the rejection names both explicit ways out
+  (declare `sandbox_args`, or `yardlet access full`), and a ready generic
+  worker's status labels its sandbox "profile-declared, not verified by
+  Yardlet". Existing generic profiles without `sandbox_args` become
+  not-invocable under sandboxed access until they declare one. (#123)
+
 ### Fixed
 
 - **The report no longer calls a delivered run "disabled".** A `Disabled`

--- a/README.ko.md
+++ b/README.ko.md
@@ -342,6 +342,14 @@ Codex와 Claude Code는 내장 어댑터를 가집니다. 다른 모든 구독 �
 차단하지 않을 때만 실행 가능합니다. 라우팅, 계획, capability projection, 워커 상태,
 TUI는 모두 같은 판정을 사용합니다.
 
+기본 접근 수준인 `sandboxed`에서는 제네릭 프로필이 `sandbox_args`도 선언해야
+합니다. 내장 어댑터의 샌드박스 플래그는 Yardlet이 직접 붙이고 그 의미를 알지만,
+자신이 소유하지 않은 샌드박스는 검증할 수 없습니다. 제네릭 워커의 선언은 적힌
+그대로 신뢰되며, 워커 상태에는 "profile-declared, not verified by Yardlet"로
+표시됩니다. 쓰기를 제한할 방법을 선언하지 않은 프로필은 `sandbox_args`를
+추가하거나 풀 액세스를 명시적으로 허용(`yardlet access full`)하기 전까지 실행
+가능 판정을 받지 못합니다.
+
 ```yaml
 - id: mytool
   best_for: "..."            # 플래너 루브릭

--- a/README.md
+++ b/README.md
@@ -360,6 +360,14 @@ configured offline probe work, `supports_noninteractive` is `true`,
 policy does not block them. Routing, planning, capability projection, worker
 status, and the TUI all use that same decision.
 
+Under the default `sandboxed` access level a generic profile must also declare
+`sandbox_args`. Yardlet appends the built-in adapters' sandbox flags itself and
+knows what they mean, but it cannot verify a sandbox it does not own: for a
+generic worker the declaration is trusted as written, worker status labels it
+"profile-declared, not verified by Yardlet", and a profile that declares no way
+to bound writes is not invocable until you add `sandbox_args` or grant full
+access explicitly (`yardlet access full`).
+
 ```yaml
 - id: mytool
   best_for: "..."            # planner rubric

--- a/src/capability_discovery.rs
+++ b/src/capability_discovery.rs
@@ -592,7 +592,8 @@ mod tests {
         let billing = crate::schemas::BillingPolicy::default();
         let policy = crate::templates::research_policy();
         // The same real projections the planner composes feed the pure core.
-        let worker_readiness = crate::guard::capability_readiness_projection(&workers, &billing);
+        let worker_readiness =
+            crate::guard::capability_readiness_projection(&workers, &billing, "full");
         let ready_capabilities =
             crate::routing::ready_capabilities_from_projection(&worker_readiness);
         let input = CapabilityDiscoveryInput {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2524,13 +2524,14 @@ fn cmd_worker(cwd: &std::path::Path, args: WorkerArgs) -> Result<()> {
             let ws = init::ensure_initialized(cwd)?.0;
             let billing = ws.load_billing()?;
             let workers = ws.load_workers()?;
+            let requested_access = ws.requested_access();
             println!("Zero-key policy: {}", billing.mode);
             println!(
                 "Billing env policy: {}\n",
                 billing.worker_invocation.ai_billing_env_policy
             );
             for p in &workers.workers {
-                let s = guard::probe(p, &billing);
+                let s = guard::probe(p, &billing, &requested_access);
                 println!("{} [{}]", s.id, s.readiness.label());
                 println!("  command: {}", s.command);
                 // Staged checklist: each readiness gate, with auth reported as

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -69,13 +69,14 @@ pub struct WorkerCapabilityReadiness {
 pub fn capability_readiness_projection(
     workers: &crate::schemas::WorkersFile,
     billing: &BillingPolicy,
+    requested_access: &str,
 ) -> Vec<WorkerCapabilityReadiness> {
     workers
         .workers
         .iter()
         .map(|profile| WorkerCapabilityReadiness {
             worker_id: profile.id.clone(),
-            readiness: probe(profile, billing).readiness,
+            readiness: probe(profile, billing, requested_access).readiness,
             capabilities: profile.capabilities.clone(),
         })
         .collect()
@@ -84,47 +85,41 @@ pub fn capability_readiness_projection(
 /// Cache identity for the inputs that can change an offline readiness verdict.
 /// It contains configuration and billing-variable names/presence only, never
 /// secret values. Snapshot/TUI cheap reloads use this to avoid carrying a ready
-/// verdict across an edited invocation contract or billing posture.
-pub fn readiness_cache_key(profile: &WorkerProfile, billing: &BillingPolicy) -> String {
+/// verdict across an edited invocation contract, billing posture, or access
+/// level (a generic worker's verdict depends on the requested access).
+pub fn readiness_cache_key(
+    profile: &WorkerProfile,
+    billing: &BillingPolicy,
+    requested_access: &str,
+) -> String {
     let invocation = serde_json::to_string(&profile.invocation)
         .unwrap_or_else(|_| format!("{:?}", profile.invocation));
     let present = present_billing_env(&billing.blocked_worker_env_names);
     format!(
-        "{}|{}|{}|{}|{}",
+        "{}|{}|{}|{}|{}|{}",
         profile.id,
         profile.enabled,
         billing.worker_invocation.ai_billing_env_policy,
         present.join(","),
+        requested_access,
         invocation
     )
 }
 
-/// Validate the sandbox declaration used by a planning capability scout.
-///
-/// Built-in adapters have a core-owned sandbox argument shape. A generic
-/// adapter must provide a distinct, non-empty, syntactically checkable
-/// sandbox contract. Yardlet cannot infer a missing flag or guess the meaning
-/// of an unknown placeholder, so those profiles fail closed before scout
-/// spawn. The disposable workspace remains the filesystem isolation boundary.
-pub fn scout_sandbox_contract(profile: &WorkerProfile) -> Result<(), String> {
-    if matches!(profile.id.as_str(), "codex" | "claude-code") {
-        return Ok(());
-    }
-
+/// Validate that a generic profile's `sandbox_args` actually declare a
+/// bounded-write sandbox contract: non-empty, distinct from the full-access
+/// arguments, free of elevation markers and unknown placeholders, and carrying
+/// at least one literal flag. Yardlet cannot infer a missing flag or guess the
+/// meaning of an unknown placeholder, so callers fail closed on Err.
+pub fn generic_sandbox_declaration(profile: &WorkerProfile) -> Result<(), String> {
     let sandbox = &profile.invocation.sandbox_args;
     if sandbox.is_empty() || sandbox.iter().any(|arg| arg.trim().is_empty()) {
-        return Err(
-            "generic planning scout sandbox contract failed closed: sandbox_args must be non-empty"
-                .to_string(),
-        );
+        return Err("sandbox_args must be non-empty".to_string());
     }
     if !profile.invocation.full_access_args.is_empty()
         && sandbox == &profile.invocation.full_access_args
     {
-        return Err(
-            "generic planning scout sandbox contract failed closed: sandbox and full-access arguments are identical"
-                .to_string(),
-        );
+        return Err("sandbox and full-access arguments are identical".to_string());
     }
 
     let mut has_literal_contract = false;
@@ -141,10 +136,7 @@ pub fn scout_sandbox_contract(profile: &WorkerProfile) -> Result<(), String> {
         .iter()
         .any(|marker| lower.contains(marker))
         {
-            return Err(
-                "generic planning scout sandbox contract failed closed: sandbox_args contain an elevation marker"
-                    .to_string(),
-            );
+            return Err("sandbox_args contain an elevation marker".to_string());
         }
         let remainder = ["{run_dir}", "{model}", "{effort}", "{image}"]
             .iter()
@@ -152,20 +144,54 @@ pub fn scout_sandbox_contract(profile: &WorkerProfile) -> Result<(), String> {
                 value.replace(placeholder, "")
             });
         if remainder.contains('{') || remainder.contains('}') {
-            return Err(
-                "generic planning scout sandbox contract failed closed: sandbox_args contain an unknown placeholder"
-                    .to_string(),
-            );
+            return Err("sandbox_args contain an unknown placeholder".to_string());
         }
         has_literal_contract |= !remainder.trim().is_empty();
     }
     if !has_literal_contract {
-        return Err(
-            "generic planning scout sandbox contract failed closed: sandbox_args do not declare a sandbox mode"
-                .to_string(),
-        );
+        return Err("sandbox_args do not declare a sandbox mode".to_string());
     }
     Ok(())
+}
+
+/// Validate the sandbox declaration used by a planning capability scout.
+///
+/// Built-in adapters have a core-owned sandbox argument shape. A generic
+/// adapter must provide a distinct, non-empty, syntactically checkable
+/// sandbox contract. Those profiles fail closed before scout spawn. The
+/// disposable workspace remains the filesystem isolation boundary.
+pub fn scout_sandbox_contract(profile: &WorkerProfile) -> Result<(), String> {
+    if matches!(profile.id.as_str(), "codex" | "claude-code") {
+        return Ok(());
+    }
+    generic_sandbox_declaration(profile).map_err(|reason| {
+        format!("generic planning scout sandbox contract failed closed: {reason}")
+    })
+}
+
+/// Whether this profile can honor the requested access level (issue #123).
+///
+/// `sandboxed` is an enforced boundary for the built-in adapters, whose
+/// sandbox flags are core-owned; for a generic worker it is only ever the
+/// profile's own declaration. A generic profile that declares no sandbox
+/// contract cannot honor `sandboxed`, so it fails closed here instead of
+/// running unbounded while the workspace believes writes are bounded.
+pub fn access_contract(profile: &WorkerProfile, requested_access: &str) -> Result<(), String> {
+    if requested_access != "sandboxed" {
+        return Ok(());
+    }
+    if matches!(profile.id.as_str(), "codex" | "claude-code") {
+        return Ok(());
+    }
+    generic_sandbox_declaration(profile).map_err(|reason| {
+        format!(
+            "worker '{}' cannot honor sandboxed access: {reason}. Yardlet cannot verify a \
+             sandbox it does not own, so this profile is not invocable while the workspace \
+             asks for sandboxed access; declare a real sandbox in invocation.sandbox_args \
+             or grant full access explicitly (yardlet access full)",
+            profile.id
+        )
+    })
 }
 
 /// The outcome of one readiness gate in the staged worker-status display.
@@ -455,7 +481,11 @@ fn fallback_paths(worker_id: &str) -> Vec<PathBuf> {
 /// Resolution prefers the first candidate whose version probe succeeds: the
 /// PATH-resolved binary first, then well-known fallback paths. This keeps a
 /// worker usable even when a wrapper shadows the real CLI on PATH.
-pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
+pub fn probe(
+    profile: &WorkerProfile,
+    billing: &BillingPolicy,
+    requested_access: &str,
+) -> WorkerStatus {
     let command = profile.invocation.command.clone();
     let billing_env_present = present_billing_env(&billing.blocked_worker_env_names);
 
@@ -482,7 +512,9 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
         }
     }
 
-    let contract_error = invocation_contract(profile).err();
+    let contract_error = invocation_contract(profile)
+        .and_then(|()| access_contract(profile, requested_access))
+        .err();
     if let Some(error) = contract_error {
         return WorkerStatus {
             id: profile.id.clone(),
@@ -528,7 +560,7 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
 
     let (binary_path, version, readiness, detail) = match verified {
         Some((path, version)) => {
-            let detail = if billing_env_present.is_empty() {
+            let mut detail = if billing_env_present.is_empty() {
                 "binary found; version ok; AI-billing env clean; will run with sanitized environment"
                     .to_string()
             } else {
@@ -539,6 +571,16 @@ pub fn probe(profile: &WorkerProfile, billing: &BillingPolicy) -> WorkerStatus {
                     billing.worker_invocation.ai_billing_env_policy
                 )
             };
+            // An operator reading "sandboxed" must be able to tell an enforced
+            // boundary from a declared one (issue #123): the generic sandbox
+            // passed the declaration check above, but Yardlet does not own it.
+            if requested_access == "sandboxed"
+                && !matches!(profile.id.as_str(), "codex" | "claude-code")
+            {
+                detail.push_str(
+                    "; sandbox is profile-declared, not verified by Yardlet",
+                );
+            }
             (Some(path), Some(version), Readiness::Ready, detail)
         }
         None => match candidates.into_iter().next() {
@@ -742,7 +784,7 @@ invocation:
         .unwrap();
         let billing = BillingPolicy::default();
 
-        let status = probe(&profile, &billing);
+        let status = probe(&profile, &billing, "full");
 
         assert_ne!(status.readiness, Readiness::Ready);
         assert_eq!(status.readiness.label(), "disabled");
@@ -778,7 +820,7 @@ invocation:
             ),
         ] {
             let profile: WorkerProfile = crate::yaml::from_str(yaml).unwrap();
-            let status = probe(&profile, &BillingPolicy::default());
+            let status = probe(&profile, &BillingPolicy::default(), "full");
             assert_eq!(status.readiness, Readiness::NotReady, "{}", status.detail);
             assert!(status.detail.contains(expected), "{}", status.detail);
         }
@@ -830,7 +872,8 @@ invocation:
             "schema_version: 1\nworkers:\n  - id: ready\n    capabilities: [Shell Tool]\n    invocation: { command: bash, supports_noninteractive: true, output_contract: files }\n  - id: absent\n    capabilities: [browser]\n    invocation: { command: yardlet-definitely-missing-command, supports_noninteractive: true, output_contract: files }\n  - id: disabled\n    enabled: false\n    capabilities: [image-generation]\n    invocation: { command: bash }\n",
         )
         .unwrap();
-        let projection = capability_readiness_projection(&workers, &BillingPolicy::default());
+        let projection =
+            capability_readiness_projection(&workers, &BillingPolicy::default(), "full");
         assert_eq!(projection.len(), 3);
         assert_eq!(projection[0].readiness, Readiness::Ready);
         assert_eq!(projection[1].readiness, Readiness::NotReady);
@@ -845,10 +888,100 @@ invocation:
                 "id: {id}\ninvocation:\n  command: bash\n  supports_noninteractive: true\n  output_contract: {output_contract}\n  version_args: [definitely-not-a-built-in-version-flag]\n"
             ))
             .unwrap();
-            let status = probe(&profile, &BillingPolicy::default());
+            let status = probe(&profile, &BillingPolicy::default(), "full");
             assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
             assert!(status.contract_error.is_none());
         }
+    }
+
+    // Issue #123: `sandboxed` must not be an unverified claim for generic
+    // workers. A profile that declares no way to bound writes is not invocable
+    // while the workspace asks for sandboxed access, and stays invocable under
+    // explicit full access.
+    #[test]
+    fn generic_worker_without_sandbox_declaration_is_not_invocable_under_sandboxed_access() {
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
+        )
+        .unwrap();
+        let billing = BillingPolicy::default();
+
+        let sandboxed = probe(&profile, &billing, "sandboxed");
+        assert_eq!(
+            sandboxed.readiness,
+            Readiness::NotReady,
+            "{}",
+            sandboxed.detail
+        );
+        assert!(
+            sandboxed.detail.contains("cannot honor sandboxed access"),
+            "{}",
+            sandboxed.detail
+        );
+
+        let full = probe(&profile, &billing, "full");
+        assert_eq!(full.readiness, Readiness::Ready, "{}", full.detail);
+    }
+
+    #[test]
+    fn generic_worker_with_declared_sandbox_is_ready_but_labeled_declared_not_verified() {
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, sandbox_args: ['--restricted'] }\n",
+        )
+        .unwrap();
+        let status = probe(&profile, &BillingPolicy::default(), "sandboxed");
+        assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        assert!(
+            status.detail.contains("profile-declared, not verified"),
+            "{}",
+            status.detail
+        );
+    }
+
+    #[test]
+    fn built_in_adapters_stay_invocable_under_sandboxed_access_without_declared_label() {
+        for id in ["codex", "claude-code"] {
+            let profile: WorkerProfile = crate::yaml::from_str(&format!(
+                "id: {id}\ninvocation: {{ command: bash, supports_noninteractive: true, output_contract: files }}\n"
+            ))
+            .unwrap();
+            let status = probe(&profile, &BillingPolicy::default(), "sandboxed");
+            assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+            assert!(
+                !status.detail.contains("profile-declared"),
+                "{}",
+                status.detail
+            );
+        }
+    }
+
+    #[test]
+    fn access_contract_rejects_elevation_markers_and_identical_full_args_under_sandboxed() {
+        let base = "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, sandbox_args: ['--dangerously-bypass'] }\n";
+        let profile: WorkerProfile = crate::yaml::from_str(base).unwrap();
+        let error = access_contract(&profile, "sandboxed").unwrap_err();
+        assert!(error.contains("elevation marker"), "{error}");
+        assert!(access_contract(&profile, "full").is_ok());
+
+        let identical: WorkerProfile = crate::yaml::from_str(
+            "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, sandbox_args: ['--x'], full_access_args: ['--x'] }\n",
+        )
+        .unwrap();
+        let error = access_contract(&identical, "sandboxed").unwrap_err();
+        assert!(error.contains("identical"), "{error}");
+    }
+
+    #[test]
+    fn readiness_cache_key_changes_with_requested_access() {
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
+        )
+        .unwrap();
+        let billing = BillingPolicy::default();
+        assert_ne!(
+            readiness_cache_key(&profile, &billing, "sandboxed"),
+            readiness_cache_key(&profile, &billing, "full")
+        );
     }
 
     #[test]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -272,8 +272,12 @@ pub struct ScoutCommandReport {
 pub fn scout(ws: &Workspace) -> Result<ScoutCommandReport> {
     let worker_profiles = ws.load_workers()?;
     let billing = ws.load_billing()?;
-    let (profile, bin, worker_id) =
-        crate::planner::pick_ready_worker(&worker_profiles, &billing, None)?;
+    let (profile, bin, worker_id) = crate::planner::pick_ready_worker(
+        &worker_profiles,
+        &billing,
+        None,
+        &ws.requested_access(),
+    )?;
     let env = guard::sanitized_worker_env_for(&billing, &profile.invocation.pass_env)
         .map_err(|e| anyhow!(e))?;
     let timeout = Duration::from_secs(profile.limits.max_wall_minutes as u64 * 60);
@@ -484,8 +488,12 @@ fn draft(
     let worker_profiles = ws.load_workers()?;
     let billing = ws.load_billing()?;
     let config = ws.load_config()?;
-    let (profile, bin, worker_id) =
-        crate::planner::pick_ready_worker(&worker_profiles, &billing, None)?;
+    let (profile, bin, worker_id) = crate::planner::pick_ready_worker(
+        &worker_profiles,
+        &billing,
+        None,
+        &config.default_access,
+    )?;
 
     let base_run_id = format!("memory-{}", Local::now().format("%Y%m%d-%H%M%S"));
     let (run_id, run_dir) = ws.claim_run_dir(&base_run_id)?;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -850,6 +850,7 @@ pub fn run_batch<F: FnMut(&str)>(
             match routing::resolve_failover_worker_for_task(
                 &workers_file,
                 &billing,
+                &ws.requested_access(),
                 &worker_id,
                 &p.task,
             ) {
@@ -3521,7 +3522,7 @@ printf "# worker handoff\n" > "$run_dir/handoff.md"
         let ws = Workspace::at(root);
         write_str(
             &ws.config_path(),
-            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\n",
+            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\n# unit fixtures opt into full access explicitly: they exercise run/parallel\n# mechanics with bash fixture workers that declare no sandbox contract\ndefault_access: full\n",
         )
         .unwrap();
         write_str(&ws.billing_path(), "schema_version: 1\n").unwrap();

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -685,7 +685,8 @@ fn audit_planning_content(
     let policy = bounded_research_policy(ws.load_research_policy()?);
     let library = crate::skills::Library::open(skill_library)
         .ok_or_else(|| anyhow!("skill library projection is unavailable"))?;
-    let readiness = guard::capability_readiness_projection(workers_file, billing);
+    let readiness =
+        guard::capability_readiness_projection(workers_file, billing, &ws.requested_access());
     let catalog = catalog_with_usability(ws, &library, &readiness);
     let classification = crate::skills::classify_repo(summary, request);
     let base_signals = request_capability_signals(request, fixture_signal_markers_enabled());
@@ -869,7 +870,8 @@ fn content_requires_scout(
     let policy = bounded_research_policy(ws.load_research_policy()?);
     let library = crate::skills::Library::open(skill_library)
         .ok_or_else(|| anyhow!("skill library projection is unavailable"))?;
-    let readiness = guard::capability_readiness_projection(workers_file, billing);
+    let readiness =
+        guard::capability_readiness_projection(workers_file, billing, &ws.requested_access());
     let catalog = catalog_with_usability(ws, &library, &readiness);
     let classification = crate::skills::classify_repo(summary, request);
     let base_signals = request_capability_signals(request, fixture_signal_markers_enabled());
@@ -1089,12 +1091,17 @@ pub fn plan_goal_with_report(
     content.intent.id = session.intent_id.clone();
     content.queue.intent_id = session.intent_id.clone();
     content.queue.queue_id = session.queue_id.clone();
-    let scout_selection = pick_ready_worker(&workers_file, &billing, worker_override)
-        .ok()
-        .map(|(base, bin, _)| {
-            let planning = ws.load_planning_worker_config().unwrap_or_default();
-            (planning_worker_profile(&base, &planning), bin)
-        });
+    let scout_selection = pick_ready_worker(
+        &workers_file,
+        &billing,
+        worker_override,
+        &ws.requested_access(),
+    )
+    .ok()
+    .map(|(base, bin, _)| {
+        let planning = ws.load_planning_worker_config().unwrap_or_default();
+        (planning_worker_profile(&base, &planning), bin)
+    });
     let attempt_id = format!("express-goal-{}", turn.request_event_id);
     let mut lines = Vec::new();
     let _audit = audit_planning_content(
@@ -1335,7 +1342,8 @@ fn plan_core(
     let planning_config = ws.load_planning_worker_config()?;
 
     // Choose a ready planning worker.
-    let (base_profile, bin, worker_id) = pick_ready_worker(workers, billing, worker_override)?;
+    let (base_profile, bin, worker_id) =
+        pick_ready_worker(workers, billing, worker_override, &config.default_access)?;
     let profile = planning_worker_profile(&base_profile, &planning_config);
 
     let base_run_id = format!("plan-{}", Local::now().format("%Y%m%d-%H%M%S"));
@@ -1601,7 +1609,8 @@ pub fn run_planning_amend(ws: &Workspace, request: &str) -> Result<PlanningRepor
     let planning_config = ws.load_planning_worker_config()?;
     let language = packet::resolve_language(&config.language, &ctx);
     let images: Vec<String> = Vec::new();
-    let (base_profile, bin, worker_id) = pick_ready_worker(&workers, &billing, None)?;
+    let (base_profile, bin, worker_id) =
+        pick_ready_worker(&workers, &billing, None, &config.default_access)?;
     let profile = planning_worker_profile(&base_profile, &planning_config);
     let base_run_id = format!("plan-{}", Local::now().format("%Y%m%d-%H%M%S"));
     let (run_id, run_dir) = ws.claim_run_dir(&base_run_id)?;
@@ -2423,13 +2432,12 @@ pub fn recover_unconsumed_plan(ws: &Workspace) -> Result<Option<String>> {
         .load_config()
         .map(|config| config.skill_library)
         .unwrap_or_default();
-    let scout_selection =
-        pick_ready_worker(&workers_file, &billing, None)
-            .ok()
-            .map(|(base, bin, _)| {
-                let planning = ws.load_planning_worker_config().unwrap_or_default();
-                (planning_worker_profile(&base, &planning), bin)
-            });
+    let scout_selection = pick_ready_worker(&workers_file, &billing, None, &ws.requested_access())
+        .ok()
+        .map(|(base, bin, _)| {
+            let planning = ws.load_planning_worker_config().unwrap_or_default();
+            (planning_worker_profile(&base, &planning), bin)
+        });
     let mut audit_lines = Vec::new();
     let _audit = audit_planning_content(
         ws,
@@ -2701,6 +2709,7 @@ pub(crate) fn pick_ready_worker(
     workers: &WorkersFile,
     billing: &crate::schemas::BillingPolicy,
     worker_override: Option<&str>,
+    requested_access: &str,
 ) -> Result<(WorkerProfile, std::path::PathBuf, String)> {
     let mut order: Vec<String> = Vec::new();
     if let Some(o) = worker_override {
@@ -2727,7 +2736,7 @@ pub(crate) fn pick_ready_worker(
         if !profile.enabled {
             continue;
         }
-        let status = guard::probe(profile, billing);
+        let status = guard::probe(profile, billing, requested_access);
         if status.readiness == Readiness::Ready {
             if let Some(bin) = status.binary_path {
                 return Ok((profile.clone(), bin, id));
@@ -2977,8 +2986,13 @@ routing:
         )
         .unwrap();
 
-        let error = pick_ready_worker(&workers, &crate::schemas::BillingPolicy::default(), None)
-            .expect_err("non-interactive contract failure must block planning selection");
+        let error = pick_ready_worker(
+            &workers,
+            &crate::schemas::BillingPolicy::default(),
+            None,
+            "full",
+        )
+        .expect_err("non-interactive contract failure must block planning selection");
         assert!(
             error.to_string().contains("supports_noninteractive"),
             "{error}"

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -73,6 +73,7 @@ pub fn resolve_worker_for_task(
         task.preferred_worker.trim().is_empty() || workers.routing.allow_preferred_worker_failover
     });
     validate_recorded_lineage(task, override_w, fallback_enabled)?;
+    let requested_access = ws.requested_access();
     let overrides = load_overrides(ws);
     let required: Vec<String> = task
         .required_capabilities
@@ -121,6 +122,7 @@ pub fn resolve_worker_for_task(
         resolve_order(
             workers,
             billing,
+            &requested_access,
             pinned.clone(),
             candidate.reason,
             std::slice::from_ref(&pinned),
@@ -134,6 +136,7 @@ pub fn resolve_worker_for_task(
         resolve_candidate(
             workers,
             billing,
+            &requested_access,
             candidate.worker_id,
             candidate.reason,
             &required,
@@ -145,6 +148,7 @@ pub fn resolve_worker_for_task(
 pub fn resolve_failover_worker_for_task(
     workers: &WorkersFile,
     billing: &BillingPolicy,
+    requested_access: &str,
     failed_worker: &str,
     task: &Task,
 ) -> Result<Resolved> {
@@ -189,7 +193,14 @@ pub fn resolve_failover_worker_for_task(
             "no alternate worker{cap_note} after excluding '{failed_worker}'"
         ));
     }
-    let resolved = resolve_order(workers, billing, order[0].clone(), "failover", &order)?;
+    let resolved = resolve_order(
+        workers,
+        billing,
+        requested_access,
+        order[0].clone(),
+        "failover",
+        &order,
+    )?;
     complete_resolution(workers, task, resolved, fallback_enabled)
 }
 
@@ -334,6 +345,7 @@ fn complete_resolution(
 fn resolve_candidate(
     workers: &WorkersFile,
     billing: &BillingPolicy,
+    requested_access: &str,
     candidate: String,
     source: &'static str,
     required: &[String],
@@ -358,12 +370,20 @@ fn resolve_candidate(
         ));
     }
 
-    resolve_order(workers, billing, candidate, source, &order)
+    resolve_order(
+        workers,
+        billing,
+        requested_access,
+        candidate,
+        source,
+        &order,
+    )
 }
 
 fn resolve_order(
     workers: &WorkersFile,
     billing: &BillingPolicy,
+    requested_access: &str,
     candidate: String,
     source: &'static str,
     order: &[String],
@@ -378,7 +398,7 @@ fn resolve_order(
             continue;
         }
         tried.push(id.clone());
-        let status = guard::probe(profile, billing);
+        let status = guard::probe(profile, billing, requested_access);
         if status.readiness == Readiness::Ready {
             if let Some(bin) = status.binary_path {
                 let reason = if id == &candidate {
@@ -647,6 +667,12 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&root);
         let ws = Workspace::at(&root);
+        std::fs::create_dir_all(root.join(".agents")).unwrap();
+        std::fs::write(
+            root.join(".agents/yardlet.yaml"),
+            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\ndefault_access: full\n",
+        )
+        .unwrap();
         let billing = BillingPolicy::default();
 
         let resolved = resolve_worker_for_task(&ws, &workers, &billing, None, &exact()).unwrap();
@@ -703,6 +729,12 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&root);
         let ws = Workspace::at(&root);
+        std::fs::create_dir_all(root.join(".agents")).unwrap();
+        std::fs::write(
+            root.join(".agents/yardlet.yaml"),
+            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\ndefault_access: full\n",
+        )
+        .unwrap();
 
         let error = resolve_worker_for_task(&ws, &workers, &BillingPolicy::default(), None, &task)
             .unwrap_err();
@@ -769,7 +801,7 @@ mod tests {
                 .unwrap();
 
         let resolved =
-            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "first", &task)
+            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "full", "first", &task)
                 .unwrap();
         assert_eq!(resolved.worker_id, "second");
 
@@ -780,6 +812,7 @@ mod tests {
         let err = resolve_failover_worker_for_task(
             &w_without_alternate,
             &BillingPolicy::default(),
+            "full",
             "first",
             &task,
         )
@@ -802,9 +835,10 @@ mod tests {
         )
         .unwrap();
 
-        let error = resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "first", &task)
-            .unwrap_err()
-            .to_string();
+        let error =
+            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "full", "first", &task)
+                .unwrap_err()
+                .to_string();
 
         assert!(
             error.contains("preferred worker") && error.contains("opt-in"),
@@ -813,7 +847,7 @@ mod tests {
 
         w.routing.allow_preferred_worker_failover = true;
         let resolved =
-            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "first", &task)
+            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "full", "first", &task)
                 .unwrap();
         assert_eq!(resolved.worker_id, "second");
     }
@@ -835,6 +869,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         let workspace = Workspace::at(&root);
+        std::fs::create_dir_all(root.join(".agents")).unwrap();
+        std::fs::write(
+            root.join(".agents/yardlet.yaml"),
+            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\ndefault_access: full\n",
+        )
+        .unwrap();
 
         let error =
             resolve_worker_for_task(&workspace, &workers, &BillingPolicy::default(), None, &task)
@@ -858,9 +898,14 @@ mod tests {
         .unwrap();
         let task: Task = crate::yaml::from_str("id: T\ntitle: t\n").unwrap();
 
-        let resolved =
-            resolve_failover_worker_for_task(&w, &BillingPolicy::default(), "failed", &task)
-                .unwrap();
+        let resolved = resolve_failover_worker_for_task(
+            &w,
+            &BillingPolicy::default(),
+            "full",
+            "failed",
+            &task,
+        )
+        .unwrap();
 
         assert_eq!(resolved.worker_id, "ready");
         assert_eq!(resolved.reason, "fallback (missing not invocable)");

--- a/src/run.rs
+++ b/src/run.rs
@@ -3242,6 +3242,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         match routing::resolve_failover_worker_for_task(
             &workers,
             &billing,
+            &ws.requested_access(),
             &active_worker_id,
             &failover_task,
         ) {
@@ -10205,7 +10206,7 @@ mod tests {
         }
         write_str(
             &ws.config_path(),
-            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\n",
+            "schema_version: 1\nproduct: yardlet\nworkspace_id: test\ncreated_at: \"2026-07-03T00:00:00Z\"\nstate_dir: .agents\ndefault_interface: tui\ncanonical_queue: work-queue.yaml\ncurrent_intent: intent-contract.yaml\n# unit fixtures opt into full access explicitly: they exercise run/parallel\n# mechanics with bash fixture workers that declare no sandbox contract\ndefault_access: full\n",
         )
         .unwrap();
         write_str(&ws.billing_path(), "schema_version: 1\n").unwrap();

--- a/src/skill_author.rs
+++ b/src/skill_author.rs
@@ -48,7 +48,8 @@ fn draft(
     let billing = ws.load_billing()?;
     let config = ws.load_config()?;
 
-    let (profile, bin, worker_id) = crate::planner::pick_ready_worker(&workers, &billing, None)?;
+    let (profile, bin, worker_id) =
+        crate::planner::pick_ready_worker(&workers, &billing, None, &config.default_access)?;
 
     let base_run_id = format!("skill-{}", Local::now().format("%Y%m%d-%H%M%S"));
     let (run_id, run_dir) = ws.claim_run_dir(&base_run_id)?;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -228,6 +228,7 @@ impl Snapshot {
         probe: impl FnMut(
             &crate::schemas::WorkerProfile,
             &crate::schemas::BillingPolicy,
+            &str,
         ) -> crate::guard::WorkerStatus,
     ) -> Result<Snapshot> {
         Self::load_inner_with_probe(ws, None, probe)
@@ -250,6 +251,7 @@ impl Snapshot {
         mut probe: impl FnMut(
             &crate::schemas::WorkerProfile,
             &crate::schemas::BillingPolicy,
+            &str,
         ) -> crate::guard::WorkerStatus,
     ) -> Result<Snapshot> {
         // A snapshot is a trusted projection used by both status and every TUI
@@ -265,6 +267,7 @@ impl Snapshot {
         let billing = ws.load_billing()?;
         let workers_file = ws.load_workers()?;
         let policy = billing.worker_invocation.ai_billing_env_policy.clone();
+        let requested_access = config.default_access.clone();
 
         // The enabled flag, model, and billing-policy posture are always re-read
         // from config (cheap and user-editable); only the expensive probe
@@ -273,7 +276,8 @@ impl Snapshot {
             .workers
             .iter()
             .map(|p| {
-                let readiness_cache_key = guard::readiness_cache_key(p, &billing);
+                let readiness_cache_key =
+                    guard::readiness_cache_key(p, &billing, &requested_access);
                 if !p.enabled {
                     return WorkerLine {
                         id: p.id.clone(),
@@ -302,7 +306,7 @@ impl Snapshot {
                         ..c.clone()
                     };
                 }
-                let s = probe(p, &billing);
+                let s = probe(p, &billing, &requested_access);
                 let present = s.billing_env_present.len();
                 WorkerLine {
                     id: s.id,
@@ -804,7 +808,7 @@ current_intent: ""
         ws.save_queue(&WorkQueue::empty()).unwrap();
 
         let calls = AtomicUsize::new(0);
-        let snapshot = Snapshot::load_with_probe(&ws, |profile, _billing| {
+        let snapshot = Snapshot::load_with_probe(&ws, |profile, _billing, _access| {
             calls.fetch_add(1, Ordering::SeqCst);
             crate::guard::WorkerStatus {
                 id: profile.id.clone(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -2429,6 +2429,14 @@ impl Workspace {
         load_yaml(&self.config_path())
     }
 
+    /// The workspace's requested worker access level for readiness verdicts.
+    /// Unreadable config fails closed to "sandboxed", the stricter posture.
+    pub fn requested_access(&self) -> String {
+        self.load_config()
+            .map(|config| config.default_access)
+            .unwrap_or_else(|_| "sandboxed".to_string())
+    }
+
     pub fn load_planning_worker_config(&self) -> Result<PlanningWorkerConfig> {
         load_yaml(&self.config_path())
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4486,7 +4486,11 @@ routing:
             .workers
             .into_iter()
             .map(|worker| crate::snapshot::WorkerLine {
-                readiness_cache_key: crate::guard::readiness_cache_key(&worker, &billing),
+                readiness_cache_key: crate::guard::readiness_cache_key(
+                    &worker,
+                    &billing,
+                    "sandboxed",
+                ),
                 id: worker.id,
                 readiness: "invocable".into(),
                 version: Some("fixture 1.0".into()),
@@ -4526,7 +4530,7 @@ routing:
         std::fs::write(
             ws.workers_path(),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\nrouting: {{}}\n",
+                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\nrouting: {{}}\n",
                 probe.display()
             ),
         )
@@ -4563,7 +4567,7 @@ routing:
         write_version_probe(&probe, "fixture 1.0");
         let workers = |supports_noninteractive: bool| {
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\n      supports_noninteractive: {}\n      output_contract: files\nrouting: {{}}\n",
+                "schema_version: 1\nworkers:\n  - id: fixture\n    enabled: true\n    invocation:\n      command: {}\n      supports_noninteractive: {}\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\nrouting: {{}}\n",
                 probe.display(), supports_noninteractive
             )
         };

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -1063,6 +1063,11 @@ fn spawn_internal(
     // process in the canonical run directory.
     let control_run_dir = output_log.parent().unwrap_or(cwd);
     guard::invocation_contract(profile).map_err(anyhow::Error::msg)?;
+    // Defensive re-check with the access this spawn actually uses: routing
+    // already gated on the workspace's requested access, but a generic worker
+    // must never start sandboxed on an unverifiable sandbox claim (issue #123).
+    let spawn_access = if full_access { "full" } else { "sandboxed" };
+    guard::access_contract(profile, spawn_access).map_err(anyhow::Error::msg)?;
     let packet_on_stdin = resume
         || matches!(profile.id.as_str(), "codex" | "claude-code")
         || profile.invocation.prompt_on_stdin();
@@ -2864,6 +2869,7 @@ invocation:
   supports_noninteractive: true
   output_contract: files
   args: ["-c", "printf stdout-only; printf stderr-only >&2"]
+  sandbox_args: ["--fixture-sandbox"]
 limits: {max_wall_minutes: 1}
 "#,
         )

--- a/templates/agents/workers.yaml
+++ b/templates/agents/workers.yaml
@@ -122,6 +122,9 @@ workers:
   #     prompt_transport: argument
   #     # {prompt} is exactly one argv item. Yardlet never builds a shell string.
   #     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
+  #     # Required under sandboxed access: Yardlet cannot verify a sandbox it
+  #     # does not own, so a generic profile must declare one (or the workspace
+  #     # must grant full access explicitly with `yardlet access full`).
   #     sandbox_args: ["--sandbox"]
   #     full_access_args: ["--full-access"]
   #     model_args: ["--model", "{model}"]

--- a/tests/fixtures/git_finish_process_recovery/scripts/run.sh
+++ b/tests/fixtures/git_finish_process_recovery/scripts/run.sh
@@ -134,6 +134,7 @@ workers:
       command: $WRAPPER_DIR/worker-sentinel
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
 routing:
   default_worker: fixture-worker
   fallback_order: [fixture-worker]

--- a/tests/fixtures/protected_branch_pr_delivery/scripts/run.sh
+++ b/tests/fixtures/protected_branch_pr_delivery/scripts/run.sh
@@ -201,6 +201,7 @@ workers:
       command: $WRAPPER_DIR/worker-sentinel
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
 routing:
   default_worker: fixture-worker
   fallback_order: [fixture-worker]

--- a/tests/fixtures/v010_001a_serial_git_finish/scripts/run.sh
+++ b/tests/fixtures/v010_001a_serial_git_finish/scripts/run.sh
@@ -280,6 +280,7 @@ workers:
       command: bash
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-001, builder, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
   - id: reviewer
@@ -287,6 +288,7 @@ workers:
       command: bash
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-002, reviewer, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
   - id: remediator
@@ -294,6 +296,7 @@ workers:
       command: bash
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-004, remediator, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
   - id: rereviewer
@@ -301,6 +304,7 @@ workers:
       command: bash
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
       args: [$WRAPPER_DIR/worker.sh, "{run_dir}", YARD-003, rereviewer, $scenario/attempts, $scenario/packets, $STERILE_HOME]
     limits: {max_wall_minutes: 1, max_retries: 0}
 EOF

--- a/tests/fixtures/v010_002_conversational_planning/scripts/run.sh
+++ b/tests/fixtures/v010_002_conversational_planning/scripts/run.sh
@@ -153,6 +153,7 @@ workers:
       command: $PLANNER
       supports_noninteractive: true
       output_contract: files
+      sandbox_args: ['--fixture-sandbox']
       args: ["{run_dir}"]
     limits:
       max_wall_minutes: 1

--- a/tests/fixtures/v010_002a_capability_discovery/scripts/run.sh
+++ b/tests/fixtures/v010_002a_capability_discovery/scripts/run.sh
@@ -470,17 +470,21 @@ EOF
 
     closed_root="$(mktemp -d "$EVIDENCE_DIR/active-isolation-empty-contract.XXXXXX")"
     setup_workspace "$closed_root" absent
-    run_in "$closed_root" goal "baseline covered goal" --plan-only >/dev/null
     closed_before="$(active_digest "$closed_root")"
-    run_in "$closed_root" new "fixture:active_state_isolation 리서치" --worker fixture-worker \
-      >"$EVIDENCE_DIR/active-isolation-empty-contract.out"
+    # Issue #123: a generic profile with no sandbox declaration now fails the
+    # shared invocability verdict before planning-worker selection, which is
+    # strictly earlier than the scout sandbox gate this scenario used to hit.
+    if run_in "$closed_root" new "fixture:active_state_isolation 리서치" --worker fixture-worker \
+      >"$EVIDENCE_DIR/active-isolation-empty-contract.out" 2>&1; then
+      fail "empty sandbox contract unexpectedly selected a planning worker"
+    fi
     [[ "$(active_digest "$closed_root")" == "$closed_before" ]] || \
       fail "empty sandbox contract changed active state"
     [[ "$(scout_count "$closed_root")" == "0" ]] || fail "empty sandbox contract spawned a scout"
-    grep -q 'sandbox contract failed closed' "$EVIDENCE_DIR/active-isolation-empty-contract.out" || \
+    grep -q 'cannot honor sandboxed access' "$EVIDENCE_DIR/active-isolation-empty-contract.out" || \
       fail "empty sandbox contract did not report fail-closed disposition"
 
-    write_summary "adversarial scout는 live 경로 없이 disposable copy에서 1회 실행됐고 빈 generic sandbox 계약은 spawn 전에 fail closed함"
+    write_summary "adversarial scout는 live 경로 없이 disposable copy에서 1회 실행됐고 빈 generic sandbox 계약은 워커 선정 전에 fail closed함"
     ;;
 
   missing_capability_dogfood)

--- a/tests/generic_worker_contract_process.rs
+++ b/tests/generic_worker_contract_process.rs
@@ -207,7 +207,7 @@ fn argv(path: &Path) -> Vec<String> {
 fn generic_argument_transport_preserves_argv_boundaries_and_delivers_the_packet_once() {
     let fixture = Fixture::new("argument");
     fixture.configure(
-        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [execute, '{run_dir}', '{prompt}', 'literal with spaces']\n",
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [execute, '{run_dir}', '{prompt}', 'literal with spaces']\n      sandbox_args: ['--fixture-sandbox']\n",
         "scrub_or_block",
     );
 
@@ -253,7 +253,7 @@ fn generic_argument_transport_preserves_argv_boundaries_and_delivers_the_packet_
 fn legacy_stdin_transport_and_default_offline_probe_remain_invocable() {
     let fixture = Fixture::new("stdin");
     fixture.configure(
-        "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
+        "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n      sandbox_args: ['--fixture-sandbox']\n",
         "scrub_or_block",
     );
 
@@ -270,9 +270,12 @@ fn legacy_stdin_transport_and_default_offline_probe_remain_invocable() {
         fs::read_to_string(fixture.capture.join("stdin")).unwrap(),
         packet
     );
-    assert!(fs::read_to_string(fixture.capture.join("prompt-argument"))
-        .unwrap()
-        .is_empty());
+    // argv position 3 carries the declared sandbox flag, never the packet:
+    // stdin transport must not duplicate the prompt into an argument.
+    assert_eq!(
+        fs::read_to_string(fixture.capture.join("prompt-argument")).unwrap(),
+        "--fixture-sandbox"
+    );
     assert_eq!(argv(&fixture.capture.join("probe-argv")), ["--version"]);
     assert_eq!(
         fs::read_to_string(fixture.capture.join("last-secret")).unwrap(),
@@ -309,7 +312,7 @@ fn invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn
         ),
         (
             "strict-billing",
-            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
+            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n      sandbox_args: ['--fixture-sandbox']\n",
             "block",
             "strict billing policy",
         ),
@@ -336,7 +339,7 @@ fn invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn
 fn failed_offline_probe_rejects_routing_before_the_worker_invocation() {
     let fixture = Fixture::new("failed-probe");
     fixture.configure(
-        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, fail]\n      args: [execute, '{run_dir}']\n",
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, fail]\n      args: [execute, '{run_dir}']\n      sandbox_args: ['--fixture-sandbox']\n",
         "scrub_or_block",
     );
 
@@ -356,4 +359,41 @@ fn failed_offline_probe_rejects_routing_before_the_worker_invocation() {
         !fixture.capture.join("invoked").exists(),
         "the failed probe must not fall through to the worker invocation"
     );
+}
+
+// Issue #123: a generic profile that declares no way to bound writes is not
+// invocable while the workspace asks for sandboxed access (the init default).
+// It must be rejected before any probe or worker subprocess starts, with a
+// message naming the missing declaration and the explicit alternatives.
+#[test]
+fn generic_worker_without_sandbox_declaration_is_rejected_under_sandboxed_access() {
+    let fixture = Fixture::new("no-sandbox-declaration");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
+        "scrub_or_block",
+    );
+
+    let output = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        !output.status.success(),
+        "an undeclared sandbox unexpectedly ran under sandboxed access"
+    );
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("cannot honor sandboxed access"),
+        "{combined}"
+    );
+    assert!(
+        combined.contains("sandbox_args") && combined.contains("yardlet access full"),
+        "the rejection must name both explicit ways out: {combined}"
+    );
+    assert!(
+        !fixture.capture.join("last-argv").exists(),
+        "rejection must happen before any probe or worker spawn"
+    );
+    assert!(!fixture.capture.join("invoked").exists());
 }

--- a/tests/provider_response_refusal_process.rs
+++ b/tests/provider_response_refusal_process.rs
@@ -72,7 +72,7 @@ mod unix {
             fs::write(
                 root.join(".agents/workers.yaml"),
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture\n    model: fixture-model\n    provider_response_refusal_patterns: ['provider declined response']\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}', 'YARD-001']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 3\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n  allow_preferred_worker_failover: false\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    model: fixture-model\n    provider_response_refusal_patterns: ['provider declined response']\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}', 'YARD-001']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 3\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n  allow_preferred_worker_failover: false\n",
                     worker.display(),
                     scenario
                 ),
@@ -300,7 +300,7 @@ mod unix {
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: primary\n    model: fixture-model\n    provider_response_refusal_patterns: ['provider declined response']\n    invocation:\n      command: {0}\n      args: ['{{run_dir}}', 'unclassified', 'YARD-001']\n      supports_noninteractive: true\n      output_contract: files\n    limits: {{max_wall_minutes: 1, max_retries: 0}}\n  - id: alternate\n    model: fixture-model\n    provider_response_refusal_patterns: ['provider declined response']\n    invocation:\n      command: {0}\n      args: ['{{run_dir}}', 'alternate_success', 'YARD-001']\n      supports_noninteractive: true\n      output_contract: files\n    limits: {{max_wall_minutes: 1, max_retries: 0}}\nrouting:\n  default_worker: primary\n  fallback_order: [primary, alternate]\n  allow_preferred_worker_failover: true\n",
+                "schema_version: 1\nworkers:\n  - id: primary\n    model: fixture-model\n    provider_response_refusal_patterns: ['provider declined response']\n    invocation:\n      command: {0}\n      args: ['{{run_dir}}', 'unclassified', 'YARD-001']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits: {{max_wall_minutes: 1, max_retries: 0}}\n  - id: alternate\n    model: fixture-model\n    provider_response_refusal_patterns: ['provider declined response']\n    invocation:\n      command: {0}\n      args: ['{{run_dir}}', 'alternate_success', 'YARD-001']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits: {{max_wall_minutes: 1, max_retries: 0}}\nrouting:\n  default_worker: primary\n  fallback_order: [primary, alternate]\n  allow_preferred_worker_failover: true\n",
                 worker.display()
             ),
         )

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -130,7 +130,7 @@ fn stopping_yardlet_takes_the_worker_it_started_with_it() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             worker.display(),
             ids.display()
         ),
@@ -272,7 +272,7 @@ fn stopping_reaches_a_grandchild_whose_launcher_exits_first() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             worker.display()
         ),
     )
@@ -401,7 +401,7 @@ fn a_result_written_before_the_interrupt_does_not_finish_the_task() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             worker.display(),
             ids.display()
         ),
@@ -528,7 +528,7 @@ fn recover_in_a_fresh_process_honours_the_interruption() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 10\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             worker.display(),
             ids.display()
         ),

--- a/tests/tui_planning_reentry_process.rs
+++ b/tests/tui_planning_reentry_process.rs
@@ -200,6 +200,7 @@ fn an_accepted_unconfirmed_plan_is_reachable_from_home_after_a_restart() {
              \x20 \x20 \x20 command: {}\n\
              \x20 \x20 \x20 supports_noninteractive: true\n\
              \x20 \x20 \x20 output_contract: files\n\
+             \x20 \x20 \x20 sandbox_args: ['--fixture-sandbox']\n\
              \x20 \x20 \x20 args: [\"{{run_dir}}\"]\n\
              \x20 \x20 limits:\n\
              \x20 \x20 \x20 max_wall_minutes: 1\n\

--- a/tests/tui_startup_review_revision_process.rs
+++ b/tests/tui_startup_review_revision_process.rs
@@ -157,6 +157,7 @@ fn slow_startup_then_ko_review_then_multiline_revision_over_one_pty() {
              \x20 \x20 \x20 command: {}\n\
              \x20 \x20 \x20 supports_noninteractive: true\n\
              \x20 \x20 \x20 output_contract: files\n\
+             \x20 \x20 \x20 sandbox_args: ['--fixture-sandbox']\n\
              \x20 \x20 \x20 args: [\"{{run_dir}}\"]\n\
              \x20 \x20 limits:\n\
              \x20 \x20 \x20 max_wall_minutes: 1\n\

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -101,7 +101,7 @@ mod unix {
             fs::write(
                 root.join(".agents/workers.yaml"),
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-ask\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: codex\n    invocation:\n      command: {0}\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-ask\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: codex\n    invocation:\n      command: {0}\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
                     worker.display(),
                 ),
             )
@@ -385,7 +385,7 @@ fi
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: {}\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\n  allow_preferred_worker_failover: false\n",
+                "schema_version: 1\nworkers:\n  - id: codex\n    model: gpt-5.6-sol\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: {}\nrouting:\n  default_worker: codex\n  fallback_order: [codex]\n  allow_preferred_worker_failover: false\n",
                 worker_path(fixture).display(),
                 max_retries
             ),
@@ -441,7 +441,7 @@ JSON
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture-planner\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-planner\n  fallback_order: [fixture-planner]\n  planning_gate:\n    primary: fixture-planner\n    fallback: \"\"\n",
+                "schema_version: 1\nworkers:\n  - id: fixture-planner\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-planner\n  fallback_order: [fixture-planner]\n  planning_gate:\n    primary: fixture-planner\n    fallback: \"\"\n",
                 planner.display()
             ),
         )
@@ -528,7 +528,7 @@ JSON
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture-planner\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-planner\n  fallback_order: [fixture-planner]\n  planning_gate:\n    primary: fixture-planner\n    fallback: \"\"\n",
+                "schema_version: 1\nworkers:\n  - id: fixture-planner\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-planner\n  fallback_order: [fixture-planner]\n  planning_gate:\n    primary: fixture-planner\n    fallback: \"\"\n",
                 planner.display()
             ),
         )
@@ -616,7 +616,7 @@ printf '# Handoff\n\nPolicy-authorized failover completed.\n' >"$run_dir/handoff
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
+                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
                 primary.display(),
                 fallback.display()
             ),
@@ -992,7 +992,7 @@ printf '# Handoff\n\nFailover fixture completed.\n' >"$run_dir/handoff.md"
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
+                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
                 primary.display(),
                 fallback.display()
             ),
@@ -1247,7 +1247,7 @@ printf 'primary intentionally omitted result.json\n' >&2
         fs::write(
             root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
                 worker.display()
             ),
         )
@@ -1369,7 +1369,7 @@ printf 'primary intentionally omitted result.json\n' >&2
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture\n    model: fixture-model\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-ask\n    model: fixture-model\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    model: fixture-model\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                "schema_version: 1\nworkers:\n  - id: fixture\n    model: fixture-model\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-ask\n    model: fixture-model\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    model: fixture-model\n    invocation:\n      command: {0}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
                 worker_path(&fixture).display(),
             ),
         )
@@ -1517,7 +1517,7 @@ printf '# Handoff\n\nSibling task drained.\n' >"$run_dir/handoff.md"
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    model: drain-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
+                "schema_version: 1\nworkers:\n  - id: fixture-primary\n    model: primary-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-fallback\n    model: fallback-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    model: drain-model\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-primary\n  fallback_order: [fixture-fallback]\n  allow_preferred_worker_failover: true\n",
                 primary.display(),
                 fallback.display(),
                 drain.display()
@@ -1693,7 +1693,7 @@ printf '# Handoff\n\nSibling task drained.\n' >"$run_dir/handoff.md"
         fs::write(
             fixture.root.join(".agents/workers.yaml"),
             format!(
-                "schema_version: 1\nworkers:\n  - id: fixture-nomodel\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-nomodel\n  fallback_order: [fixture-nomodel]\n",
+                "schema_version: 1\nworkers:\n  - id: fixture-nomodel\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\n  - id: fixture-drain\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture-nomodel\n  fallback_order: [fixture-nomodel]\n",
                 primary.display(),
                 drain.display()
             ),
@@ -3122,7 +3122,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             fs::write(
                 &workers_path,
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files, sandbox_args: ['--fixture-sandbox'] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files, sandbox_args: ['--fixture-sandbox'] }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
                     producer_command.display(),
                     worker.display()
                 ),

--- a/tests/v010_004_local_app_dogfood.rs
+++ b/tests/v010_004_local_app_dogfood.rs
@@ -139,7 +139,7 @@ mod unix {
             fs::write(
                 root.join(".agents/workers.yaml"),
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: local-app-fixture\n    invocation:\n      command: \"{}\"\n      args: [\"{{run_dir}}\", \"{}\", \"{}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: local-app-fixture\n  fallback_order: [local-app-fixture]\n",
+                    "schema_version: 1\nworkers:\n  - id: local-app-fixture\n    invocation:\n      command: \"{}\"\n      args: [\"{{run_dir}}\", \"{}\", \"{}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: local-app-fixture\n  fallback_order: [local-app-fixture]\n",
                     worker.display(),
                     app.display(),
                     capture.display()

--- a/tests/v010_004_resource_operations.rs
+++ b/tests/v010_004_resource_operations.rs
@@ -81,7 +81,7 @@ mod unix {
             fs::write(
                 root.join(".agents/workers.yaml"),
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
                     worker.display()
                 ),
             )

--- a/tests/v010_004_resource_publication.rs
+++ b/tests/v010_004_resource_publication.rs
@@ -61,7 +61,7 @@ mod unix {
             fs::write(
                 root.join(".agents/workers.yaml"),
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
                     worker.display()
                 ),
             )

--- a/tests/worker_survives_terminal_hangup_process.rs
+++ b/tests/worker_survives_terminal_hangup_process.rs
@@ -119,7 +119,7 @@ fn a_worker_survives_a_hangup_delivered_to_yardlets_process_group() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             worker.display(),
             ids.display()
         ),

--- a/tests/worker_teardown_kills_grandchildren_process.rs
+++ b/tests/worker_teardown_kills_grandchildren_process.rs
@@ -140,7 +140,7 @@ fn stopping_a_worker_takes_down_the_cli_it_launched() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 2\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             launcher.display(),
             ids.display()
         ),
@@ -263,7 +263,7 @@ fn a_wall_clock_timeout_does_not_hang_on_a_grandchild_holding_the_pipes() {
     fs::write(
         root.join(".agents/workers.yaml"),
         format!(
-            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      args: ['{{run_dir}}', '{}']\n      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n",
             launcher.display(),
             ids.display()
         ),


### PR DESCRIPTION
Closes #123.

## What

`access: sandboxed` meant two different things: an enforced boundary for the built-in adapters (core-owned flags) and an unverified claim for generic workers — a valid generic profile with empty `sandbox_args` ran unbounded and could write canonical `.agents/` state while the workspace believed writes were bounded.

This lands Direction 1 (verify rather than assume) plus the Direction 3 honesty label:

- `guard::access_contract` joins the shared invocability verdict: under `sandboxed` access a generic profile must declare a real sandbox contract — non-empty `sandbox_args`, distinct from `full_access_args`, no elevation markers or unknown placeholders (the same declaration `scout_sandbox_contract` already required; the validator is now shared as `generic_sandbox_declaration`).
- The refusal names both explicit ways out: declare `invocation.sandbox_args`, or grant full access explicitly with `yardlet access full`. Same posture as the billing guard.
- The requested access threads through every consumer of the single verdict: CLI `worker status`, TUI snapshot — including `readiness_cache_key`, so flipping `yardlet access` invalidates a cached Ready — routing, failover, planning worker selection, and capability projection. Spawn defensively re-checks the access it actually uses.
- A ready generic worker's status says `sandbox is profile-declared, not verified by Yardlet`, so an operator reading "sandboxed" can tell an enforced boundary from a declared one.
- EN/KO README and the workers.yaml template document the requirement and the label 1:1.

## Migration note

Existing generic profiles without `sandbox_args` become not-invocable under sandboxed access until they declare one (or the workspace grants full access). This is the intended fail-closed behavior — the previous behavior was the vulnerability.

## Verification

- New guard unit tests (refusal under sandboxed, ready-with-label, built-in exemption, elevation/identical-args rejection, cache-key sensitivity); the refusal test was proven RED by neutering the gate and re-proven GREEN after restoring it.
- New process counterexample: a generic profile with no sandbox declaration is rejected before any probe or worker spawn, with the message naming both ways out.
- The capability-discovery `active_state_isolation` scenario now observes the fail-closed verdict at planning-worker selection — strictly earlier than the scout gate it used to hit.
- Full `cargo test --all-features --no-fail-fast`: 31 targets ok, 0 failed. fmt and clippy (`-D warnings`, all targets/features) clean.