### PR TITLE
feat(worker): opt-in native session resume for generic workers (V010-006 slice 2)

### DIFF
--- a/.agents/skills/generic-fixture-attempt-env-scrub-last-secret/SKILL.md
+++ b/.agents/skills/generic-fixture-attempt-env-scrub-last-secret/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: generic-fixture-attempt-env-scrub-last-secret
+description: generic fixture 워커의 attempt별 env-scrub 단언은 last-secret 사본으로
+source: learned
+---
+tests/generic_worker_contract_process.rs의 fake worker.sh는 매 호출 상단에서 $capture/last-secret에 present/absent를 기록한다. 특정 분기(probe/resume/fresh)의 청구-비밀 세정을 단언하려면 그 분기 안에서 `cp "$capture/last-secret" "$capture/<branch>-secret"`로 복사한 뒤 테스트에서 `<branch>-secret == "absent"`를 단언하라. 값이 근거 있는지는 build_generic_* 커맨드의 cmd.env_clear() + 공통 env 맵 적용(src/workers/mod.rs)이 보장한다. 단언만 먼저 넣어 파일-부재 RED로 비공허성을 확인한 뒤 캡처를 추가할 것.

--- a/.agents/skills/generic-session-resume-review-evidence-map/SKILL.md
+++ b/.agents/skills/generic-session-resume-review-evidence-map/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: generic-session-resume-review-evidence-map
+description: generic-session-resume-review-evidence-map
+source: learned
+---
+제네릭 세션 재개 계약 검토 시 인과 사슬을 이 6점으로 추적: (1) 캡처규칙 src/workers/mod.rs session_capture_rule(resume 시 None), (2) ref 기록 run.rs worker.completed payload + state.rs replay가 producer.worker_session_ref 채움, (3) 판정 run.rs same_worker && supports_native_resume(&profile), (4) 모드 state.rs answer_question native 분기, (5) 실행 run.rs continuation==NativeResume → session_id·resume=true, (6) command build_generic_resume_command 재검증+argv 직접확장. positive/negative는 generic_worker_contract_process.rs와 v010_003 fallback 테스트로 확인하고, 반드시 cargo test --all-features(slow tier 포함)로 exit status를 새로 기록.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- **Opt-in native session resume for generic workers.** A generic profile can
+  declare a `session` contract: a capture rule (stream + exact line prefix)
+  that turns a fresh child's own output into an opaque session ref, and a
+  `resume_args` template with exactly one `{session}`. When the profile
+  declares it and the questioning attempt actually captured a ref, `yardlet
+  answer` resumes that same worker session natively; otherwise it falls back
+  to the existing explicit-packet continuation. Resume eligibility is decided
+  by the selected profile's contract and the captured ref, never by worker id
+  strings or guessed session files, and resume argv preserves argument
+  boundaries without shell parsing. Profiles that omit the block keep today's
+  behavior unchanged.
+
 ### Changed
 
 - **`sandboxed` access is no longer an unverified claim for generic workers.**

--- a/README.ko.md
+++ b/README.ko.md
@@ -352,6 +352,9 @@ TUI는 모두 같은 판정을 사용합니다.
     version_args: ["version", "--offline"] # 기본값: ["--version"]
     prompt_transport: argument              # 기본값: stdin
     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
+    session:                                # 선택적 native resume 계약
+      capture: {stream: stdout, prefix: "SESSION_REF="}
+      resume_args: ["resume", "--session", "{session}", "--prompt", "{prompt}"]
     sandbox_args: ["--sandbox"]        # 기본 접근 수준
     full_access_args: ["--yolo"]       # 풀 액세스가 허용될 때만
     model_args: ["--model", "{model}"] # 모델이 설정되면 추가됨
@@ -365,6 +368,21 @@ stdin으로 보내고, `version_args`를 생략하면 `--version`을 실행합�
 넣으세요. Yardlet은 셸 문자열을 만들지 않고 하나의 `Command` 인자로 치환하여 인자
 경계를 보존합니다. stdin 전달에는 `{prompt}`를 넣으면 안 됩니다. 그 밖의 호출
 플레이스홀더는 `{run_dir}`, `{model}`, `{effort}`, `{image}`입니다.
+
+제네릭 native resume은 하위 호환 opt-in입니다. `session`을 생략하면 기존
+`ExplicitPacket` 답변 continuation을 유지합니다. `session`이 있으면
+`capture.stream`은 `stdout` 또는 `stderr`여야 하고, `capture.prefix`는 비어 있지 않은
+단일 행 prefix여야 하며, `resume_args`에는 `{session}`이 정확히 한 번 있어야 합니다.
+fresh child의 선택된 raw stream에서 이 정확한 prefix 뒤에 처음 나온 비어 있지 않은
+suffix가 opaque `worker_session_ref`가 됩니다. Yardlet은 전역 session 파일을 읽거나 다른
+attempt의 참조를 추론하지 않습니다.
+
+resume template은 fresh generic invocation과 같은 `command`, access, model, effort, image,
+정화된 환경 계약을 사용합니다. `{prompt}`는 `prompt_transport`를 따릅니다. `stdin`이면
+`resume_args`에서 생략하고, `argument`이면 정확히 한 번 넣습니다. 각 template 항목은
+하나의 `Command` 인자가 되므로 `{session}`과 `{prompt}`의 argv 경계가 유지됩니다.
+session block이 없거나, fresh child가 비어 있지 않은 ref를 내지 않거나, answer routing이
+다른 worker를 선택하면 Yardlet은 native resume 대신 안전하게 `ExplicitPacket`을 사용합니다.
 
 워커는 실행 디렉터리에 `result.json`과 `handoff.md`를 작성해야 합니다. 실행 env는
 프로필이 `pass_env`로 변수를 다시 옵트인하지 않는 한 정화됩니다. 버전 프로브도 정화된

--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ status, and the TUI all use that same decision.
     version_args: ["version", "--offline"] # default: ["--version"]
     prompt_transport: argument              # default: stdin
     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
+    session:                                # optional native resume contract
+      capture: {stream: stdout, prefix: "SESSION_REF="}
+      resume_args: ["resume", "--session", "{session}", "--prompt", "{prompt}"]
     sandbox_args: ["--sandbox"]        # default access level
     full_access_args: ["--yolo"]       # only when full access is granted
     model_args: ["--model", "{model}"] # added when a model is set
@@ -385,6 +388,22 @@ Yardlet substitutes it as one `Command` argument, preserving argument
 boundaries without constructing a shell string. Stdin delivery must not include
 `{prompt}`. The other invocation placeholders are `{run_dir}`, `{model}`,
 `{effort}`, and `{image}`.
+
+Generic native resume is backward-compatible and opt-in. Omit `session` to keep
+the existing `ExplicitPacket` answer continuation. When `session` is present,
+`capture.stream` must be `stdout` or `stderr`, `capture.prefix` must be a
+non-empty single-line prefix, and `resume_args` must contain exactly one
+`{session}`. The first non-empty suffix after that exact prefix in the fresh
+child's selected raw stream becomes the opaque `worker_session_ref`. Yardlet
+does not inspect global session files or infer a reference from another attempt.
+
+The resume template uses the same `command`, access, model, effort, image, and
+sanitized environment contract as the fresh generic invocation. `{prompt}`
+follows `prompt_transport`: omit it from `resume_args` for `stdin`, or include it
+exactly once for `argument`. Each template item becomes one `Command` argument,
+so `{session}` and `{prompt}` retain their argv boundaries. If the session block
+is absent, the fresh child emits no non-empty ref, or answer routing selects a
+different worker, Yardlet safely uses `ExplicitPacket` instead of native resume.
 
 The worker must write `result.json` and `handoff.md` in the run directory. Its
 execution env is sanitized unless the profile opts variables back in with

