### PR TITLE
fix(state): scope task conversations per intent so reused ids cannot leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@
 
 ### Fixed
 
+- **Task conversations are scoped per intent.** The answer/resume transcript
+  store was keyed by task id alone, so a reused id (`YARD-002` exists in almost
+  every intent) accumulated turns from every past intent and leaked them into
+  new task packets: a review packet carried fragments of unrelated intents'
+  conversations, implying acceptance criteria that exist nowhere in its
+  contract. Transcripts now live under
+  `.agents/conversations/<intent>/<task>.yaml`; a sibling or past intent's
+  turns are unreachable by construction. Legacy top-level transcript files are
+  left in place but never read. (#134)
+
+
 - **The report no longer calls a delivered run "disabled".** A `Disabled`
   Git-finish record only ever meant the push was disabled by policy, but the
   per-task report line read as if nothing was delivered. The line now reports

--- a/src/eval_fixtures.rs
+++ b/src/eval_fixtures.rs
@@ -390,6 +390,7 @@ fn needs_user_transcript_persists() -> Result<Vec<String>> {
     let fixture = FixtureWorkspace::new("needs-user")?;
     crate::state::append_conversation_turn(
         &fixture.ws,
+        "intent-fixture",
         "FIX-004",
         ConversationTurn {
             role: TurnRole::Worker,
@@ -400,6 +401,7 @@ fn needs_user_transcript_persists() -> Result<Vec<String>> {
     )?;
     crate::state::append_conversation_turn(
         &fixture.ws,
+        "intent-fixture",
         "FIX-004",
         ConversationTurn {
             role: TurnRole::User,
@@ -408,14 +410,17 @@ fn needs_user_transcript_persists() -> Result<Vec<String>> {
             ts: String::new(),
         },
     )?;
-    let transcript = fixture.ws.load_conversation("FIX-004");
+    let transcript = fixture.ws.load_conversation("intent-fixture", "FIX-004");
     if transcript.turns.len() != 2 || transcript.turns[1].text != "Option A" {
         bail!("conversation transcript did not round-trip")
     }
     Ok(vec![format!(
         "{} preserved turn(s) in {}",
         transcript.turns.len(),
-        fixture.ws.conversation_path("FIX-004").display()
+        fixture
+            .ws
+            .conversation_path("intent-fixture", "FIX-004")
+            .display()
     )])
 }
 

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -2178,6 +2178,7 @@ pub(crate) fn persist_ingested_decision_questions(
         };
         crate::state::append_conversation_turn(
             ws,
+            &queue.intent_id,
             id,
             crate::schemas::ConversationTurn {
                 role: crate::schemas::TurnRole::Worker,

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -3378,7 +3378,8 @@ queue:
         let queue = ws.load_queue().unwrap();
         assert_eq!(queue.tasks[0].state, TaskState::NeedsUser);
         assert!(queue.tasks[0].required_capabilities.is_empty());
-        std::fs::remove_file(ws.conversation_path("YARD-001")).unwrap();
+        let intent_id = ws.load_queue().unwrap().intent_id;
+        std::fs::remove_file(ws.conversation_path(&intent_id, "YARD-001")).unwrap();
         assert_eq!(
             crate::run::latest_question_for(&ws, "YARD-001").as_deref(),
             Some(
@@ -3386,7 +3387,7 @@ queue:
             )
         );
         crate::state::save_yaml(
-            &ws.conversation_path("YARD-001"),
+            &ws.conversation_path(&intent_id, "YARD-001"),
             &crate::schemas::Conversation {
                 task_id: "YARD-001".to_string(),
                 turns: vec![crate::schemas::ConversationTurn {
@@ -3491,7 +3492,9 @@ queue:
             error.contains("active_runtime_envelope_mismatch"),
             "{error}"
         );
-        assert!(!ws.conversation_path("YARD-001").exists());
+        assert!(!ws
+            .conversation_path(&ws.load_queue().unwrap().intent_id, "YARD-001")
+            .exists());
         assert!(!ws.transition_path("YARD-001").exists());
         let _ = std::fs::remove_dir_all(&ws.root);
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -2115,6 +2115,7 @@ fn persist_needs_user_question(
             .unwrap_or_default();
         state::append_conversation_turn(
             ws,
+            &context.intent_id,
             &context.task_id,
             ConversationTurn {
                 role: TurnRole::Worker,
@@ -2463,10 +2464,15 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         .map(str::trim)
         .filter(|a| !a.is_empty())
     {
-        if ws.load_conversation(&task.id).turns.is_empty() {
+        if ws
+            .load_conversation(&queue.intent_id, &task.id)
+            .turns
+            .is_empty()
+        {
             if let Some(q) = latest_question_for(ws, &task.id) {
                 let _ = state::append_conversation_turn(
                     ws,
+                    &queue.intent_id,
                     &task.id,
                     ConversationTurn {
                         role: TurnRole::Worker,
@@ -2479,6 +2485,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         }
         let _ = state::append_conversation_turn(
             ws,
+            &queue.intent_id,
             &task.id,
             ConversationTurn {
                 role: TurnRole::User,
@@ -2487,7 +2494,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
                 ts: Local::now().to_rfc3339(),
             },
         );
-        ws.load_conversation(&task.id).turns
+        ws.load_conversation(&queue.intent_id, &task.id).turns
     } else {
         Vec::new()
     };
@@ -4623,6 +4630,7 @@ fn migrate_stale_gate_to_decision(
         ws.save_queue_locked(lock, &latest)?;
         state::append_conversation_turn(
             ws,
+            &latest.intent_id,
             &task_id,
             ConversationTurn {
                 role: TurnRole::Worker,
@@ -8330,6 +8338,7 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
         if let Some(question) = persisted_question.as_deref() {
             let _ = state::append_conversation_turn(
                 ws,
+                &intent_id,
                 &task.id,
                 ConversationTurn {
                     role: TurnRole::Worker,
@@ -9117,7 +9126,7 @@ pub fn latest_question_for(ws: &Workspace, task_id: &str) -> Option<String> {
     // is still the worker's; once the user replies, the last turn is theirs.
     // Conversation files survive replanning, so scope attributable turns to
     // the current intent.
-    let conv = ws.load_conversation(task_id);
+    let conv = ws.load_conversation(current_intent.as_deref().unwrap_or(""), task_id);
     match conv.turns.last() {
         Some(t) if t.role == TurnRole::Worker && !t.text.trim().is_empty() => {
             if let Some(cur) = &current_intent {
@@ -15191,6 +15200,7 @@ exit 1
 
         crate::state::append_conversation_turn(
             &ws,
+            &q.intent_id,
             &id,
             ConversationTurn {
                 role: TurnRole::User,

--- a/src/state.rs
+++ b/src/state.rs
@@ -392,8 +392,13 @@ impl Workspace {
     pub fn conversations_dir(&self) -> PathBuf {
         self.agents_dir().join("conversations")
     }
-    pub fn conversation_path(&self, task_id: &str) -> PathBuf {
-        self.conversations_dir().join(format!("{task_id}.yaml"))
+    pub fn conversation_path(&self, intent_id: &str, task_id: &str) -> PathBuf {
+        // Scoped per (intent, task): task ids are reused across intents, and a
+        // task-id-only transcript leaked past intents' turns into new packets
+        // (issue #134). Legacy top-level <task>.yaml files are never read.
+        self.conversations_dir()
+            .join(intent_id)
+            .join(format!("{task_id}.yaml"))
     }
     pub fn transitions_dir(&self) -> PathBuf {
         self.agents_dir().join("transitions")
@@ -2725,8 +2730,8 @@ impl Workspace {
 
     /// A task's conversation transcript (empty when the task never paused for
     /// the user). A malformed file reads as empty rather than failing the run.
-    pub fn load_conversation(&self, task_id: &str) -> Conversation {
-        let p = self.conversation_path(task_id);
+    pub fn load_conversation(&self, intent_id: &str, task_id: &str) -> Conversation {
+        let p = self.conversation_path(intent_id, task_id);
         if !p.is_file() {
             return Conversation {
                 task_id: task_id.to_string(),
@@ -4739,7 +4744,7 @@ impl Workspace {
 
         self.save_queue_locked(&lock, &queue)?;
         for (task_id, turn) in pending_conversations {
-            append_conversation_turn(self, &task_id, turn)?;
+            append_conversation_turn(self, &snapshot.intent_id, &task_id, turn)?;
         }
         for transition in pending_transitions {
             append_transition(self, transition)?;
@@ -5515,10 +5520,11 @@ fn leading_spaces(line: &str) -> usize {
 /// skipped, so a retried run never double-records.
 pub fn append_conversation_turn(
     ws: &Workspace,
+    intent_id: &str,
     task_id: &str,
     turn: ConversationTurn,
 ) -> Result<()> {
-    let mut conv = ws.load_conversation(task_id);
+    let mut conv = ws.load_conversation(intent_id, task_id);
     if conv.task_id.is_empty() {
         conv.task_id = task_id.to_string();
     }
@@ -5539,7 +5545,7 @@ pub fn append_conversation_turn(
         return Ok(());
     }
     conv.turns.push(turn);
-    save_yaml(&ws.conversation_path(task_id), &conv)
+    save_yaml(&ws.conversation_path(intent_id, task_id), &conv)
 }
 
 pub fn transition(
@@ -7059,22 +7065,30 @@ routing:
         let ws = Workspace::at(&dir);
 
         // First worker question seeds the transcript.
-        append_conversation_turn(&ws, "YARD-1", worker("Forward+ or GL?", "run-1")).unwrap();
+        append_conversation_turn(
+            &ws,
+            "intent-a",
+            "YARD-1",
+            worker("Forward+ or GL?", "run-1"),
+        )
+        .unwrap();
         // The same run's worker turn is deduped by run_id.
-        append_conversation_turn(&ws, "YARD-1", worker("dup of run-1", "run-1")).unwrap();
+        append_conversation_turn(&ws, "intent-a", "YARD-1", worker("dup of run-1", "run-1"))
+            .unwrap();
         // A user reply lands.
-        append_conversation_turn(&ws, "YARD-1", user("what is Forward+?")).unwrap();
+        append_conversation_turn(&ws, "intent-a", "YARD-1", user("what is Forward+?")).unwrap();
         // An identical consecutive user turn is skipped.
-        append_conversation_turn(&ws, "YARD-1", user("what is Forward+?")).unwrap();
+        append_conversation_turn(&ws, "intent-a", "YARD-1", user("what is Forward+?")).unwrap();
         // A worker turn from a different run lands.
         append_conversation_turn(
             &ws,
+            "intent-a",
             "YARD-1",
             worker("Forward+ is the advanced path", "run-2"),
         )
         .unwrap();
 
-        let conv = ws.load_conversation("YARD-1");
+        let conv = ws.load_conversation("intent-a", "YARD-1");
         assert_eq!(conv.task_id, "YARD-1");
         assert_eq!(conv.turns.len(), 3, "the two duplicate turns are dropped");
         assert_eq!(conv.turns[0].role, TurnRole::Worker);
@@ -7083,7 +7097,16 @@ routing:
         assert_eq!(conv.turns[2].run_id, "run-2");
 
         // A task that never paused reads as an empty transcript.
-        assert!(ws.load_conversation("YARD-2").turns.is_empty());
+        assert!(ws.load_conversation("intent-a", "YARD-2").turns.is_empty());
+        // A reused task id under a different intent shares nothing (issue #134).
+        assert!(ws.load_conversation("intent-b", "YARD-1").turns.is_empty());
+        append_conversation_turn(&ws, "intent-b", "YARD-1", user("fresh intent turn")).unwrap();
+        assert_eq!(ws.load_conversation("intent-b", "YARD-1").turns.len(), 1);
+        assert_eq!(
+            ws.load_conversation("intent-a", "YARD-1").turns.len(),
+            conv.turns.len(),
+            "a sibling intent's append must not grow another intent's transcript"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -7925,7 +7948,7 @@ records:
             ws.latest_transition("TOOL").unwrap().cause,
             TransitionCause::TidyDefer
         );
-        assert!(!ws.load_conversation("DECIDE").turns.is_empty());
+        assert!(!ws.load_conversation("", "DECIDE").turns.is_empty());
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4271,7 +4271,9 @@ fn run_belongs_to_intent(ws: &Workspace, run_id: &str, intent_id: Option<&str>) 
 /// User turns inherit the attribution of the worker turn they answer. A
 /// run-less seeded decision is included only when it is the current question.
 fn answer_conversation(app: &App, task_id: &str, question: &str) -> Option<String> {
-    let conversation = app.ws.load_conversation(task_id);
+    let conversation = app
+        .ws
+        .load_conversation(current_intent_id(app).unwrap_or(""), task_id);
     let last_worker = conversation
         .turns
         .iter()
@@ -6082,6 +6084,7 @@ tasks:
         );
         state::append_conversation_turn(
             &ws,
+            "intent-old",
             "ASK",
             crate::schemas::ConversationTurn {
                 role: crate::schemas::TurnRole::Worker,
@@ -6093,6 +6096,7 @@ tasks:
         .unwrap();
         state::append_conversation_turn(
             &ws,
+            "intent-old",
             "ASK",
             crate::schemas::ConversationTurn {
                 role: crate::schemas::TurnRole::User,
@@ -6104,6 +6108,7 @@ tasks:
         .unwrap();
         state::append_conversation_turn(
             &ws,
+            "intent-current",
             "ASK",
             crate::schemas::ConversationTurn {
                 role: crate::schemas::TurnRole::Worker,
@@ -6115,6 +6120,7 @@ tasks:
         .unwrap();
         state::append_conversation_turn(
             &ws,
+            "intent-current",
             "ASK",
             crate::schemas::ConversationTurn {
                 role: crate::schemas::TurnRole::User,


### PR DESCRIPTION
Closes #134.

## Root cause

The answer/resume transcript store was keyed by task id alone (`.agents/conversations/<task>.yaml`). Task ids like `YARD-002` are reused in almost every intent, so one file accumulated turns from every past intent (the live workspace's `YARD-002.yaml` holds 17 turns going back to July 14 across many intents). On a conversational resume, `prepare` threads `ws.load_conversation(&task.id).turns` into the packet, so the worker received the whole cross-intent transcript. That is exactly what the YARD-002 reviewer saw and had to discard: fragments about a git-finish push audit, telemetry `next_state`, gh hostname derivation, and phantom "AC-005~007".

Downstream surfaces had already grown per-call intent filters (the TUI answer context attributes turns via each turn's run intent; the pending-question scan rejects other intents' runs), which is how this stayed invisible: the display layer was patched, the store and the packet path were not.

## Fix

- Transcripts move to `.agents/conversations/<intent>/<task>.yaml`, the same `(intent, task)` key task channels use. A sibling or past intent's turns are unreachable by construction.
- `conversation_path` / `load_conversation` / `append_conversation_turn` take the intent id; every producer already had it in scope (queue, `ChannelRunContext`, `finalize_run`'s queue intent, tidy's queue snapshot, the TUI's current-intent projection).
- Legacy top-level transcript files stay on disk but are never read. Deliberately no migration: the existing files are the contamination.
- The TUI's run-attribution filter stays as defense in depth.

## Verification

- New assertions in the conversation round-trip unit test: appending under one intent never grows another intent's transcript, and a reused task id under a fresh intent starts empty. Proven RED by toggling the path back to task-id-only (test fails on the leak), GREEN restored.
- The TUI answer-context test now seeds stale turns under the old intent and current turns under the current intent, and still requires the stale ones to be invisible.
- Full `cargo test --all-features --no-fail-fast`: 31 targets ok, 0 failed. fmt clean, clippy `-D warnings` all targets/features clean.