### PR TITLE
fix(planning): survive the post-tidy scaffold queue instead of wedging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Fixed
+
+- **A post-tidy scaffold queue no longer wedges the workspace.** After `tidy`
+  archived a drained intent and cleared the live files, the completion screen's
+  redo-all key persisted the in-memory scaffold queue even with zero tasks to
+  requeue, and the activation gate then read "queue present, intent missing"
+  as corruption — blocking every confirm, status, and snapshot until the file
+  was hand-deleted (issue #138). Redo now writes nothing when there is nothing
+  to redo, and the gate treats a pristine provenance-free scaffold as the
+  clean legacy state while task-bearing or provenance-bearing queues keep
+  failing closed.
+
 ### Added
 
 - **One-command start for the unambiguous planning case.** `yardlet planning

--- a/src/planning.rs
+++ b/src/planning.rs
@@ -2724,11 +2724,20 @@ pub fn validate_active_activation(ws: &Workspace) -> Result<ActivationGate> {
                 })?,
             None => false,
         };
-        if queue
-            .as_ref()
-            .is_some_and(|queue| workspace_requires_activation || queue_provenance_present(queue))
-            || modern_evidence
-        {
+        // A pristine scaffold queue (no intent id, no tasks, no provenance) is
+        // what a stray writer materializes from `load_queue()` after tidy has
+        // cleared the live files. It carries zero information about any
+        // confirmed intent, so it reads as "no queue" even while the sticky
+        // workspace activation marker is set — otherwise one stray file wedges
+        // every confirm, status, and snapshot (issue #138). Any queue carrying
+        // an intent id, tasks, or provenance stays fail-closed.
+        let queue_evidence = queue.as_ref().is_some_and(|queue| {
+            let pristine = queue.intent_id.trim().is_empty()
+                && queue.tasks.is_empty()
+                && !queue_provenance_present(queue);
+            !pristine && (workspace_requires_activation || queue_provenance_present(queue))
+        });
+        if queue_evidence || modern_evidence {
             return Err(inconsistent("active intent is missing"));
         }
         return Ok(ActivationGate::Legacy);
@@ -3093,6 +3102,40 @@ queue:
         ));
         let _ = std::fs::remove_dir_all(&root);
         Workspace::at(&root)
+    }
+
+    /// Issue #138: after tidy archives an intent and clears both live files, a
+    /// stray writer can re-persist the in-memory scaffold (`WorkQueue::empty()`),
+    /// and the workspace-level activation marker is sticky once set. That pair
+    /// carries zero information about any confirmed intent, so the gate must
+    /// read it as the clean legacy state instead of wedging every confirm,
+    /// status, and snapshot behind "active intent is missing".
+    #[test]
+    fn pristine_scaffold_queue_with_sticky_activation_marker_stays_legacy() {
+        let ws = temp_workspace("pristine-scaffold-gate");
+        ws.require_confirmed_activation().unwrap();
+        ws.save_queue(&crate::schemas::WorkQueue::empty()).unwrap();
+        let gate = validate_active_activation(&ws)
+            .expect("a provenance-free scaffold queue is not corruption");
+        assert_eq!(gate, ActivationGate::Legacy);
+    }
+
+    /// The #138 tolerance is for the pristine scaffold ONLY: a queue that
+    /// carries tasks while the intent contract is missing is still real
+    /// corruption and must keep failing closed.
+    #[test]
+    fn scaffold_queue_with_tasks_still_fails_closed_without_an_intent() {
+        let ws = temp_workspace("scaffold-with-tasks-gate");
+        ws.require_confirmed_activation().unwrap();
+        let mut queue = crate::schemas::WorkQueue::empty();
+        queue.tasks = draft().queue.tasks.clone();
+        ws.save_queue(&queue).unwrap();
+        let error = validate_active_activation(&ws)
+            .expect_err("a task-bearing queue without an intent is corruption");
+        assert!(
+            error.to_string().contains("active intent is missing"),
+            "{error}"
+        );
     }
 
     fn pending_plan(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2834,10 +2834,18 @@ fn redo_all(app: &mut App) {
                     n += 1;
                 }
             }
-            match app.ws.save_queue_locked(&lock, &q) {
-                Ok(()) => app.toast = Some((true, format!("{}: {n}", app.lang.l().redo_done))),
-                Err(error) => {
-                    app.toast = Some((false, format!("{} {error}", app.lang.l().run_failed)))
+            // Nothing to redo, nothing to write: with no queue file on disk
+            // (the normal post-tidy state) `load_queue` materializes an
+            // in-memory scaffold, and persisting it wedged the workspace
+            // against the sticky activation marker (issue #138).
+            if n == 0 {
+                app.toast = Some((true, format!("{}: 0", app.lang.l().redo_done)));
+            } else {
+                match app.ws.save_queue_locked(&lock, &q) {
+                    Ok(()) => app.toast = Some((true, format!("{}: {n}", app.lang.l().redo_done))),
+                    Err(error) => {
+                        app.toast = Some((false, format!("{} {error}", app.lang.l().run_failed)))
+                    }
                 }
             }
         }
@@ -4870,6 +4878,24 @@ routing:
         std::fs::write(ws.workers_path(), WORKERS_WITH_COMMENTS).unwrap();
         std::fs::write(ws.billing_path(), crate::templates::BILLING_POLICY).unwrap();
         ws
+    }
+
+    /// Issue #138: `R` (redo all) on the completion screen with no queue file on
+    /// disk — the normal post-tidy state — loaded the in-memory scaffold
+    /// (`WorkQueue::empty()`) and persisted it even with zero done tasks,
+    /// materializing a queue file that never existed. Combined with the sticky
+    /// activation marker that wedged the whole workspace. Nothing to redo must
+    /// mean nothing written.
+    #[test]
+    fn redo_all_with_nothing_to_redo_does_not_materialize_a_queue_file() {
+        let ws = workspace_with_user_config("redo-all-no-queue");
+        assert!(!ws.queue_path().is_file());
+        let mut app = App::new(ws.clone());
+        redo_all(&mut app);
+        assert!(
+            !ws.queue_path().is_file(),
+            "redo with zero done tasks must not persist the scaffold queue (issue #138)"
+        );
     }
 
     fn cached_snapshot(ws: &Workspace) -> Snapshot {


### PR DESCRIPTION
Closes #138.

## Root cause (both halves pinned)

1. **The scaffold writer:** the completion screen's `R` (redo all) handler loads the queue and saves it back unconditionally. With no queue file on disk (the normal post-tidy state) `load_queue()` returns the in-memory `WorkQueue::empty()` scaffold, so pressing `R` with zero done tasks materialized a queue file that never existed. Timeline evidence in #138: tidy cleared at 16:20:53, the scaffold appeared at 16:20:55, byte-for-byte the serde serialization of `WorkQueue::empty()` (not the init template).
2. **The wedge:** `validate_active_activation` reads any parseable queue plus the sticky `activation-required` marker, minus an intent contract, as corruption. One zero-information file blocked every confirm, status, and snapshot.

## Fix

- `redo_all` writes nothing when there is nothing to redo (toast still reports 0).
- The gate treats a pristine scaffold (empty intent id, no tasks, no provenance) as the clean legacy state. This is also the systemic backstop for any other latent load-then-save writer (e.g. `hold_batch`, unreachable with an empty queue today). A queue carrying tasks or provenance without an intent **still fails closed** — pinned by a new negative test.

## TDD evidence

Both defects reproduced RED first: the gate test failed with the exact incident error (`unconfirmed_or_inconsistent: active intent is missing`) and the redo test failed on the materialized file; both GREEN after the fix, plus the fail-closed negative.

## Gates

`cargo fmt --check` ok, `clippy --all-targets --all-features -D warnings` ok, `cargo test --all-features --no-fail-fast` 31/31 result blocks ok (exit 0). Codename scan of the diff: 0 hits.

Not addressed here (follow-ups on #138): the TUI silently serving a stale snapshot while loads fail.