--- a/docs/reviews/generic-worker-session-resume-review.md
+++ b/docs/reviews/generic-worker-session-resume-review.md
@@ -1,0 +1,106 @@
+# 제네릭 워커 세션 재개 계약 독립 검토 (YARD-002)
+
+- 검토 대상 구현: `f181b61` "yardlet(YARD-001): 제네릭 워커의 opt-in native session resume 구현" (현재 브랜치에 머지됨)
+- 검토 유형: read-only 독립 검토 (제품 코드 미수정)
+- 검토 HEAD: `1b44827`
+- 판정 요약: **AC-001 ~ AC-005 전부 PASS → status: done**
+- 실행 게이트: `cargo fmt -- --check` = 0, `cargo clippy --all-targets --all-features -- -D warnings` = 0, `cargo test --all-features` = 0 (856 passed / 0 failed / 31 test binaries), public-scan clean
+
+---
+
+## 수용 기준 판정 (file:line + test evidence)
+
+### AC-001 — 선택적 세션 계약 선언 + 캡처 규칙·resume template 동시 검증, 기존 profile 무변경 로드 · **PASS**
+
+증거 (코드):
+- 스키마가 opt-in: `src/schemas.rs:2224-2227` `Invocation.session: Option<GenericSessionInvocation>` 에 `#[serde(default, skip_serializing_if = "Option::is_none")]`. 하위 구조 `GenericSessionInvocation{capture, resume_args}` (`src/schemas.rs:2231-2241`), `GenericSessionCapture{stream, prefix}` (`src/schemas.rs:2243-2249`).
+- 세션 선언 시에만 검증: `src/schemas.rs:2332` `let Some(session) = &self.session else { return Ok(()) }` — 미선언이면 즉시 통과. 선언 시 capture.stream ∈ {stdout,stderr} (`:2334-2342`), prefix non-empty·single-line (`:2344-2347`), resume_args placeholder 검증(`:2349-2380`)이 함께 강제된다.
+- 캡처 규칙과 resume template이 한 블록에서 함께 검증됨 → "선언 시 캡처 규칙과 resume argument template이 함께 검증"을 만족.
+
+증거 (테스트):
+- `src/schemas.rs` unit `generic_session_contract_is_opt_in_and_rejects_incomplete_templates` — legacy profile(session 생략)이 `validate().unwrap()` 통과하고 `session.is_none()`; 완전 선언 profile 통과; 불완전 5종(빈 capture, prefix 누락, {session} 0개, {session} 2개, resume {prompt} 불일치) 각각 명시 error로 거절.
+- process `invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn` — `session-capture`/`session-resume-ref`/`session-resume-prompt` 케이스가 probe·worker spawn 이전에 거절됨.
+- process `legacy_stdin_transport_and_default_offline_probe_remain_invocable` — 세션 블록 없는 기존 profile이 그대로 실행되어 packet을 stdin으로 전달.
+
+### AC-002 — 세션 지원 워커의 answer가 같은 worker·정확히 같은 session ref의 NativeResume으로 실행, 답변 1회 전달 후 완료 · **PASS**
+
+증거 (코드):
+- fresh child에서 세션 ref 캡처: `src/workers/mod.rs:924-955` `session_capture_rule` + `prefixed_session_ref_from_line`, 스트리밍 캡처 `capture_prefixed_session_ref` (`:957`), EOF 잔여 처리 (spawn 루프). 캡처된 ref는 `outcome.session_id` → `worker.completed` payload (`src/run.rs:1957`) → 이벤트 리플레이로 producer attempt의 `worker_session_ref` (`src/state.rs:3724-3730`)로 기록.
+- answer 결정: `src/run.rs:2302-2319` `same_worker` 확인 후 `supports_native_resume` 계산, `worker_session_ref`를 `same_worker`일 때만 전달. `src/state.rs:4054-4072`에서 `native`(=supports_native_resume && non-empty ref)일 때 `ContinuationMode::NativeResume`로 설정하고 ref 저장.
+- 실행: `src/run.rs:2881-2888` NativeResume이면 `session_id = attempt.worker_session_ref`, `effective_chained = true` → spawn `resume=true`. `src/workers/mod.rs:1210-1223`에서 generic 분기가 `build_generic_resume_command`로 정확한 session ref를 사용.
+- 답변 1회: `build_generic_resume_command`(`src/workers/mod.rs:690-748`)가 placeholder를 `Command` argv에 직접 확장(shell 미개입), `{prompt}`가 packet을 정확히 1회 치환.
+
+증거 (테스트):
+- process `generic_answer_uses_captured_session_ref_and_declared_native_resume_template` — `resume-argv[2] == "fixture session ref"`, `resume-prompt`에 답변 문자열 count==1, `resume-stdin` 비어 있음(argument transport 중복 없음), attempt record `continuation: native_resume` + `worker_session_ref: fixture session ref`, `worker.completed`가 ref 유지, 최종 status done.
+- unit `generic_resume_uses_the_profile_command_and_preserves_each_argument_boundary` — resume argv 순서/경계 보존.
+- process(v010_003) `native_resume_preserves_session_ref_and_answer_causality` — 세션 ref·인과 보존.
+
+### AC-003 — resume 가능 판정은 worker id 문자열이 아니라 profile 세션 계약 + 현재 fresh child의 ref로; 전역/타 attempt 추측 없음 · **PASS**
+
+증거 (코드):
+- `supports_native_resume`가 `&str`이 아닌 `&WorkerProfile`을 받도록 시그니처 변경: `src/workers/mod.rs:509-511` — generic 경로는 `profile.invocation.session.is_some()`로 판정(내장 codex/claude-code는 out-of-scope로 id 유지). 계약 완전성은 로드시 검증(`src/schemas.rs:2332-2380`) + `build_generic_resume_command`의 재검증(`src/workers/mod.rs:698-711`)으로 보장.
+- ref 출처 고정: producer는 열린 질문을 낸 바로 그 attempt(`src/run.rs:2234-2238`, `attempt_id == question.attempt_id`), 그 ref는 해당 attempt의 fresh child에서만 유래(`src/state.rs:3724-3730`). resume 시 재캡처 없음: `src/workers/mod.rs:929-931` `if resume { return None }`. 전역 세션 파일 미참조.
+- worker 변경 차단: `same_worker` gate(`src/run.rs:2302,2316`) → 다른 worker는 ref 상속 불가.
+
+증거 (테스트):
+- unit `generic_resume_uses_the_profile_command_and_preserves_each_argument_boundary` — 세션 블록 있는 profile에 대해 `supports_native_resume(&profile) == true` 단언(id 무관, profile 기반).
+- process(v010_003) `unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet` — worker 변경 시 continuation의 `worker_session_ref`가 null이고, producer의 `worker.completed`는 `producer-session-ref`를 유지.
+
+### AC-004 — 계약/ref 없으면 ExplicitPacket fallback, 불완전·모호 template은 실행 전 거절, 빈/내장 전용 command로 추락 금지 · **PASS**
+
+증거 (코드):
+- 계약 없음·ref 없음 → ExplicitPacket: `src/state.rs:4054-4072` (native 조건 불충족 시 `ContinuationMode::ExplicitPacket`). 이중 안전망: `src/schemas.rs:3505-3509` attempt validation이 NativeResume에 non-empty `worker_session_ref` 강제.
+- 불완전/모호 template 실행 전 거절: `src/schemas.rs:2332-2380` 로드 검증; `build_generic_resume_command`가 spawn 직전 재검증(`src/workers/mod.rs:698-707`)하며 빈 session ref(`:704-706`)와 세션 계약 부재(`:709-711`)에 bail.
+- 빈/내장 전용 command 추락 방지: spawn 분기(`src/workers/mod.rs:1198-1224`) — generic resume은 `_ =>` 팔에서 `build_generic_resume_command`로만, 내장은 `build_resume_command`로만; `session.ok_or_else`로 ref 부재를 오류화(`:1213-1216`).
+
+증거 (테스트):
+- process `generic_answer_without_a_captured_session_ref_uses_explicit_packet_fallback` — SESSION_REF 미방출 시 `resume-argv` 미생성, packet에 "Explicit continuation packet" 포함, attempt `continuation: explicit_packet`.
+- process `invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn` — 불완전 세션 계약 3종 거절.
+- process(v010_003) `unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet` — worker 변경 시 explicit_packet fallback.
+
+### AC-005 — sandbox/full·model·effort·image 인자, 환경 정화, 결과 파일 계약 무약화 + fmt·전체 feature suite 통과 · **PASS** (env 정화 resume 경로 직접 단언은 관측상 부재 — 결함 아님)
+
+증거 (코드):
+- resume command가 access/model/effort/image 인자를 fresh와 동일 구조로 보존: `build_generic_resume_command`(`src/workers/mod.rs:713-745`)가 full_access_args/sandbox_args, model_args(explicit), effort_args(explicit), image_args를 적용 — `build_generic_command`(`src/workers/mod.rs:657-679`)와 대칭.
+- 환경 정화 유지: 두 빌더 모두 `cmd.env_clear()` 호출(`:745`, `:681`), 이후 `spawn_internal`이 정화된 env를 fresh/resume 공통 경로에서 적용(`src/workers/mod.rs:1261-1263`). env 자체는 billing-policy로 스크럽됨.
+- 결과 파일 계약: resume_args의 `{run_dir}` 확장으로 worker가 result.json을 run_dir에 기록(테스트 fixture가 실증).
+
+증거 (실행/테스트):
+- `cargo fmt -- --check` = **0**, `cargo clippy --all-targets --all-features -- -D warnings` = **0**, `cargo test --all-features` = **0** (856 passed / 0 failed / 31 binaries). (본 run의 `validation.log` 참조.)
+- unit `generic_resume_uses_the_profile_command_and_preserves_each_argument_boundary` — resume argv 전체 순서 `[resume, "session ref with spaces", <packet>, "safe mode", --model, fixture-model, --effort, high, --image, "image one.png"]`, program·cwd 보존.
+- fresh 경로 env 정화는 `generic_argument_transport_preserves_argv_boundaries_and_delivers_the_packet_once`, `legacy_stdin_transport_and_default_offline_probe_remain_invocable`가 `last-secret == absent`로 단언.
+
+관측(비차단): resume 경로에 대한 env-scrub 직접 단언(예: resume fixture에서 `last-secret == absent`)은 없다. env 적용이 fresh/resume 공통 코드라 구조상 분기 불가하므로 결함은 아니지만, 회귀망 강화 여지가 있어 후속 과제로 제안한다.
+
+---
+
+## Positive · Negative 매트릭스 (실제 test로 확인)
+
+| 시나리오 | 기대 | 확인 test | 결과 |
+|---|---|---|---|
+| 세션 지원 profile + ref 캡처 → answer | NativeResume, 같은 ref, 답변 1회 | `generic_answer_uses_captured_session_ref_and_declared_native_resume_template` | ok |
+| legacy profile (세션 생략) | 무변경 로드·실행 | `generic_session_contract_is_opt_in_...`, `legacy_stdin_transport_...` | ok |
+| session ref 유실 | ExplicitPacket fallback | `generic_answer_without_a_captured_session_ref_uses_explicit_packet_fallback` | ok |
+| 불완전 세션 template | spawn 전 거절 | `invalid_contract_and_strict_billing_are_rejected_...`, `generic_session_contract_is_opt_in_...` | ok |
+| worker 변경 | ref 미상속, ExplicitPacket | `unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet` | ok |
+| argv 경계·access·cwd 보존 | 경계 유지 | `generic_resume_uses_the_profile_command_and_preserves_each_argument_boundary` | ok |
+
+---
+
+## 잔여 위험 (residual risk)
+
+1. **[minor] resume 경로 env-scrub 회귀 단언 부재.** fresh 경로만 `last-secret == absent`를 단언한다. 구조상 공통 코드라 현재는 안전하나, 향후 resume가 별도 env 조립 경로로 갈라질 경우를 대비한 명시 단언이 없다. → 후속 과제 제안(FT-1).
+2. **[minor] resume_args에 `{run_dir}` 필수 검증 없음.** fresh `args`와 동일하게 검증은 강제하지 않는다(대칭이라 약화는 아님). `{run_dir}`를 빠뜨린 profile은 worker가 결과 파일 위치를 모를 수 있으나, 이는 기존 generic 계약과 동일한 profile 작성자 책임 범위다.
+3. **[info] NativeResume packet은 전체 컴파일 packet.** 답변만이 아닌 full packet(task·repo·conversation)을 프롬프트로 전달한다. 답변 문자열은 1회만 나타나 AC-002를 만족하며, 이는 기존 내장 answer-resume packet 의미와 동일(범위 밖)하므로 결함이 아니다.
+
+## 실행 명령 (독립 재실행)
+
+```
+cargo fmt -- --check                                          # exit 0
+cargo clippy --all-targets --all-features -- -D warnings      # exit 0
+cargo test --all-features                                     # exit 0 (856 passed / 0 failed)
+# 대상 회귀만:
+cargo test --all-features generic_session_contract_is_opt_in_and_rejects_incomplete_templates
+cargo test --all-features --test generic_worker_contract_process
+cargo test --all-features --test v010_003_task_channels_process unavailable_question_producer_falls_back_to_selected_worker_with_explicit_packet
+```

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -878,6 +878,7 @@ invocation:
                 model_args: vec![],
                 effort_args: vec![],
                 pass_env: vec![],
