### PR TITLE
fix(ui): confirm leads to the drain, and auto_ime stops fighting Karabiner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@
   turns are unreachable by construction. Legacy top-level transcript files are
   left in place but never read. (#134)
 
+- **Confirm now leads somewhere.** Confirming a plan in the TUI used to leave
+  the operator on the review screen with no way to start the queue it had just
+  activated. A successful confirm now returns to Home and the toast names the
+  drain actions (A for the full queue, r for one task); the CLI's
+  `planning confirm` prints the equivalent next command. (#129)
+
 
 - **The report no longer calls a delivered run "disabled".** A `Disabled`
   Git-finish record only ever meant the push was disabled by policy, but the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@
   drain actions (A for the full queue, r for one task); the CLI's
   `planning confirm` prints the equivalent next command. (#129)
 
+- **auto_ime no longer fights external input-source switching.** The TUI's
+  input-source sync polled every second and re-forced an ASCII layout on
+  shortcut screens, silently reverting any 한/영 switch made meanwhile by the
+  user or by tools like Karabiner-Elements. The ASCII switch now happens only
+  on a real screen transition, a deliberate toggle afterwards sticks, and the
+  template config documents the interaction and the `auto_ime: false` escape
+  hatch. (#130)
+
 
 - **The report no longer calls a delivered run "disabled".** A `Disabled`
   Git-finish record only ever meant the push was disabled by policy, but the

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1415,6 +1415,10 @@ fn cmd_planning(cwd: &std::path::Path, args: PlanningArgs) -> Result<()> {
                 "Confirmed {} with activation {}. The exact visible draft is now active.",
                 expected_head, activation.confirmation_id
             );
+            println!(
+                "Next: `yardlet run --auto --execute` drains the queue \
+                 (`yardlet run --next --execute` runs one task; add --execute or nothing runs)."
+            );
             Ok(())
         }
         PlanningCmd::Replan { message, worker } => {

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -544,6 +544,7 @@ pub struct L {
     pub planning_accepted: &'static str,
     pub planning_rejected: &'static str,
     pub planning_confirmed: &'static str,
+    pub planning_confirmed_next: &'static str,
     // job-result prefixes (mixed with worker-authored content)
     pub planned_via: &'static str,
     pub tasks_word: &'static str,
@@ -810,6 +811,7 @@ pub const EN: L = L {
     planning_accepted: "Proposal accepted as visible draft",
     planning_rejected: "Proposal rejected",
     planning_confirmed: "Exact visible draft confirmed",
+    planning_confirmed_next: "queue is active: press A to drain it, or r to run the next task",
     planned_via: "Planned via",
     tasks_word: "tasks",
     planning_failed: "Planning failed:",
@@ -1075,6 +1077,7 @@ pub const KO: L = L {
     planning_accepted: "제안을 표시 초안으로 수락함",
     planning_rejected: "제안을 거절함",
     planning_confirmed: "표시된 정확한 초안을 확정함",
+    planning_confirmed_next: "큐가 활성화됨: A로 전체 드레인, r로 다음 작업 1개 실행",
     planned_via: "계획 완료 ·",
     tasks_word: "개 작업",
     planning_failed: "계획 실패:",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3172,6 +3172,26 @@ fn review_gate(app: &App) -> planning_review::ReviewGate {
     }
 }
 
+/// A successful confirm ends the review screen's job: the queue is active and
+/// the drain actions live on Home, so land the operator there and name the
+/// next step instead of leaving a dead-end screen (issue #129).
+fn finish_planning_confirm(app: &mut App, result: Result<String>) {
+    match result {
+        Ok(message) => {
+            let _ = refresh_planning_review(app);
+            app.input_clear();
+            app.planning_review_editing = false;
+            app.screen = Screen::Home;
+            app.reload();
+            app.toast = Some((
+                true,
+                format!("{message} · {}", app.lang.l().planning_confirmed_next),
+            ));
+        }
+        Err(error) => finish_planning_review_action(app, Err(error)),
+    }
+}
+
 fn finish_planning_review_action(app: &mut App, result: Result<String>) {
     match result {
         Ok(message) => match refresh_planning_review(app) {
@@ -3394,7 +3414,7 @@ fn handle_planning_review_key(app: &mut App, code: KeyCode, modifiers: KeyModifi
                             activation.confirmation_id
                         )
                     });
-            finish_planning_review_action(app, result);
+            finish_planning_confirm(app, result);
         }
     }
 }
@@ -6039,6 +6059,40 @@ tasks:
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn confirm_success_lands_on_home_and_names_the_drain_actions() {
+        let ws = workspace_with_user_config("confirm-next-step");
+        let mut app = App::new(ws.clone());
+        app.screen = Screen::PlanningReview;
+        app.planning_review_editing = true;
+
+        finish_planning_confirm(&mut app, Ok("confirmed: cnf_x".to_string()));
+
+        assert_eq!(
+            app.screen,
+            Screen::Home,
+            "confirm must not dead-end on the review screen"
+        );
+        assert!(!app.planning_review_editing);
+        let (ok, toast) = app.toast.clone().expect("confirm sets a toast");
+        assert!(ok);
+        assert!(toast.contains("confirmed: cnf_x"), "{toast}");
+        assert!(
+            toast.contains(app.lang.l().planning_confirmed_next),
+            "the toast must name the next step: {toast}"
+        );
+
+        // A failed confirm keeps today's behavior: stay on the screen and
+        // surface the error.
+        app.screen = Screen::PlanningReview;
+        finish_planning_confirm(&mut app, Err(anyhow::anyhow!("stale head")));
+        assert_eq!(app.screen, Screen::PlanningReview);
+        let (ok, toast) = app.toast.clone().expect("error sets a toast");
+        assert!(!ok);
+        assert!(toast.contains("stale head"), "{toast}");
+        let _ = std::fs::remove_dir_all(ws.root);
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -636,17 +636,23 @@ impl App {
             return;
         }
         self.ime_checked = Instant::now();
-        if matches!(self.screen, Screen::NewWork | Screen::Answer)
-            || (self.screen == Screen::PlanningReview && self.planning_review_editing)
-        {
-            // Text input: give the user their IME back.
-            if let Some(id) = self.ime_saved.take() {
-                let _ = ime::select_by_id(&id);
+        let text_input = matches!(self.screen, Screen::NewWork | Screen::Answer)
+            || (self.screen == Screen::PlanningReview && self.planning_review_editing);
+        match ime_sync_action(text_input, force) {
+            ImeSync::RestoreSaved => {
+                // Text input: give the user their IME back.
+                if let Some(id) = self.ime_saved.take() {
+                    let _ = ime::select_by_id(&id);
+                }
             }
-        } else if let Some((id, ascii)) = ime::current_id_and_ascii() {
-            if !ascii && ime::select_ascii() {
-                self.ime_saved = Some(id);
+            ImeSync::ForceAscii => {
+                if let Some((id, ascii)) = ime::current_id_and_ascii() {
+                    if !ascii && ime::select_ascii() {
+                        self.ime_saved = Some(id);
+                    }
+                }
             }
+            ImeSync::Leave => {}
         }
     }
 
@@ -985,6 +991,29 @@ fn title_for(app: &App) -> String {
 }
 
 /// Modification time of the binary this process was started from.
+/// What one input-source sync pass may do. The ASCII force runs only on a
+/// real screen transition: the periodic poll must never wrestle a deliberate
+/// 한/영 toggle back to ASCII, because tools like Karabiner-Elements switch
+/// the source out from under us and the user always wins (issue #130). The
+/// poll still restores a saved IME once a text screen is focused (covers the
+/// in-screen edit toggle on the plan review, which changes no screen).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImeSync {
+    RestoreSaved,
+    ForceAscii,
+    Leave,
+}
+
+fn ime_sync_action(text_input_screen: bool, force: bool) -> ImeSync {
+    if text_input_screen {
+        ImeSync::RestoreSaved
+    } else if force {
+        ImeSync::ForceAscii
+    } else {
+        ImeSync::Leave
+    }
+}
+
 fn binary_mtime() -> Option<std::time::SystemTime> {
     std::fs::metadata(std::env::current_exe().ok()?)
         .ok()?
@@ -1110,7 +1139,9 @@ fn main_loop(terminal: &mut ratatui::DefaultTerminal, mut app: App) -> Result<bo
             app.sync_ime(true);
             last_screen = Some(app.screen);
         } else {
-            // Catch a manual 한/영 toggle while on a shortcut screen.
+            // Poll only restores the IME on text screens (in-screen edit
+            // toggles change no screen); it never re-forces ASCII, so a
+            // deliberate 한/영 toggle sticks (issue #130).
             app.sync_ime(false);
         }
         // Keep the Monitor's log cache current (stat per frame; read on growth).
@@ -6059,6 +6090,17 @@ tasks:
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ime_poll_never_forces_ascii_over_a_deliberate_toggle() {
+        // Screen transition may force ASCII on shortcut screens.
+        assert_eq!(ime_sync_action(false, true), ImeSync::ForceAscii);
+        // The periodic poll must not wrestle a manual/Karabiner 한/영 toggle.
+        assert_eq!(ime_sync_action(false, false), ImeSync::Leave);
+        // Text screens always get the saved IME back, poll or transition.
+        assert_eq!(ime_sync_action(true, false), ImeSync::RestoreSaved);
+        assert_eq!(ime_sync_action(true, true), ImeSync::RestoreSaved);
     }
 
     #[test]

--- a/templates/agents/yardlet.yaml
+++ b/templates/agents/yardlet.yaml
@@ -11,6 +11,12 @@ current_intent: .agents/intent-contract.yaml
 language: auto
 default_access: sandboxed
 max_parallel: 1
+# macOS only: switch to an ASCII input source when a shortcut screen gains
+# focus, and restore your IME on text screens. The switch happens only on a
+# screen transition; a manual 한/영 toggle afterwards is respected. If this
+# still fights your input-source tooling (e.g. Karabiner-Elements rules keyed
+# on the active source), set it to false. Trade-off when off: with a CJK IME
+# active, the first key on a shortcut screen is eaten by composition.
 auto_ime: true
 ambiguity_gate: true
 harness_discovery: true


### PR DESCRIPTION
Two small TUI fixes from live dogfooding, one commit each.

## 1. Land on Home after confirm and name the drain actions (closes #129)

Confirming a plan left the operator on the review screen with no way to start the queue it had just activated; the live question was "how do I start this? it used to be an Auto."

- A successful confirm returns to Home and the toast names the drain actions (`A` full drain, `r` one task) in both languages; a failed confirm keeps today's stay-and-show-error behavior.
- CLI parity: `yardlet planning confirm` prints the equivalent next command.
- No gate is touched: confirm still activates only the exact visible head, and starting the drain stays an explicit action.

## 2. auto_ime stops wrestling external input-source switches (closes #130)

The input-source sync polled every second and re-forced ASCII on shortcut screens, silently reverting any 한/영 switch made meanwhile by the user or by Karabiner-Elements ("yardlet keeps stealing Karabiner events").

- The decision is a pure classifier now: a real screen transition may force ASCII; the poll may only restore the saved IME on text screens (covers the plan review's in-screen edit toggle); a deliberate toggle on a shortcut screen sticks.
- The template config documents the interaction and the `auto_ime: false` escape hatch with its trade-off.

## Verification

- `finish_planning_confirm` unit test drives success (Home + next-step toast) and failure (stay + error); proven RED against the old dead-end behavior.
- `ime_sync_action` classifier test pins ForceAscii to transitions only, Leave on polls, RestoreSaved on text screens.
- fmt clean, clippy `-D warnings` all targets/features clean, unit suite green on both commits.