+                session: None,
             },
             limits: crate::schemas::Limits::default(),
             provider_response_refusal_patterns: vec![],

--- a/src/run.rs
+++ b/src/run.rs
@@ -2300,6 +2300,8 @@ pub(crate) fn prepare_answer_action_with_deviations(
     let billing = ws.load_billing()?;
     let selected = routing::resolve_worker_for_task(ws, &workers_file, &billing, None, task)?;
     let same_worker = selected.worker_id == producer.worker_id;
+    let selected_profile = find_worker(&workers_file.workers, &selected.worker_id)?;
+    let supports_native_resume = same_worker && workers::supports_native_resume(selected_profile);
     ws.answer_question(&AnswerActionRequest {
         continuation_attempt_id: action_attempt_id(&action_id),
         answer_id: format!("ans-{}", action_attempt_id(&action_id)),
@@ -2314,7 +2316,7 @@ pub(crate) fn prepare_answer_action_with_deviations(
         worker_session_ref: same_worker
             .then(|| producer.worker_session_ref.clone())
             .flatten(),
-        supports_native_resume: same_worker && workers::supports_native_resume(&selected.worker_id),
+        supports_native_resume,
     })?;
     Ok(true)
 }

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -2221,6 +2221,32 @@ pub struct Invocation {
     /// itself never reads or stores the values.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pass_env: Vec<String>,
+    /// Opt-in native session continuation for a generic adapter. Existing
+    /// profiles omit this and keep ExplicitPacket answer continuation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session: Option<GenericSessionInvocation>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GenericSessionInvocation {
+    /// Exact fresh-child raw stream marker used to capture the provider's
+    /// opaque session reference. Yardlet never consults global session state.
+    #[serde(default)]
+    pub capture: GenericSessionCapture,
+    /// Generic resume argv template. It uses the invocation's prompt transport
+    /// and must contain exactly one `{session}` placeholder.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resume_args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GenericSessionCapture {
+    /// Raw child stream containing the marker: `stdout` or `stderr`.
+    #[serde(default)]
+    pub stream: String,
+    /// Exact line prefix. The non-empty trimmed suffix is the session ref.
+    #[serde(default)]
+    pub prefix: String,
 }
 
 fn default_prompt_transport() -> String {
@@ -2259,8 +2285,15 @@ impl Invocation {
                 "worker '{worker_id}' generic version_args must contain a configured offline probe"
             ));
         }
-        validate_invocation_args(worker_id, "version_args", &self.version_args, false, false)?;
-        validate_invocation_args(worker_id, "args", &self.args, true, true)?;
+        validate_invocation_args(
+            worker_id,
+            "version_args",
+            &self.version_args,
+            false,
+            false,
+            false,
+        )?;
+        validate_invocation_args(worker_id, "args", &self.args, true, true, false)?;
         for (label, args) in [
             ("sandbox_args", &self.sandbox_args),
             ("full_access_args", &self.full_access_args),
@@ -2268,7 +2301,7 @@ impl Invocation {
             ("model_args", &self.model_args),
             ("effort_args", &self.effort_args),
         ] {
-            validate_invocation_args(worker_id, label, args, true, false)?;
+            validate_invocation_args(worker_id, label, args, true, false, false)?;
         }
 
         let prompt_count = self
@@ -2277,17 +2310,75 @@ impl Invocation {
             .map(|arg| arg.matches("{prompt}").count())
             .sum::<usize>();
         match self.prompt_transport.trim() {
-            "stdin" if prompt_count == 0 => Ok(()),
-            "stdin" => Err(format!(
+            "stdin" if prompt_count == 0 => {}
+            "stdin" => {
+                return Err(format!(
                 "worker '{worker_id}' uses prompt_transport stdin, so args must not contain {{prompt}}"
-            )),
-            "argument" | "arg" if prompt_count == 1 => Ok(()),
-            "argument" | "arg" => Err(format!(
+            ))
+            }
+            "argument" | "arg" if prompt_count == 1 => {}
+            "argument" | "arg" => {
+                return Err(format!(
                 "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in args"
-            )),
-            other => Err(format!(
+            ))
+            }
+            other => {
+                return Err(format!(
                 "worker '{worker_id}' has unsupported prompt_transport '{other}'; expected stdin or argument"
+            ))
+            }
+        }
+
+        let Some(session) = &self.session else {
+            return Ok(());
+        };
+        match session.capture.stream.trim() {
+            "stdout" | "stderr" => {}
+            other => {
+                return Err(format!(
+                    "worker '{worker_id}' generic session capture stream '{other}' is invalid; expected stdout or stderr"
+                ))
+            }
+        }
+        if session.capture.prefix.trim().is_empty() || session.capture.prefix.contains(['\n', '\r'])
+        {
+            return Err(format!(
+                "worker '{worker_id}' generic session capture prefix must be non-empty and single-line"
+            ));
+        }
+        validate_invocation_args(
+            worker_id,
+            "session.resume_args",
+            &session.resume_args,
+            true,
+            true,
+            true,
+        )?;
+        let session_count = session
+            .resume_args
+            .iter()
+            .map(|arg| arg.matches("{session}").count())
+            .sum::<usize>();
+        if session_count != 1 {
+            return Err(format!(
+                "worker '{worker_id}' generic session resume_args require exactly one {{session}} placeholder"
+            ));
+        }
+        let resume_prompt_count = session
+            .resume_args
+            .iter()
+            .map(|arg| arg.matches("{prompt}").count())
+            .sum::<usize>();
+        match self.prompt_transport.trim() {
+            "stdin" if resume_prompt_count == 0 => Ok(()),
+            "stdin" => Err(format!(
+                "worker '{worker_id}' uses prompt_transport stdin, so session.resume_args must not contain {{prompt}}"
             )),
+            "argument" | "arg" if resume_prompt_count == 1 => Ok(()),
+            "argument" | "arg" => Err(format!(
+                "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in session.resume_args"
+            )),
+            _ => unreachable!("prompt transport was validated above"),
         }
     }
 }
@@ -2298,6 +2389,7 @@ fn validate_invocation_args(
     args: &[String],
     allow_runtime_placeholders: bool,
     allow_prompt: bool,
+    allow_session: bool,
 ) -> Result<(), String> {
     for arg in args {
         let mut remainder = arg.clone();
@@ -2308,6 +2400,9 @@ fn validate_invocation_args(
         }
         if allow_prompt {
             remainder = remainder.replace("{prompt}", "");
+        }
+        if allow_session {
+            remainder = remainder.replace("{session}", "");
         }
         if remainder.contains('{') || remainder.contains('}') {
             return Err(format!(
@@ -3890,6 +3985,51 @@ delivery: auto
             let error = workers
                 .validate()
                 .expect_err("ambiguous generic prompt transport must fail validation");
+            assert!(error.contains(expected), "{error:?} does not contain {expected:?}");
+        }
+    }
+
+    #[test]
+    fn generic_session_contract_is_opt_in_and_rejects_incomplete_templates() {
+        let legacy: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation: {command: fixture}\n",
+        )
+        .unwrap();
+        legacy.validate().unwrap();
+        assert!(legacy.workers[0].invocation.session.is_none());
+
+        let configured: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: argument\n      args: [run, '{prompt}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: [resume, '{session}', '{prompt}']\n",
+        )
+        .unwrap();
+        configured.validate().unwrap();
+
+        for (yaml, expected) in [
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      session: {}\n",
+                "session capture stream",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      session:\n        capture: {stream: stdout}\n        resume_args: [resume, '{session}']\n",
+                "session capture prefix",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: [resume]\n",
+                "exactly one {session}",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: [resume, '{session}', '{session}']\n",
+                "exactly one {session}",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: argument\n      args: [run, '{prompt}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: [resume, '{session}']\n",
+                "exactly one {prompt}",
+            ),
+        ] {
+            let workers: WorkersFile = crate::yaml::from_str(yaml).unwrap();
+            let error = workers
+                .validate()
+                .expect_err("incomplete generic session contract must fail validation");
             assert!(error.contains(expected), "{error:?} does not contain {expected:?}");
         }
     }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -506,8 +506,8 @@ fn explicit(v: &str) -> bool {
     !v.trim().is_empty() && !v.eq_ignore_ascii_case("auto")
 }
 
-pub fn supports_native_resume(worker_id: &str) -> bool {
-    matches!(worker_id, "codex" | "claude-code")
+pub fn supports_native_resume(profile: &WorkerProfile) -> bool {
+    matches!(profile.id.as_str(), "codex" | "claude-code") || profile.invocation.session.is_some()
 }
 
 /// The profile a task actually runs with. A per-task `model`/`effort` overrides
@@ -682,6 +682,72 @@ pub fn build_generic_command(
     Ok(cmd)
 }
 
+/// Build a generic worker's opt-in native resume command from the same binary
+/// and invocation profile as its fresh child. Placeholder expansion writes
+/// directly to `Command` argv, so the opaque session ref and prompt each retain
+/// their declared argument boundary without shell parsing.
+#[allow(clippy::too_many_arguments)]
+fn build_generic_resume_command(
+    inv: &Invocation,
+    bin: &Path,
+    packet: &str,
+    session_ref: &str,
+    run_dir: &Path,
+    cwd: &Path,
+    full_access: bool,
+    model: &str,
+    effort: &str,
+    images: &[String],
+) -> Result<Command> {
+    inv.validate_generic("generic worker")
+        .map_err(anyhow::Error::msg)?;
+    if session_ref.trim().is_empty() {
+        anyhow::bail!("generic native resume requires a non-empty session ref");
+    }
+    let session = inv
+        .session
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("generic worker has no native session contract"))?;
+    let expand = |arg: &str, image: &str| -> String {
+        arg.replace("{run_dir}", &run_dir.display().to_string())
+            .replace("{model}", model)
+            .replace("{effort}", effort)
+            .replace("{image}", image)
+            .replace("{session}", session_ref)
+            .replace("{prompt}", packet)
+    };
+    let mut cmd = Command::new(bin);
+    for arg in &session.resume_args {
+        cmd.arg(expand(arg, ""));
+    }
+    let access = if full_access {
+        &inv.full_access_args
+    } else {
+        &inv.sandbox_args
+    };
+    for arg in access {
+        cmd.arg(expand(arg, ""));
+    }
+    if explicit(model) {
+        for arg in &inv.model_args {
+            cmd.arg(expand(arg, ""));
+        }
+    }
+    if explicit(effort) {
+        for arg in &inv.effort_args {
+            cmd.arg(expand(arg, ""));
+        }
+    }
+    for image in images {
+        for arg in &inv.image_args {
+            cmd.arg(expand(arg, image));
+        }
+    }
+    cmd.current_dir(cwd);
+    cmd.env_clear();
+    Ok(cmd)
+}
+
 /// Build the command to RESUME an existing worker session (continue, not redo).
 /// claude: `-p --resume <id>`; codex: `exec resume <id> -` (prompt on stdin).
 /// Note: codex `resume` has no `--sandbox`/`--add-dir`; full-access bypasses the
@@ -844,6 +910,70 @@ fn capture_codex_thread_id(
     }
     // `thread.started` is a small leading event. Fail closed instead of
     // retaining unbounded non-JSON output while waiting for it.
+    if pending.len() > 64 * 1024 {
+        pending.clear();
+    }
+}
+
+#[derive(Clone)]
+enum SessionCaptureRule {
+    CodexThread,
+    Prefixed(String),
+}
+
+fn session_capture_rule(
+    profile: &WorkerProfile,
+    stream: RawStreamKind,
+    resume: bool,
+) -> Option<SessionCaptureRule> {
+    if resume {
+        return None;
+    }
+    if profile.id == "codex" && stream == RawStreamKind::Stdout {
+        return Some(SessionCaptureRule::CodexThread);
+    }
+    if matches!(profile.id.as_str(), "codex" | "claude-code") {
+        return None;
+    }
+    let capture = &profile.invocation.session.as_ref()?.capture;
+    let selected_stream = match capture.stream.trim() {
+        "stdout" => RawStreamKind::Stdout,
+        "stderr" => RawStreamKind::Stderr,
+        _ => return None,
+    };
+    (selected_stream == stream).then(|| SessionCaptureRule::Prefixed(capture.prefix.clone()))
+}
+
+fn prefixed_session_ref_from_line(line: &[u8], prefix: &str) -> Option<String> {
+    let line = std::str::from_utf8(line)
+        .ok()?
+        .trim_end_matches(['\r', '\n']);
+    line.strip_prefix(prefix)
+        .map(str::trim)
+        .filter(|session_ref| !session_ref.is_empty())
+        .map(str::to_string)
+}
+
+fn capture_prefixed_session_ref(
+    pending: &mut Vec<u8>,
+    chunk: &[u8],
+    prefix: &str,
+    captured: &std::sync::Arc<std::sync::Mutex<Option<String>>>,
+) {
+    if captured.lock().is_ok_and(|guard| guard.is_some()) {
+        return;
+    }
+    pending.extend_from_slice(chunk);
+    while let Some(newline) = pending.iter().position(|byte| *byte == b'\n') {
+        let line: Vec<u8> = pending.drain(..=newline).collect();
+        if let Some(session_ref) = prefixed_session_ref_from_line(&line, prefix) {
+            if let Ok(mut guard) = captured.lock() {
+                *guard = Some(session_ref);
+            }
+            pending.clear();
+            return;
+        }
+    }
     if pending.len() > 64 * 1024 {
         pending.clear();
     }
@@ -1063,20 +1193,35 @@ fn spawn_internal(
     // process in the canonical run directory.
     let control_run_dir = output_log.parent().unwrap_or(cwd);
     guard::invocation_contract(profile).map_err(anyhow::Error::msg)?;
-    let packet_on_stdin = resume
-        || matches!(profile.id.as_str(), "codex" | "claude-code")
+    let packet_on_stdin = matches!(profile.id.as_str(), "codex" | "claude-code")
         || profile.invocation.prompt_on_stdin();
     let mut cmd = if resume {
-        build_resume_command(
-            &profile.id,
-            bin,
-            worker_run_dir,
-            cwd,
-            full_access,
-            &profile.model,
-            images,
-            session,
-        )
+        match profile.id.as_str() {
+            "codex" | "claude-code" => build_resume_command(
+                &profile.id,
+                bin,
+                worker_run_dir,
+                cwd,
+                full_access,
+                &profile.model,
+                images,
+                session,
+            ),
+            _ => build_generic_resume_command(
+                &profile.invocation,
+                bin,
+                packet,
+                session.ok_or_else(|| {
+                    anyhow::anyhow!("generic native resume requires an exact session ref")
+                })?,
+                worker_run_dir,
+                cwd,
+                full_access,
+                &profile.model,
+                &profile.effort,
+                images,
+            )?,
+        }
     } else {
         let mut c = match profile.id.as_str() {
             // Built-in adapters with verified flags.
@@ -1344,12 +1489,18 @@ fn spawn_internal(
             .and_then(Path::file_name)
             .and_then(|name| name.to_str())
     });
-    type StreamSource = (Box<dyn Read + Send>, bool, RawSink, RawStreamKind, String);
+    type StreamSource = (
+        Box<dyn Read + Send>,
+        Option<SessionCaptureRule>,
+        RawSink,
+        RawStreamKind,
+        String,
+    );
     let mut sources: Vec<StreamSource> = Vec::new();
     if let Some(o) = child.stdout.take() {
         sources.push((
             Box::new(o),
-            profile.id == "codex" && !resume,
+            session_capture_rule(profile, RawStreamKind::Stdout, resume),
             stdout_raw,
             RawStreamKind::Stdout,
             format!("raw_{}_stdout", attempt_id.unwrap_or("unknown")),
@@ -1358,7 +1509,7 @@ fn spawn_internal(
     if let Some(e) = child.stderr.take() {
         sources.push((
             Box::new(e),
-            false,
+            session_capture_rule(profile, RawStreamKind::Stderr, resume),
             stderr_raw,
             RawStreamKind::Stderr,
             format!("raw_{}_stderr", attempt_id.unwrap_or("unknown")),
@@ -1417,10 +1568,19 @@ fn spawn_internal(
                     loop {
                         match src.read(&mut buf) {
                             Ok(0) => {
-                                if capture_session && !pending.is_empty() {
-                                    if let Some(id) = codex_thread_id_from_json_line(&pending) {
+                                if !pending.is_empty() {
+                                    let session_ref = match &capture_session {
+                                        Some(SessionCaptureRule::CodexThread) => {
+                                            codex_thread_id_from_json_line(&pending)
+                                        }
+                                        Some(SessionCaptureRule::Prefixed(prefix)) => {
+                                            prefixed_session_ref_from_line(&pending, prefix)
+                                        }
+                                        None => None,
+                                    };
+                                    if let Some(session_ref) = session_ref {
                                         if let Ok(mut guard) = captured.lock() {
-                                            *guard = Some(id);
+                                            *guard = Some(session_ref);
                                         }
                                     }
                                 }
@@ -1447,8 +1607,19 @@ fn spawn_internal(
                             }
                             Err(error) => return Err(error),
                             Ok(n) => {
-                                if capture_session {
-                                    capture_codex_thread_id(&mut pending, &buf[..n], &captured);
+                                match &capture_session {
+                                    Some(SessionCaptureRule::CodexThread) => {
+                                        capture_codex_thread_id(&mut pending, &buf[..n], &captured);
+                                    }
+                                    Some(SessionCaptureRule::Prefixed(prefix)) => {
+                                        capture_prefixed_session_ref(
+                                            &mut pending,
+                                            &buf[..n],
+                                            prefix,
+                                            &captured,
+                                        );
+                                    }
+                                    None => {}
                                 }
                                 if let Some(raw_sink) = &raw_sink {
                                     if let Ok(mut raw) = raw_sink.lock() {
@@ -2332,6 +2503,62 @@ image_args: ["-i", "{image}"]
         ));
         assert!(cl.windows(2).any(|w| w[0] == "--resume" && w[1] == "SID"));
         assert!(cl.windows(2).any(|w| w[0] == "--model" && w[1] == "opus"));
+    }
+
+    #[test]
+    fn generic_resume_uses_the_profile_command_and_preserves_each_argument_boundary() {
+        let profile: WorkerProfile = crate::yaml::from_str(
+            r#"
+id: fixture
+model: fixture-model
+effort: high
+invocation:
+  command: fixture
+  prompt_transport: argument
+  args: [fresh, '{prompt}']
+  sandbox_args: ['safe mode']
+  full_access_args: ['full mode']
+  model_args: [--model, '{model}']
+  effort_args: [--effort, '{effort}']
+  image_args: [--image, '{image}']
+  session:
+    capture: {stream: stdout, prefix: 'SESSION_REF='}
+    resume_args: [resume, '{session}', '{prompt}']
+"#,
+        )
+        .unwrap();
+        let packet = "answer with spaces; $(must stay literal)";
+        let command = build_generic_resume_command(
+            &profile.invocation,
+            Path::new("fixture"),
+            packet,
+            "session ref with spaces",
+            Path::new("/tmp/run"),
+            Path::new("/tmp/work tree"),
+            false,
+            &profile.model,
+            &profile.effort,
+            &["image one.png".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            args_of(&command),
+            [
+                "resume",
+                "session ref with spaces",
+                packet,
+                "safe mode",
+                "--model",
+                "fixture-model",
+                "--effort",
+                "high",
+                "--image",
+                "image one.png",
+            ]
+        );
+        assert_eq!(command.get_program(), Path::new("fixture"));
+        assert_eq!(command.get_current_dir(), Some(Path::new("/tmp/work tree")));
+        assert!(supports_native_resume(&profile));
     }
 
     #[cfg(unix)]

--- a/templates/agents/workers.yaml
+++ b/templates/agents/workers.yaml
@@ -108,7 +108,9 @@ workers:
 
   # Generic CLI example. Uncomment and customize the whole block.
   # Existing profiles may omit prompt_transport to send the packet on stdin
-  # and omit version_args to probe with --version.
+  # and omit version_args to probe with --version. Native session resume is
+  # also backward-compatible and opt-in: omit the whole session block to keep
+  # ExplicitPacket answer continuation.
   # - id: mytool
   #   kind: cli_worker
   #   best_for: "tasks this CLI handles well"
@@ -122,6 +124,12 @@ workers:
   #     prompt_transport: argument
   #     # {prompt} is exactly one argv item. Yardlet never builds a shell string.
   #     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
+  #     session:
+  #       # The non-empty suffix after this exact fresh-child raw line prefix
+  #       # becomes the opaque session ref. stream is stdout or stderr.
+  #       capture: { stream: stdout, prefix: "SESSION_REF=" }
+  #       # Exactly one {session}; {prompt} follows prompt_transport above.
+  #       resume_args: ["resume", "--session", "{session}", "--prompt", "{prompt}"]
   #     sandbox_args: ["--sandbox"]
   #     full_access_args: ["--full-access"]
   #     model_args: ["--model", "{model}"]

--- a/tests/fixtures/v010_003_task_channels/worker.sh
+++ b/tests/fixtures/v010_003_task_channels/worker.sh
@@ -372,6 +372,7 @@ case "$task_id" in
       printf 'fallback worker explicit continuation\n'
       write_done "fallback worker completed explicit continuation"
     else
+      printf 'SESSION_REF=producer-session-ref\n'
       printf 'producer worker question context\n'
       write_question "continue with a fallback worker?"
     fi

--- a/tests/generic_worker_contract_process.rs
+++ b/tests/generic_worker_contract_process.rs
@@ -393,19 +393,19 @@ fn invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn
         ),
         (
             "session-capture",
-            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n      session:\n        capture: {}\n        resume_args: ['{run_dir}', '{session}']\n",
+            "      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n      args: [execute, '{run_dir}']\n      session:\n        capture: {}\n        resume_args: ['{run_dir}', '{session}']\n",
             "scrub_or_block",
             "session capture stream",
         ),
         (
             "session-resume-ref",
-            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: ['{run_dir}']\n",
+            "      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n      args: [execute, '{run_dir}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: ['{run_dir}']\n",
             "scrub_or_block",
             "exactly one {session}",
         ),
         (
             "session-resume-prompt",
-            "      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: argument\n      args: [execute, '{run_dir}', '{prompt}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: ['{run_dir}', '{session}']\n",
+            "      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n      prompt_transport: argument\n      args: [execute, '{run_dir}', '{prompt}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: ['{run_dir}', '{session}']\n",
             "scrub_or_block",
             "exactly one {prompt}",
         ),
@@ -464,7 +464,7 @@ fn failed_offline_probe_rejects_routing_before_the_worker_invocation() {
 fn generic_answer_uses_captured_session_ref_and_declared_native_resume_template() {
     let fixture = Fixture::new("native-resume");
     fixture.configure(
-        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [ask, '{run_dir}', '{prompt}']\n      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n        resume_args: [resume, '{run_dir}', '{session}', '{prompt}', 'literal with spaces']\n",
+        "      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [ask, '{run_dir}', '{prompt}']\n      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n        resume_args: [resume, '{run_dir}', '{session}', '{prompt}', 'literal with spaces']\n",
         "scrub_or_block",
     );
 
@@ -541,7 +541,7 @@ fn generic_answer_uses_captured_session_ref_and_declared_native_resume_template(
 fn generic_answer_without_a_captured_session_ref_uses_explicit_packet_fallback() {
     let fixture = Fixture::new("missing-session-ref");
     fixture.configure(
-        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [ask-without-session, '{run_dir}', '{prompt}']\n      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n        resume_args: [resume, '{run_dir}', '{session}', '{prompt}']\n",
+        "      supports_noninteractive: true\n      output_contract: files\n      sandbox_args: ['--fixture-sandbox']\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [ask-without-session, '{run_dir}', '{prompt}']\n      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n        resume_args: [resume, '{run_dir}', '{session}', '{prompt}']\n",
         "scrub_or_block",
     );
 

--- a/tests/generic_worker_contract_process.rs
+++ b/tests/generic_worker_contract_process.rs
@@ -165,9 +165,89 @@ if [ "${{1:-}}" = --version ]; then
 fi
 printf invoked > "$capture/invoked"
 run_dir="$2"
+run_id="$(basename "$run_dir")"
+if [ "${{1:-}}" = ask ]; then
+  cp "$capture/last-argv" "$capture/fresh-argv"
+  printf '%s' "${{3:-}}" > "$capture/prompt-argument"
+  cat > "$capture/stdin"
+  printf 'SESSION_REF=fixture session ref\n'
+  cat > "$run_dir/result.json" <<EOF
+{{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "needs_user",
+  "intent_adherence": {{"drift_detected": false, "notes": ""}},
+  "changes": {{"files_modified": [], "files_created": [], "files_deleted": []}},
+  "validation": {{"commands_run": [], "passed": true, "failures": []}},
+  "question_for_user": "Continue in the same generic session?",
+  "compact_summary": "generic fixture needs an answer",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}}
+EOF
+  printf '# Generic worker question\n' > "$run_dir/handoff.md"
+  exit 0
+fi
+if [ "${{1:-}}" = ask-without-session ]; then
+  printf '%s' "${{3:-}}" > "$capture/prompt-argument"
+  cat > "$capture/stdin"
+  if grep -q 'Explicit continuation packet' "$capture/prompt-argument"; then
+    cat > "$run_dir/result.json" <<EOF
+{{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "compact_summary": "generic explicit fallback complete"
+}}
+EOF
+    printf '# Generic worker explicit fallback\n' > "$run_dir/handoff.md"
+  else
+    cat > "$run_dir/result.json" <<EOF
+{{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "needs_user",
+  "question_for_user": "Continue without a captured session ref?",
+  "compact_summary": "generic fixture omitted its session ref"
+}}
+EOF
+    printf '# Generic worker omitted session ref\n' > "$run_dir/handoff.md"
+  fi
+  exit 0
+fi
+if [ "${{1:-}}" = resume ]; then
+  cp "$capture/last-argv" "$capture/resume-argv"
+  printf '%s' "${{4:-}}" > "$capture/resume-prompt"
+  cat > "$capture/resume-stdin"
+  if [ "${{3:-}}" != 'fixture session ref' ]; then
+    printf 'wrong session ref: %s\n' "${{3:-}}" >&2
+    exit 64
+  fi
+  cat > "$run_dir/result.json" <<EOF
+{{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {{"drift_detected": false, "notes": ""}},
+  "changes": {{"files_modified": [], "files_created": [], "files_deleted": []}},
+  "validation": {{"commands_run": [], "passed": true, "failures": []}},
+  "question_for_user": null,
+  "compact_summary": "generic native resume complete",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}}
+EOF
+  printf '# Generic worker resumed\n' > "$run_dir/handoff.md"
+  exit 0
+fi
 printf '%s' "${{3:-}}" > "$capture/prompt-argument"
 cat > "$capture/stdin"
-run_id="$(basename "$run_dir")"
 cat > "$run_dir/result.json" <<EOF
 {{
   "schema_version": 1,
@@ -308,6 +388,24 @@ fn invalid_contract_and_strict_billing_are_rejected_before_probe_or_worker_spawn
             "exactly one {prompt}",
         ),
         (
+            "session-capture",
+            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n      session:\n        capture: {}\n        resume_args: ['{run_dir}', '{session}']\n",
+            "scrub_or_block",
+            "session capture stream",
+        ),
+        (
+            "session-resume-ref",
+            "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: ['{run_dir}']\n",
+            "scrub_or_block",
+            "exactly one {session}",
+        ),
+        (
+            "session-resume-prompt",
+            "      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: argument\n      args: [execute, '{run_dir}', '{prompt}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: ['{run_dir}', '{session}']\n",
+            "scrub_or_block",
+            "exactly one {prompt}",
+        ),
+        (
             "strict-billing",
             "      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{run_dir}']\n",
             "block",
@@ -356,4 +454,131 @@ fn failed_offline_probe_rejects_routing_before_the_worker_invocation() {
         !fixture.capture.join("invoked").exists(),
         "the failed probe must not fall through to the worker invocation"
     );
+}
+
+#[test]
+fn generic_answer_uses_captured_session_ref_and_declared_native_resume_template() {
+    let fixture = Fixture::new("native-resume");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [ask, '{run_dir}', '{prompt}']\n      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n        resume_args: [resume, '{run_dir}', '{session}', '{prompt}', 'literal with spaces']\n",
+        "scrub_or_block",
+    );
+
+    let first = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        first.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let answer = fixture.run_with_secret(&[
+        "answer",
+        "native answer with spaces",
+        "--task",
+        "YARD-001",
+        "--action-id",
+        "act-generic-native-answer",
+    ]);
+    assert!(
+        answer.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&answer.stdout),
+        String::from_utf8_lossy(&answer.stderr)
+    );
+
+    let resume_argv = argv(&fixture.capture.join("resume-argv"));
+    assert_eq!(resume_argv[0], "resume");
+    assert_eq!(resume_argv[2], "fixture session ref");
+    assert_eq!(resume_argv[4], "literal with spaces");
+    let resume_prompt = fs::read_to_string(fixture.capture.join("resume-prompt")).unwrap();
+    assert_eq!(
+        resume_prompt.matches("native answer with spaces").count(),
+        1
+    );
+    assert!(
+        fs::read(fixture.capture.join("resume-stdin"))
+            .unwrap()
+            .is_empty(),
+        "argument resume transport must not duplicate the prompt on stdin"
+    );
+
+    let channel_root = fixture.root.join(".agents/task-channels");
+    let attempt_records = files_below(&channel_root, ".yaml")
+        .into_iter()
+        .filter(|path| path.to_string_lossy().contains("/attempts/"))
+        .map(|path| fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>();
+    assert!(attempt_records.iter().any(|record| {
+        record.contains("continuation: native_resume")
+            && record.contains("worker_session_ref: fixture session ref")
+    }));
+    let event_records = files_below(&channel_root, ".yaml")
+        .into_iter()
+        .filter(|path| path.to_string_lossy().contains("/events/"))
+        .map(|path| fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>();
+    assert!(
+        event_records.iter().any(|record| {
+            record.contains("type: worker.completed")
+                && record.contains("worker_session_ref: fixture session ref")
+        }),
+        "worker.completed did not retain the generic session ref: {event_records:#?}"
+    );
+    let latest_packet = fs::read_to_string(fixture.latest_run().join("task-packet.md")).unwrap();
+    assert!(!latest_packet.contains("Explicit continuation packet"));
+}
+
+#[test]
+fn generic_answer_without_a_captured_session_ref_uses_explicit_packet_fallback() {
+    let fixture = Fixture::new("missing-session-ref");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe, offline]\n      prompt_transport: argument\n      args: [ask-without-session, '{run_dir}', '{prompt}']\n      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n        resume_args: [resume, '{run_dir}', '{session}', '{prompt}']\n",
+        "scrub_or_block",
+    );
+
+    must_succeed(
+        &fixture.root,
+        &fixture.binary,
+        &["run", "--task", "YARD-001", "--execute"],
+    );
+    must_succeed(
+        &fixture.root,
+        &fixture.binary,
+        &[
+            "answer",
+            "fallback answer",
+            "--task",
+            "YARD-001",
+            "--action-id",
+            "act-generic-fallback-answer",
+        ],
+    );
+
+    assert!(!fixture.capture.join("resume-argv").exists());
+    let packet = fs::read_to_string(fixture.latest_run().join("task-packet.md")).unwrap();
+    assert!(packet.contains("Explicit continuation packet"));
+    let attempt_records = files_below(&fixture.root.join(".agents/task-channels"), ".yaml")
+        .into_iter()
+        .filter(|path| path.to_string_lossy().contains("/attempts/"))
+        .map(|path| fs::read_to_string(path).unwrap())
+        .collect::<Vec<_>>();
+    assert!(attempt_records
+        .iter()
+        .any(|record| record.contains("continuation: explicit_packet")));
+}
+
+fn files_below(root: &Path, suffix: &str) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                files.extend(files_below(&path, suffix));
+            } else if path.to_string_lossy().ends_with(suffix) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
 }

--- a/tests/generic_worker_contract_process.rs
+++ b/tests/generic_worker_contract_process.rs
@@ -221,6 +221,7 @@ EOF
 fi
 if [ "${{1:-}}" = resume ]; then
   cp "$capture/last-argv" "$capture/resume-argv"
+  cp "$capture/last-secret" "$capture/resume-secret"
   printf '%s' "${{4:-}}" > "$capture/resume-prompt"
   cat > "$capture/resume-stdin"
   if [ "${{3:-}}" != 'fixture session ref' ]; then
@@ -500,6 +501,11 @@ fn generic_answer_uses_captured_session_ref_and_declared_native_resume_template(
             .unwrap()
             .is_empty(),
         "argument resume transport must not duplicate the prompt on stdin"
+    );
+    assert_eq!(
+        fs::read_to_string(fixture.capture.join("resume-secret")).unwrap(),
+        "absent",
+        "native resume must reach the worker across the same billing-env sanitation boundary as its fresh child"
     );
 
     let channel_root = fixture.root.join(".agents/task-channels");

--- a/tests/pty_child_guard.rs
+++ b/tests/pty_child_guard.rs
@@ -168,6 +168,38 @@ fn write_idle_script(path: &std::path::Path, marker: &str) {
     std::fs::set_permissions(path, permissions).expect("chmod the idle script");
 }
 
+fn wait_for_pid_file(path: &std::path::Path, within: Duration) -> bool {
+    let has_numeric_contents = || {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|contents| contents.trim().parse::<u32>().ok())
+            .is_some()
+    };
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if has_numeric_contents() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    has_numeric_contents()
+}
+
+#[test]
+fn pid_file_is_ready_only_with_numeric_contents() {
+    let workspace = common::WorkspaceGuard::create(scratch("pid-file-ready"));
+    let pid_path = workspace.join("fixture.pid");
+
+    std::fs::write(&pid_path, "").expect("write an empty pid file");
+    assert!(!wait_for_pid_file(&pid_path, Duration::ZERO));
+
+    std::fs::write(&pid_path, "not-a-pid\n").expect("write an invalid pid file");
+    assert!(!wait_for_pid_file(&pid_path, Duration::ZERO));
+
+    std::fs::write(&pid_path, "1234\n").expect("write a numeric pid file");
+    assert!(wait_for_pid_file(&pid_path, Duration::ZERO));
+}
+
 #[test]
 fn the_pid_file_guard_reaps_a_process_that_never_removed_its_pid_file() {
     // The leak this exists for: a hook still polling when an assertion fires. It
@@ -186,10 +218,10 @@ fn the_pid_file_guard_reaps_a_process_that_never_removed_its_pid_file() {
             .spawn()
             .expect("spawn the idle fixture"),
     );
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < deadline && !pid_path.exists() {
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    assert!(
+        wait_for_pid_file(&pid_path, Duration::from_secs(5)),
+        "the fixture never wrote its pid"
+    );
     let pid: u32 = std::fs::read_to_string(&pid_path)
         .expect("the fixture never wrote its pid")
         .trim()
@@ -248,10 +280,10 @@ fn the_pid_file_guard_leaves_a_pid_that_is_not_the_process_it_was_watching() {
             .spawn()
             .expect("spawn the bystander"),
     );
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while Instant::now() < deadline && !pid_path.exists() {
-        std::thread::sleep(Duration::from_millis(10));
-    }
+    assert!(
+        wait_for_pid_file(&pid_path, Duration::from_secs(5)),
+        "the bystander never wrote its pid"
+    );
     let pid: u32 = std::fs::read_to_string(&pid_path)
         .expect("the bystander never wrote its pid")
         .trim()

--- a/tests/run_stop_takes_worker_with_it_process.rs
+++ b/tests/run_stop_takes_worker_with_it_process.rs
@@ -69,14 +69,42 @@ fn write_worker(path: &Path) {
 }
 
 fn wait_for(path: &Path, within: Duration) -> bool {
+    let has_numeric_contents = || {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|contents| contents.trim().parse::<i32>().ok())
+            .is_some()
+    };
     let deadline = Instant::now() + within;
     while Instant::now() < deadline {
-        if path.exists() {
+        if has_numeric_contents() {
             return true;
         }
         std::thread::sleep(Duration::from_millis(20));
     }
-    path.exists()
+    has_numeric_contents()
+}
+
+#[test]
+fn pid_file_is_ready_only_with_numeric_contents() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let workspace = common::WorkspaceGuard::create(std::env::temp_dir().join(format!(
+        "yardlet-run-stop-pid-ready-{}-{nonce}",
+        std::process::id()
+    )));
+    let pid_file = workspace.path().join("worker-pid");
+
+    fs::write(&pid_file, "").unwrap();
+    assert!(!wait_for(&pid_file, Duration::ZERO));
+
+    fs::write(&pid_file, "not-a-pid\n").unwrap();
+    assert!(!wait_for(&pid_file, Duration::ZERO));
+
+    fs::write(&pid_file, "1234\n").unwrap();
+    assert!(wait_for(&pid_file, Duration::ZERO));
 }
 
 fn wait_until_gone(pid: i32, within: Duration) -> bool {

--- a/tests/v010_003_task_channels_process.rs
+++ b/tests/v010_003_task_channels_process.rs
@@ -3122,7 +3122,7 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             fs::write(
                 &workers_path,
                 format!(
-                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation: {{ command: {}, args: [\"{{run_dir}}\"], supports_noninteractive: true, output_contract: files }}\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
+                    "schema_version: 1\nworkers:\n  - id: fixture-fallback-a\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      session:\n        capture: {{ stream: stdout, prefix: 'SESSION_REF=' }}\n        resume_args: [\"{{run_dir}}\", \"{{session}}\"]\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\n  - id: fixture-fallback-b\n    invocation:\n      command: {}\n      args: [\"{{run_dir}}\"]\n      supports_noninteractive: true\n      output_contract: files\n      session:\n        capture: {{ stream: stdout, prefix: 'SESSION_REF=' }}\n        resume_args: [\"{{run_dir}}\", \"{{session}}\"]\n    limits: {{ max_wall_minutes: 1, max_retries: 0 }}\nrouting:\n  default_worker: fixture-fallback-a\n  fallback_order: [fixture-fallback-b]\n  allow_preferred_worker_failover: true\n",
                     producer_command.display(),
                     worker.display()
                 ),
@@ -3151,6 +3151,23 @@ mv "$YARD_RUN_DIR/run.yaml.tmp" "$YARD_RUN_DIR/run.yaml"
             .find(|attempt| string(attempt, "continuation") == "explicit_packet")
             .unwrap();
         assert_eq!(string(continuation, "worker_id"), "fixture-fallback-b");
+        assert!(continuation["worker_session_ref"].is_null());
+        let producer = attempts
+            .iter()
+            .find(|attempt| string(attempt, "worker_id") == "fixture-fallback-a")
+            .unwrap();
+        let events = yaml_dir(&channel.join("events"));
+        let producer_completed = events
+            .iter()
+            .find(|event| {
+                string(event, "event_type") == "worker.completed"
+                    && event["attempt_id"] == producer["attempt_id"]
+            })
+            .unwrap();
+        assert_eq!(
+            string(&producer_completed["payload"], "worker_session_ref"),
+            "producer-session-ref"
+        );
         assert_eq!(
             string(continuation, "caused_by_action_id"),
             "act-fallback-answer"


### PR DESCRIPTION
Second V010-006 slice, produced by a Yardlet dogfood drain the operator ran from the TUI (5 tasks: YARD-001 impl, YARD-002 independent review, YARD-003/004 PID-file race fixes the drain surfaced, YARD-005 env-scrub regression assertion from the review's follow-up).

## What

- Generic profiles can declare an opt-in `session` contract: a capture rule (stdout/stderr + exact line prefix, non-empty suffix becomes the opaque session ref) and a `resume_args` template with exactly one `{session}`. Declared-and-captured → `yardlet answer` resumes the same worker session natively; missing contract or missing ref → the existing explicit-packet continuation, unchanged.
- Resume eligibility comes from the selected profile's full contract plus the ref the questioning attempt itself captured — never worker-id strings, global session files, or another attempt's ref. Incomplete/ambiguous templates are rejected at load and re-checked before spawn; generic resume can never fall through to an empty or built-in-only command.
- Resume argv preserves argument boundaries (no shell string), applies the same sandbox/full, model/effort/image args and env sanitation as fresh runs.
- EN/KO README + workers.yaml template document the block; independent review report at `docs/reviews/generic-worker-session-resume-review.md` (AC-001..005 all pass, file:line evidence).
- Fixture hardening from the drain: run-stop and pty_child_guard fixtures wait for a parseable PID value instead of file existence; native resume path gains an env-scrub assertion.

## Reconciliation

The slice was authored while #128/#131 landed on main. This branch merges `origin/main` and resolves four conflicts: template keeps both the session block and the sandbox requirement comment; spawn keeps the #123 access re-check plus the slice's `packet_on_stdin` change (generic resume prompts follow the resume template, not an unconditional stdin); the new session fixtures declare `sandbox_args` to satisfy the #123 gate; both new-test groups are kept side by side.

## Verification

- Review task's own gates at authoring time: fmt 0, clippy 0, `--all-features` 856 passed / 0 failed, public-scan clean.
- Post-merge on this branch: `cargo test --all-features --no-fail-fast` 31 targets ok / 0 failed, fmt + clippy (`-D warnings`) clean.