### PR TITLE
feat(guard): tell wrong-product, old, and logged-out workers apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,24 @@
 
 ### Added
 
+- **Readiness tells the five failure modes apart.** A worker whose binary
+  answered `--version` with exit 0 used to read as ready even when the command
+  name resolved to a different product, when the CLI was older than the profile
+  needs, or when it was never logged in. A profile can now declare three
+  optional invocation fields — `identity_probe` (args + `expected_signature`),
+  `auth_probe` (args + `ready_patterns` / `unauthenticated_patterns`), and
+  `min_version` — and readiness reports `wrong product`, `unsupported version`,
+  and `unauthenticated` as distinct, non-invocable states next to the existing
+  missing-binary and ready ones. The gates run in order (identity, version,
+  `min_version`, then auth) and stop at the first failure, every probe runs in
+  the same sanitized zero-key environment as a real invocation, and each state
+  carries its fix (`worker status`, the routing refusal, and the TUI workers
+  panel all name it, e.g. "upgrade to >= 1.2.0"). Auth stays deliberately
+  tolerant: only a positively reported logged-out CLI blocks, while unknown
+  output leaves the worker invocable with an "unverified" label, since Yardlet
+  never makes a billed call to confirm a subscription login. Profiles that omit
+  all three fields keep today's behavior exactly.
+
 - **One-command start for the unambiguous planning case.** `yardlet planning
   start` accepts the sole fresh proposal when needed, confirms the exact visible
   draft, and enters the existing auto-drain. The Planning Review screen exposes

--- a/README.ko.md
+++ b/README.ko.md
@@ -370,6 +370,14 @@ TUI는 모두 같은 판정을 사용합니다.
     supports_noninteractive: true
     output_contract: files
     version_args: ["version", "--offline"] # 기본값: ["--version"]
+    min_version: "1.2.0"                    # 선택: 최소 지원 버전
+    identity_probe:                         # 선택: 잘못된 바이너리 검사
+      args: ["--version"]
+      expected_signature: mytool
+    auth_probe:                             # 선택: 관용적 로그인 검사
+      args: ["auth", "status"]
+      ready_patterns: ["logged in as"]
+      unauthenticated_patterns: ["not logged in"]
     prompt_transport: argument              # 기본값: stdin
     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
     session:                                # 선택적 native resume 계약
@@ -404,11 +412,37 @@ resume template은 fresh generic invocation과 같은 `command`, access, model, 
 session block이 없거나, fresh child가 비어 있지 않은 ref를 내지 않거나, answer routing이
 다른 worker를 선택하면 Yardlet은 native resume 대신 안전하게 `ExplicitPacket`을 사용합니다.
 
+`identity_probe`, `min_version`, `auth_probe`는 선택 사항이며 서로 독립적입니다.
+생략하면 기존 동작이 그대로 유지되어, 버전 프로브에 exit 0으로 답하는 바이너리는
+무엇이든 통과합니다. 선언하면 지금까지 똑같이 보이던 준비 실패들이 구분됩니다.
+
+| 선언 | 실패 시 상태 | 상태 화면과 TUI가 알려주는 것 |
+|---|---|---|
+| (없음) | `not ready` | CLI가 PATH나 알려진 설치 경로에 없음 |
+| `identity_probe` | `wrong product` | 같은 명령 이름에 다른 제품이 응답. `command:`에 명시 경로 지정 |
+| `min_version` | `unsupported version` | 선언한 최소 버전 이상으로 업그레이드 |
+| `auth_probe` | `unauthenticated` | 워커 CLI에서 직접 로그인 |
+
+게이트는 identity → 버전 프로브 → `min_version` → auth 순서로 실행되며 첫 실패에서
+멈춥니다. 따라서 보고되는 상태는 언제나 가장 먼저 잘못된 것을 가리킵니다. 세 상태는
+ready 상태를 확인하는 모든 곳(라우팅, 계획, capability projection,
+`yardlet worker status`, TUI 워커 패널)에서 실행 불가로 취급됩니다.
+
+`identity_probe.expected_signature`는 프로브 출력 첫 줄에 대해 대소문자를 구분하지 않는
+부분문자열로 대조하므로, 전체 버전 배너가 아니라 안정적인 제품 표식을 선언하세요.
+`min_version`은 관용적으로 비교합니다. 양쪽에서 선행 `major.minor.patch` 세 자리만 읽고,
+어느 한쪽이라도 없으면 판정 불가로 처리해 절대 차단하지 않습니다. `auth_probe`는 의도적으로
+3값입니다. unauthenticated 패턴은 차단하고, ready 패턴은 로그인을 확인하며, 그 밖의
+경우(프로브 실행 실패 포함)에는 로그인 미검증 라벨만 붙은 채 실행 가능 상태가 유지됩니다.
+인자가 없거나 서명이 비었거나 패턴이 하나도 없는 선언은 아무것도 spawn하기 전에 정적
+계약에서 실패합니다. Yardlet은 맨 명령이 안전한 오프라인 프로브인지 추측하면 안 되기
+때문입니다.
+
 워커는 실행 디렉터리에 `result.json`과 `handoff.md`를 작성해야 합니다. 실행 env는
-프로필이 `pass_env`로 변수를 다시 옵트인하지 않는 한 정화됩니다. 버전 프로브도 정화된
-환경에서 로컬로만 실행됩니다. 설정한 실행 파일과 프로브 인자를 네트워크나 공급자 호출
-없이 확인하지만 로그인 또는 API 인증까지 증명할 수는 없습니다. 따라서 실제 워커가
-시작될 때 인증이 실패할 수 있습니다.
+프로필이 `pass_env`로 변수를 다시 옵트인하지 않는 한 정화됩니다. 버전, identity, auth
+프로브도 모두 정화된 환경에서 로컬로만 실행됩니다. 설정한 실행 파일과 프로브 인자를
+네트워크나 공급자 호출 없이 확인합니다. Yardlet은 구독 로그인을 확인하려고 과금되는
+호출을 하지 않으므로, `auth_probe` 없이는 실제 워커가 시작될 때 인증이 실패할 수 있습니다.
 
 생태계의 에이전트들이 Yardlet의 공급 측입니다.
 [oh-my-pi](https://github.com/can1357/oh-my-pi)(`omp`), OpenCode, Gemini CLI,

--- a/README.md
+++ b/README.md
@@ -391,6 +391,14 @@ access explicitly (`yardlet access full`).
     supports_noninteractive: true
     output_contract: files
     version_args: ["version", "--offline"] # default: ["--version"]
+    min_version: "1.2.0"                    # optional lowest supported version
+    identity_probe:                         # optional wrong-binary check
+      args: ["--version"]
+      expected_signature: mytool
+    auth_probe:                             # optional, tolerant login check
+      args: ["auth", "status"]
+      ready_patterns: ["logged in as"]
+      unauthenticated_patterns: ["not logged in"]
     prompt_transport: argument              # default: stdin
     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
     session:                                # optional native resume contract
@@ -428,11 +436,42 @@ so `{session}` and `{prompt}` retain their argv boundaries. If the session block
 is absent, the fresh child emits no non-empty ref, or answer routing selects a
 different worker, Yardlet safely uses `ExplicitPacket` instead of native resume.
 
+`identity_probe`, `min_version`, and `auth_probe` are optional and independent;
+omitting them keeps the previous behavior, where any binary that answers the
+version probe with exit 0 passes. Declaring them separates readiness failures
+that used to look identical:
+
+| Declaration | State when it fails | What status and the TUI say |
+|---|---|---|
+| (none) | `not ready` | the CLI is not on PATH or in a known install path |
+| `identity_probe` | `wrong product` | another product answers this command name; set an explicit `command:` path |
+| `min_version` | `unsupported version` | upgrade to >= the declared minimum |
+| `auth_probe` | `unauthenticated` | sign in with the worker CLI itself |
+
+The gates run in that order — identity, then the version probe, then
+`min_version`, then auth — and stop at the first failure, so the reported state
+always names the first thing that is wrong. All three states are non-invocable
+everywhere the ready state is checked: routing, planning, capability
+projection, `yardlet worker status`, and the TUI workers panel.
+
+`identity_probe.expected_signature` is matched case-insensitively as a substring
+of the probe's first output line, so declare a stable product marker rather than
+a full version banner. `min_version` is compared tolerantly: only the leading
+`major.minor.patch` triple on each side is read, and if either side has none the
+result is unknown and never blocks. `auth_probe` is deliberately three-valued —
+an unauthenticated pattern blocks, a ready pattern confirms a login, and
+anything else (including a probe that fails to run) leaves the worker invocable
+with the login still marked unverified. A declared probe with no arguments, an
+empty signature, or no patterns fails the static contract before anything is
+spawned, because Yardlet must not guess whether a bare command is a safe
+offline probe.
+
 The worker must write `result.json` and `handoff.md` in the run directory. Its
 execution env is sanitized unless the profile opts variables back in with
-`pass_env`. The version probe is also sanitized and local-only: it verifies the
-configured executable and probe arguments without network or provider calls,
-but it cannot prove login or API authentication. Authentication can therefore
+`pass_env`. Every readiness probe — version, identity, and auth — is also
+sanitized and local-only: they verify the configured executable and probe
+arguments without network or provider calls. Yardlet never makes a billed call
+to confirm a subscription login, so without an `auth_probe` authentication can
 still fail when the actual worker starts.
 
 The ecosystem's agents are Yardlet's supply side: terminal agents like

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2569,6 +2569,24 @@ fn cmd_worker(cwd: &std::path::Path, args: WorkerArgs) -> Result<()> {
                 let s = guard::probe(p, &billing, &requested_access);
                 println!("{} [{}]", s.id, s.readiness.label());
                 println!("  command: {}", s.command);
+                // The extended readiness states are only actionable with their
+                // fix, so name it right under the command line.
+                match s.readiness {
+                    guard::Readiness::WrongProduct => println!(
+                        "  fix: another product answers '{}'; set an explicit `command:` path in .agents/workers.yaml",
+                        s.command
+                    ),
+                    guard::Readiness::UnsupportedVersion => println!(
+                        "  fix: upgrade {} to >= {}",
+                        s.command,
+                        s.required_version.as_deref().unwrap_or("the declared minimum")
+                    ),
+                    guard::Readiness::Unauthenticated => println!(
+                        "  fix: sign in with '{}' itself (its own subscription account); Yardlet never asks for an API key",
+                        s.command
+                    ),
+                    _ => {}
+                }
                 // Staged checklist: each readiness gate, with auth reported as
                 // unverifiable offline (Yardlet never makes a billed call).
                 for stage in s.stages(&billing) {

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -26,6 +26,15 @@ pub enum Readiness {
     /// resolved CLI or its runtime cannot be confirmed. Yardlet stops rather than
     /// guess (it never risks a billed call to verify auth).
     Ambiguous,
+    /// A binary answered the probe, but its declared identity signature does not
+    /// match: a different product is installed under the same command name.
+    WrongProduct,
+    /// The resolved CLI is the right product but reports a version below the
+    /// profile's declared `min_version`.
+    UnsupportedVersion,
+    /// The declared offline auth probe positively reported that the CLI is not
+    /// logged in. An unknown login is never this state (it stays Ready).
+    Unauthenticated,
 }
 
 impl Readiness {
@@ -35,8 +44,152 @@ impl Readiness {
             Readiness::NotReady => "not ready",
             Readiness::Disabled => "disabled",
             Readiness::Ambiguous => "ambiguous",
+            Readiness::WrongProduct => "wrong product",
+            Readiness::UnsupportedVersion => "unsupported version",
+            Readiness::Unauthenticated => "unauthenticated",
         }
     }
+}
+
+/// Outcome of the optional offline product-identity gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityState {
+    /// No `identity_probe` in the profile: legacy posture, nothing was spawned.
+    NotDeclared,
+    /// The probe's first line carried the declared signature.
+    Matched,
+    /// The probe ran and its first line did NOT carry the declared signature.
+    Mismatched,
+    /// The probe could not be run (non-zero exit, no output, or no spawn).
+    Unverified,
+}
+
+/// Outcome of the optional offline auth gate. Deliberately three-valued:
+/// Yardlet never makes a billed call to verify a subscription login, so only a
+/// positively reported "not logged in" blocks; anything else stays invocable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthState {
+    /// No `auth_probe` in the profile: unchanged "not verified offline" posture.
+    NotProbed,
+    /// A declared unauthenticated pattern matched the probe output.
+    Unauthenticated,
+    /// A declared ready pattern matched the probe output.
+    Authenticated,
+    /// The probe was declared but inconclusive (no pattern matched, or it could
+    /// not be run). Never blocks.
+    Unknown,
+}
+
+/// Outcome of the optional `min_version` gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VersionVerdict {
+    /// Both sides parsed and the found version is at or above the minimum.
+    Satisfied,
+    /// Both sides parsed and the found version is below the minimum.
+    Below,
+    /// No `min_version` declared, or either side carries no numeric triple.
+    /// Unknown is never a block.
+    Undetermined,
+}
+
+/// Does an identity probe's first output line identify the expected product?
+///
+/// Case-insensitive substring match, so a profile can declare a stable product
+/// marker (`"codex-cli"`) without pinning the whole version banner. An empty
+/// signature has nothing to check and cannot fail (the static contract gate
+/// rejects a declared-but-empty signature before any spawn).
+pub fn identity_matches(first_line: &str, expected_signature: &str) -> bool {
+    let expected = expected_signature.trim().to_lowercase();
+    if expected.is_empty() {
+        return true;
+    }
+    first_line.to_lowercase().contains(&expected)
+}
+
+/// Tolerant three-way auth verdict over an auth probe's combined output
+/// (stdout + stderr). Unauthenticated patterns win over ready patterns so a CLI
+/// that prints both a banner and a "not logged in" line is not read as ready.
+/// Exit status is deliberately NOT a verdict: many CLIs exit non-zero exactly
+/// when they are logged out, and an unrunnable probe must stay Unknown.
+pub fn auth_state_from_output(
+    output: &str,
+    ready_patterns: &[String],
+    unauthenticated_patterns: &[String],
+) -> AuthState {
+    let haystack = output.to_lowercase();
+    let matches = |patterns: &[String]| {
+        patterns
+            .iter()
+            .map(|pattern| pattern.trim().to_lowercase())
+            .filter(|pattern| !pattern.is_empty())
+            .any(|pattern| haystack.contains(&pattern))
+    };
+    if matches(unauthenticated_patterns) {
+        AuthState::Unauthenticated
+    } else if matches(ready_patterns) {
+        AuthState::Authenticated
+    } else {
+        AuthState::Unknown
+    }
+}
+
+/// Tolerant version comparison: compare the first `major.minor.patch` triple
+/// found on each side and treat anything unparseable as undetermined. Yardlet
+/// cannot know a worker CLI's private versioning scheme, so an uncomparable
+/// version is reported as unknown and never blocks a run.
+pub fn version_verdict(found: &str, min_version: &str) -> VersionVerdict {
+    match (numeric_triple(found), numeric_triple(min_version)) {
+        (Some(found), Some(min)) if found >= min => VersionVerdict::Satisfied,
+        (Some(_), Some(_)) => VersionVerdict::Below,
+        _ => VersionVerdict::Undetermined,
+    }
+}
+
+/// The first `N.N.N` triple in a string, ignoring any surrounding banner text
+/// and any pre-release suffix (`1.2.3-beta` parses as 1.2.3).
+fn numeric_triple(text: &str) -> Option<(u64, u64, u64)> {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if !bytes[index].is_ascii_digit() {
+            index += 1;
+            continue;
+        }
+        // A triple must start at a component boundary, not mid-number.
+        if index > 0 && bytes[index - 1].is_ascii_digit() {
+            index += 1;
+            continue;
+        }
+        let mut cursor = index;
+        let mut parts: Vec<u64> = Vec::new();
+        while parts.len() < 3 {
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            if cursor == start {
+                break;
+            }
+            let digits: String = bytes[start..cursor].iter().collect();
+            match digits.parse::<u64>() {
+                Ok(value) => parts.push(value),
+                Err(_) => break,
+            }
+            if parts.len() == 3 {
+                break;
+            }
+            if cursor < bytes.len() && bytes[cursor] == '.' {
+                cursor += 1;
+            } else {
+                break;
+            }
+        }
+        if parts.len() == 3 {
+            return Some((parts[0], parts[1], parts[2]));
+        }
+        index = cursor.max(index + 1);
+    }
+    None
 }
 
 #[derive(Debug, Clone)]
@@ -50,6 +203,13 @@ pub struct WorkerStatus {
     /// Static generic invocation contract failure. Kept separate so staged
     /// status can report why no version subprocess was started.
     pub contract_error: Option<String>,
+    /// Outcome of the optional offline product-identity gate.
+    pub identity: IdentityState,
+    /// Outcome of the optional offline auth gate.
+    pub auth: AuthState,
+    /// The profile's declared `min_version`, carried so status, the snapshot,
+    /// and the TUI can all say "upgrade to >= X" without re-reading the config.
+    pub required_version: Option<String>,
     pub readiness: Readiness,
     pub detail: String,
 }
@@ -256,6 +416,7 @@ pub fn invocation_contract(profile: &WorkerProfile) -> Result<(), String> {
             profile.id
         ));
     }
+    profile.invocation.validate_probes(&profile.id)?;
     let output = profile.invocation.output_contract.trim();
     match profile.id.as_str() {
         "codex" | "claude-code" if matches!(output, "files" | "json_or_files") => Ok(()),
@@ -315,9 +476,44 @@ impl WorkerStatus {
             },
         };
 
+        // Only a profile that declared an identity probe gets the extra gate
+        // line; every other profile keeps the existing checklist unchanged.
+        let identity = match self.identity {
+            IdentityState::NotDeclared => None,
+            IdentityState::Matched => Some(StatusStage {
+                label: "identity",
+                mark: StageMark::Pass,
+                note: "identity probe matched the declared product signature".to_string(),
+            }),
+            IdentityState::Mismatched => Some(StatusStage {
+                label: "identity",
+                mark: StageMark::Fail,
+                note: format!(
+                    "identity probe reported a different product under command '{}'; fix `command:` in .agents/workers.yaml to point at the real CLI",
+                    self.command
+                ),
+            }),
+            IdentityState::Unverified => Some(StatusStage {
+                label: "identity",
+                mark: StageMark::Fail,
+                note: "configured identity probe failed; the resolved CLI is unverified"
+                    .to_string(),
+            }),
+        };
+
         let policy = billing.worker_invocation.ai_billing_env_policy.as_str();
         let blocked = billing_blocked(policy, self.billing_env_present.len());
-        let version = if self.contract_error.is_some() {
+        let version = if self.readiness == Readiness::UnsupportedVersion {
+            StatusStage {
+                label: "version",
+                mark: StageMark::Fail,
+                note: format!(
+                    "{} is below the profile's min_version; upgrade to >= {}",
+                    self.version.as_deref().unwrap_or("the reported version"),
+                    self.required_version.as_deref().unwrap_or("the minimum")
+                ),
+            }
+        } else if self.contract_error.is_some() {
             StatusStage {
                 label: "version",
                 mark: StageMark::Skipped,
@@ -379,13 +575,33 @@ impl WorkerStatus {
             }
         };
 
-        let auth = StatusStage {
-            label: "auth",
-            mark: StageMark::Offline,
-            note: "not verified offline; Yardlet never makes a billed call to check, it relies on the worker's own subscription login".to_string(),
+        let auth = match self.auth {
+            AuthState::NotProbed => StatusStage {
+                label: "auth",
+                mark: StageMark::Offline,
+                note: "not verified offline; Yardlet never makes a billed call to check, it relies on the worker's own subscription login".to_string(),
+            },
+            AuthState::Authenticated => StatusStage {
+                label: "auth",
+                mark: StageMark::Pass,
+                note: "the declared offline auth probe reports the CLI is logged in".to_string(),
+            },
+            AuthState::Unauthenticated => StatusStage {
+                label: "auth",
+                mark: StageMark::Fail,
+                note: "the declared offline auth probe reports the CLI is NOT logged in; log in with the worker CLI's own subscription account, then retry".to_string(),
+            },
+            AuthState::Unknown => StatusStage {
+                label: "auth",
+                mark: StageMark::Offline,
+                note: "the declared offline auth probe was inconclusive; login stays unverified and is never assumed to have failed".to_string(),
+            },
         };
 
-        vec![contract, binary, version, billing_env, auth]
+        let mut stages = vec![contract, binary];
+        stages.extend(identity);
+        stages.extend([version, billing_env, auth]);
+        stages
     }
 
     /// One-line verdict framed as invocation safety under the current policy,
@@ -406,6 +622,19 @@ impl WorkerStatus {
             }
             Readiness::Ambiguous => {
                 "not invocable: binary found but unverified (see version gate)".to_string()
+            }
+            Readiness::WrongProduct => format!(
+                "not invocable: a different product answers command '{}' (see identity gate)",
+                self.command
+            ),
+            Readiness::UnsupportedVersion => format!(
+                "not invocable: {} is below the profile's min_version; upgrade to >= {}",
+                self.version.as_deref().unwrap_or("the reported version"),
+                self.required_version.as_deref().unwrap_or("the minimum")
+            ),
+            Readiness::Unauthenticated => {
+                "not invocable: the worker CLI reports it is not logged in (see auth gate); log in with its own subscription account, then retry"
+                    .to_string()
             }
             Readiness::NotReady => format!("not invocable: {}", self.detail),
             Readiness::Disabled => {
@@ -474,11 +703,19 @@ fn fallback_paths(worker_id: &str) -> Vec<PathBuf> {
     }
 }
 
-/// Probe one worker's readiness. Does not invoke any provider API. Version
-/// probing runs the local CLI's configured arguments, which must be offline.
-/// Built-in adapters retain their core-owned `--version` probe.
+/// Probe one worker's readiness. Does not invoke any provider API. Every probe
+/// runs the local CLI's configured arguments, which must be offline, in the
+/// same sanitized zero-key environment used for a real invocation. Built-in
+/// adapters retain their core-owned `--version` probe.
 ///
-/// Resolution prefers the first candidate whose version probe succeeds: the
+/// Gate order per candidate binary: identity (when declared) -> version ->
+/// `min_version` (when declared); the auth probe (when declared) then runs once,
+/// on the selected binary. A failed gate stops the later ones, so the reported
+/// state always names the FIRST thing that is wrong. The static invocation and
+/// access contracts still run before all of them, because they decide whether
+/// Yardlet may spawn anything at all.
+///
+/// Resolution prefers the first candidate that passes those gates: the
 /// PATH-resolved binary first, then well-known fallback paths. This keeps a
 /// worker usable even when a wrapper shadows the real CLI on PATH.
 pub fn probe(
@@ -488,6 +725,12 @@ pub fn probe(
 ) -> WorkerStatus {
     let command = profile.invocation.command.clone();
     let billing_env_present = present_billing_env(&billing.blocked_worker_env_names);
+    let required_version = profile
+        .invocation
+        .min_version
+        .as_ref()
+        .map(|min| min.trim().to_string())
+        .filter(|min| !min.is_empty());
 
     if !profile.enabled {
         return WorkerStatus {
@@ -497,6 +740,9 @@ pub fn probe(
             version: None,
             billing_env_present,
             contract_error: None,
+            identity: IdentityState::NotDeclared,
+            auth: AuthState::NotProbed,
+            required_version,
             readiness: Readiness::Disabled,
             detail: "disabled in .agents/workers.yaml".to_string(),
         };
@@ -523,6 +769,9 @@ pub fn probe(
             version: None,
             billing_env_present,
             contract_error: Some(error.clone()),
+            identity: IdentityState::NotDeclared,
+            auth: AuthState::NotProbed,
+            required_version,
             readiness: Readiness::NotReady,
             detail: error,
         };
@@ -539,6 +788,9 @@ pub fn probe(
             version: None,
             billing_env_present,
             contract_error: None,
+            identity: IdentityState::NotDeclared,
+            auth: AuthState::NotProbed,
+            required_version,
             readiness: Readiness::NotReady,
             detail: "strict billing policy refuses to start any worker subprocess while AI-billing env is set"
                 .to_string(),
@@ -554,40 +806,144 @@ pub fn probe(
     } else {
         &profile.invocation.version_args
     };
-    let verified = candidates
-        .iter()
-        .find_map(|p| read_version(p, version_args, billing).map(|v| (p.clone(), v)));
-
-    let (binary_path, version, readiness, detail) = match verified {
-        Some((path, version)) => {
-            let mut detail = if billing_env_present.is_empty() {
-                "binary found; version ok; AI-billing env clean; will run with sanitized environment"
-                    .to_string()
-            } else {
-                format!(
-                    "binary found; version ok; {} AI-billing env var(s) present in parent and will \
-                     be scrubbed before the worker runs (policy: {})",
-                    billing_env_present.len(),
-                    billing.worker_invocation.ai_billing_env_policy
-                )
-            };
-            // An operator reading "sandboxed" must be able to tell an enforced
-            // boundary from a declared one (issue #123): the generic sandbox
-            // passed the declaration check above, but Yardlet does not own it.
-            if requested_access == "sandboxed"
-                && !matches!(profile.id.as_str(), "codex" | "claude-code")
-            {
-                detail.push_str(
-                    "; sandbox is profile-declared, not verified by Yardlet",
-                );
+    // Run the per-candidate gates in declaration order and keep the first
+    // candidate that clears them all. A candidate's first failing gate is
+    // remembered so the verdict can name what is actually wrong.
+    let mut selected: Option<(PathBuf, String, IdentityState)> = None;
+    let mut first_failure: Option<(PathBuf, CandidateFailure)> = None;
+    for path in &candidates {
+        match evaluate_candidate(
+            path,
+            profile,
+            billing,
+            version_args,
+            required_version.as_deref(),
+        ) {
+            Ok((version, identity)) => {
+                selected = Some((path.clone(), version, identity));
+                break;
             }
-            (Some(path), Some(version), Readiness::Ready, detail)
+            Err(failure) => {
+                if first_failure.is_none() {
+                    first_failure = Some((path.clone(), failure));
+                }
+            }
         }
-        None => match candidates.into_iter().next() {
-            // A binary exists but no candidate passed its version probe: ambiguous.
-            Some(path) => (
+    }
+
+    let (binary_path, version, identity, auth, readiness, detail) = match selected {
+        Some((path, version, identity)) => {
+            // Auth runs last, once, and only on the binary that already proved
+            // it is the right product at a supported version.
+            let auth = match &profile.invocation.auth_probe {
+                Some(auth_probe) => match run_probe(&path, &auth_probe.args, billing) {
+                    Some(output) => auth_state_from_output(
+                        &output.combined,
+                        &auth_probe.ready_patterns,
+                        &auth_probe.unauthenticated_patterns,
+                    ),
+                    None => AuthState::Unknown,
+                },
+                None => AuthState::NotProbed,
+            };
+            if auth == AuthState::Unauthenticated {
+                (
+                    Some(path.clone()),
+                    Some(version),
+                    identity,
+                    auth,
+                    Readiness::Unauthenticated,
+                    format!(
+                        "binary resolved to {} and its version is ok, but the profile's offline auth probe reports the CLI is NOT logged in. \
+                         Log in with the worker CLI's own subscription account, then retry. Yardlet did not call an AI API and did not ask for an API key.",
+                        path.display()
+                    ),
+                )
+            } else {
+                let mut detail = if billing_env_present.is_empty() {
+                    "binary found; version ok; AI-billing env clean; will run with sanitized environment"
+                        .to_string()
+                } else {
+                    format!(
+                        "binary found; version ok; {} AI-billing env var(s) present in parent and will \
+                         be scrubbed before the worker runs (policy: {})",
+                        billing_env_present.len(),
+                        billing.worker_invocation.ai_billing_env_policy
+                    )
+                };
+                if identity == IdentityState::Matched {
+                    detail.push_str("; identity probe matched the declared product signature");
+                }
+                match auth {
+                    AuthState::Authenticated => {
+                        detail.push_str("; offline auth probe reports the CLI is logged in")
+                    }
+                    AuthState::Unknown => detail
+                        .push_str("; offline auth probe was inconclusive, login stays unverified"),
+                    _ => {}
+                }
+                // An operator reading "sandboxed" must be able to tell an enforced
+                // boundary from a declared one (issue #123): the generic sandbox
+                // passed the declaration check above, but Yardlet does not own it.
+                if requested_access == "sandboxed"
+                    && !matches!(profile.id.as_str(), "codex" | "claude-code")
+                {
+                    detail.push_str("; sandbox is profile-declared, not verified by Yardlet");
+                }
+                (
+                    Some(path),
+                    Some(version),
+                    identity,
+                    auth,
+                    Readiness::Ready,
+                    detail,
+                )
+            }
+        }
+        None => match first_failure {
+            Some((path, CandidateFailure::WrongProduct { seen, expected })) => (
                 Some(path.clone()),
                 None,
+                IdentityState::Mismatched,
+                AuthState::NotProbed,
+                Readiness::WrongProduct,
+                format!(
+                    "binary resolved to {} but its identity probe reported {seen:?}, which does not carry the declared signature {expected:?}: \
+                     a different product is installed under the command name '{command}'. Set an explicit `command:` path in \
+                     .agents/workers.yaml, then retry. Yardlet did not call an AI API and did not ask for an API key.",
+                    path.display()
+                ),
+            ),
+            Some((path, CandidateFailure::UnsupportedVersion { found, minimum })) => (
+                Some(path.clone()),
+                Some(found.clone()),
+                IdentityState::from_declaration(profile, true),
+                AuthState::NotProbed,
+                Readiness::UnsupportedVersion,
+                format!(
+                    "binary resolved to {} reports version {found:?}, below the profile's declared min_version {minimum}: \
+                     upgrade to >= {minimum}, then retry. Yardlet did not call an AI API and did not ask for an API key.",
+                    path.display()
+                ),
+            ),
+            Some((path, CandidateFailure::IdentityProbeFailed)) => (
+                Some(path.clone()),
+                None,
+                IdentityState::Unverified,
+                AuthState::NotProbed,
+                Readiness::Ambiguous,
+                format!(
+                    "binary resolved to {} but the configured offline identity probe failed; the resolved CLI or its runtime \
+                     is unverified. Set an explicit `command:` path in .agents/workers.yaml or fix \
+                     the local CLI runtime, then retry. Yardlet did not call an AI API and did not ask for an API key.",
+                    path.display()
+                ),
+            ),
+            Some((path, CandidateFailure::VersionProbeFailed)) => (
+                Some(path.clone()),
+                None,
+                IdentityState::from_declaration(profile, true),
+                AuthState::NotProbed,
                 Readiness::Ambiguous,
                 format!(
                     "binary resolved to {} but the configured offline version probe failed; the resolved CLI or its runtime \
@@ -600,6 +956,8 @@ pub fn probe(
             None => (
                 None,
                 None,
+                IdentityState::NotDeclared,
+                AuthState::NotProbed,
                 Readiness::NotReady,
                 format!(
                     "worker CLI '{command}' not found on PATH or known install paths. Install it \
@@ -617,9 +975,121 @@ pub fn probe(
         version,
         billing_env_present,
         contract_error: None,
+        identity,
+        auth,
+        required_version,
         readiness,
         detail,
     }
+}
+
+impl IdentityState {
+    /// The identity outcome for a gate that was already passed (or never
+    /// declared) by the time a later gate failed.
+    fn from_declaration(profile: &WorkerProfile, passed: bool) -> IdentityState {
+        match (&profile.invocation.identity_probe, passed) {
+            (None, _) => IdentityState::NotDeclared,
+            (Some(_), true) => IdentityState::Matched,
+            (Some(_), false) => IdentityState::Unverified,
+        }
+    }
+}
+
+/// The first gate a candidate binary failed.
+enum CandidateFailure {
+    WrongProduct { seen: String, expected: String },
+    IdentityProbeFailed,
+    VersionProbeFailed,
+    UnsupportedVersion { found: String, minimum: String },
+}
+
+/// Run the per-candidate gates in order: identity (when declared), then the
+/// offline version probe, then `min_version` (when declared). Returns the
+/// verified version line and the identity outcome.
+fn evaluate_candidate(
+    path: &std::path::Path,
+    profile: &WorkerProfile,
+    billing: &BillingPolicy,
+    version_args: &[String],
+    required_version: Option<&str>,
+) -> Result<(String, IdentityState), CandidateFailure> {
+    let identity = match &profile.invocation.identity_probe {
+        None => IdentityState::NotDeclared,
+        Some(identity_probe) => match run_probe(path, &identity_probe.args, billing) {
+            Some(output) if output.success && !output.first_line.is_empty() => {
+                if identity_matches(&output.first_line, &identity_probe.expected_signature) {
+                    IdentityState::Matched
+                } else {
+                    return Err(CandidateFailure::WrongProduct {
+                        seen: output.first_line,
+                        expected: identity_probe.expected_signature.trim().to_string(),
+                    });
+                }
+            }
+            _ => return Err(CandidateFailure::IdentityProbeFailed),
+        },
+    };
+
+    let version =
+        read_version(path, version_args, billing).ok_or(CandidateFailure::VersionProbeFailed)?;
+
+    if let Some(minimum) = required_version {
+        if version_verdict(&version, minimum) == VersionVerdict::Below {
+            return Err(CandidateFailure::UnsupportedVersion {
+                found: version,
+                minimum: minimum.to_string(),
+            });
+        }
+    }
+
+    Ok((version, identity))
+}
+
+/// One offline probe attempt's output. Never contains secret values: the child
+/// runs with the same sanitized zero-key environment as a real invocation.
+struct ProbeOutput {
+    success: bool,
+    first_line: String,
+    combined: String,
+}
+
+/// Spawn one offline probe in the sanitized worker environment. Returns None
+/// when Yardlet must not or could not run it, which every caller treats as
+/// "unknown", never as a positive result.
+fn run_probe(
+    path: &std::path::Path,
+    args: &[String],
+    billing: &BillingPolicy,
+) -> Option<ProbeOutput> {
+    // Never spawn a bare command: Yardlet cannot know whether it would be an
+    // interactive session rather than an offline probe.
+    if args.is_empty() || args.iter().all(|arg| arg.trim().is_empty()) {
+        return None;
+    }
+    let env = sanitized_worker_env_for(billing, &[]).ok()?;
+    let mut command = Command::new(path);
+    command.args(args).env_clear();
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    let out = command.output().ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let primary = if !out.stdout.is_empty() {
+        &stdout
+    } else {
+        &stderr
+    };
+    Some(ProbeOutput {
+        success: out.status.success(),
+        first_line: primary
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        combined: format!("{stdout}\n{stderr}"),
+    })
 }
 
 fn read_version(
@@ -627,26 +1097,11 @@ fn read_version(
     version_args: &[String],
     billing: &BillingPolicy,
 ) -> Option<String> {
-    let env = sanitized_worker_env_for(billing, &[]).ok()?;
-    let mut command = Command::new(path);
-    command.args(version_args).env_clear();
-    for (key, value) in env {
-        command.env(key, value);
-    }
-    let out = command.output().ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let text = if !out.stdout.is_empty() {
-        String::from_utf8_lossy(&out.stdout)
-    } else {
-        String::from_utf8_lossy(&out.stderr)
-    };
-    let line = text.lines().next()?.trim().to_string();
-    if line.is_empty() {
+    let out = run_probe(path, version_args, billing)?;
+    if !out.success || out.first_line.is_empty() {
         None
     } else {
-        Some(line)
+        Some(out.first_line)
     }
 }
 
@@ -757,6 +1212,9 @@ mod tests {
             version: Some("codex 1.0.0".into()),
             billing_env_present,
             contract_error: None,
+            identity: IdentityState::NotDeclared,
+            auth: AuthState::NotProbed,
+            required_version: None,
             readiness: Readiness::Ready,
             detail: String::new(),
         }
@@ -984,6 +1442,357 @@ invocation:
         );
     }
 
+    // ---- readiness contract: identity / auth / version decision logic -------
+    // These three are the whole judgement surface of the extended contract, so
+    // they stay pure and unit-tested away from any subprocess.
+
+    #[test]
+    fn identity_signature_matches_case_insensitively_and_rejects_another_product() {
+        // The declared marker only has to appear in the probe's first line.
+        assert!(identity_matches("codex-cli 0.9.7 (rust)", "codex-cli"));
+        assert!(identity_matches("Codex-CLI 0.9.7", "codex-cli"));
+        assert!(identity_matches("  codex-cli 0.9.7", "  CODEX-CLI  "));
+        // A different product under the same command name must not pass.
+        assert!(!identity_matches("GNU coreutils codex 9.4", "codex-cli"));
+        assert!(!identity_matches("", "codex-cli"));
+        // Nothing declared to check cannot fail.
+        assert!(identity_matches("anything at all", "   "));
+    }
+
+    #[test]
+    fn auth_probe_output_is_a_tolerant_three_way_verdict() {
+        let ready = vec!["logged in".to_string()];
+        let unauth = vec!["not logged in".to_string(), "please run login".to_string()];
+
+        assert_eq!(
+            auth_state_from_output("You are not logged in.", &ready, &unauth),
+            AuthState::Unauthenticated
+        );
+        assert_eq!(
+            auth_state_from_output("Logged in as someone", &ready, &unauth),
+            AuthState::Authenticated
+        );
+        // Unknown output is never a hard stop.
+        assert_eq!(
+            auth_state_from_output("status: unavailable", &ready, &unauth),
+            AuthState::Unknown
+        );
+        assert_eq!(
+            auth_state_from_output("", &ready, &unauth),
+            AuthState::Unknown
+        );
+        // An unauthenticated marker wins over a ready-looking banner.
+        assert_eq!(
+            auth_state_from_output("Logged in: no, please run login", &ready, &unauth),
+            AuthState::Unauthenticated
+        );
+        // Blank patterns must not match everything.
+        assert_eq!(
+            auth_state_from_output("whatever", &[String::new()], &["  ".to_string()]),
+            AuthState::Unknown
+        );
+    }
+
+    #[test]
+    fn min_version_comparison_blocks_only_a_confidently_lower_version() {
+        assert_eq!(
+            version_verdict("fixture-worker 1.2.3", "1.2.0"),
+            VersionVerdict::Satisfied
+        );
+        assert_eq!(version_verdict("1.2.0", "1.2.0"), VersionVerdict::Satisfied);
+        assert_eq!(
+            version_verdict("mytool 0.9.9 (build 7)", "1.0.0"),
+            VersionVerdict::Below
+        );
+        // Component-wise, not lexicographic.
+        assert_eq!(
+            version_verdict("1.10.0", "1.9.0"),
+            VersionVerdict::Satisfied
+        );
+        // Pre-release suffixes are ignored, not treated as a parse failure.
+        assert_eq!(
+            version_verdict("2.0.0-beta.1", "1.9.9"),
+            VersionVerdict::Satisfied
+        );
+        // Either side unparseable: unknown, and unknown never blocks.
+        assert_eq!(
+            version_verdict("nightly build", "1.0.0"),
+            VersionVerdict::Undetermined
+        );
+        assert_eq!(
+            version_verdict("1.0.0", "latest"),
+            VersionVerdict::Undetermined
+        );
+        assert_eq!(version_verdict("1.2", "1.3"), VersionVerdict::Undetermined);
+    }
+
+    #[test]
+    fn readiness_cache_key_changes_when_a_probe_declaration_changes() {
+        let billing = BillingPolicy::default();
+        let key = |invocation: &str| {
+            let profile: WorkerProfile = crate::yaml::from_str(&format!(
+                "id: generic-fixture\ninvocation: {{ command: bash, supports_noninteractive: true, output_contract: files, {invocation} }}\n"
+            ))
+            .unwrap();
+            readiness_cache_key(&profile, &billing, "full")
+        };
+        let base = key("args: ['{run_dir}']");
+        assert_ne!(
+            base,
+            key("args: ['{run_dir}'], identity_probe: { args: ['--version'], expected_signature: fixture }")
+        );
+        assert_ne!(
+            key("args: ['{run_dir}'], identity_probe: { args: ['--version'], expected_signature: fixture }"),
+            key("args: ['{run_dir}'], identity_probe: { args: ['--version'], expected_signature: other }")
+        );
+        assert_ne!(
+            base,
+            key("args: ['{run_dir}'], auth_probe: { args: [auth], unauthenticated_patterns: ['not logged in'] }")
+        );
+        assert_ne!(base, key("args: ['{run_dir}'], min_version: '1.2.0'"));
+        assert_ne!(
+            key("args: ['{run_dir}'], min_version: '1.2.0'"),
+            key("args: ['{run_dir}'], min_version: '2.0.0'")
+        );
+    }
+
+    #[test]
+    fn declared_but_unusable_probes_fail_the_static_contract_before_any_spawn() {
+        for (invocation, expected) in [
+            (
+                "identity_probe: { args: [], expected_signature: fixture }",
+                "identity_probe.args",
+            ),
+            (
+                "identity_probe: { args: ['--version'], expected_signature: '  ' }",
+                "expected_signature",
+            ),
+            (
+                "auth_probe: { args: [], unauthenticated_patterns: ['not logged in'] }",
+                "auth_probe.args",
+            ),
+            (
+                "auth_probe: { args: [auth, status] }",
+                "at least one ready_patterns",
+            ),
+        ] {
+            // Built-in adapters are covered too: these fields are new, so no
+            // existing profile can regress and a broken declaration must never
+            // spawn a bare command.
+            for id in ["generic-fixture", "codex"] {
+                let profile: WorkerProfile = crate::yaml::from_str(&format!(
+                    "id: {id}\ninvocation: {{ command: bash, supports_noninteractive: true, output_contract: files, {invocation} }}\n"
+                ))
+                .unwrap();
+                let status = probe(&profile, &BillingPolicy::default(), "full");
+                assert_eq!(status.readiness, Readiness::NotReady, "{}", status.detail);
+                assert!(status.detail.contains(expected), "{}", status.detail);
+            }
+        }
+    }
+
+    /// A profile whose probes are answered by `echo`: `echo <arg>` prints its
+    /// arguments, so each declared probe's output is exactly what the test
+    /// declares. No worker CLI is needed to exercise the gates end to end.
+    fn echo_profile(invocation: &str) -> WorkerProfile {
+        crate::yaml::from_str(&format!(
+            "id: generic-fixture\ninvocation: {{ command: echo, supports_noninteractive: true, output_contract: files, {invocation} }}\n"
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn identity_mismatch_is_wrong_product_not_ready() {
+        let profile = echo_profile(
+            "identity_probe: { args: ['some-other-product 3.1'], expected_signature: 'fixture-worker' }",
+        );
+        let status = probe(&profile, &BillingPolicy::default(), "full");
+        assert_eq!(
+            status.readiness,
+            Readiness::WrongProduct,
+            "{}",
+            status.detail
+        );
+        assert_eq!(status.readiness.label(), "wrong product");
+        assert_eq!(status.identity, IdentityState::Mismatched);
+        assert!(
+            status.detail.contains("some-other-product"),
+            "{}",
+            status.detail
+        );
+        assert!(
+            status.detail.contains("fixture-worker"),
+            "{}",
+            status.detail
+        );
+
+        let matching = echo_profile(
+            "identity_probe: { args: ['fixture-worker 3.1'], expected_signature: 'fixture-worker' }",
+        );
+        let status = probe(&matching, &BillingPolicy::default(), "full");
+        assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        assert_eq!(status.identity, IdentityState::Matched);
+    }
+
+    #[test]
+    fn version_below_declared_minimum_is_unsupported_version_with_upgrade_guidance() {
+        let profile = echo_profile("version_args: ['fixture-worker 0.9.9'], min_version: '1.2.0'");
+        let status = probe(&profile, &BillingPolicy::default(), "full");
+        assert_eq!(
+            status.readiness,
+            Readiness::UnsupportedVersion,
+            "{}",
+            status.detail
+        );
+        assert_eq!(status.readiness.label(), "unsupported version");
+        assert_eq!(status.required_version.as_deref(), Some("1.2.0"));
+        assert!(status.detail.contains(">= 1.2.0"), "{}", status.detail);
+        assert!(
+            status
+                .invocation_verdict(&BillingPolicy::default())
+                .contains(">= 1.2.0"),
+            "{}",
+            status.invocation_verdict(&BillingPolicy::default())
+        );
+
+        // At or above the minimum stays invocable, and an unparseable version
+        // is unknown rather than a block.
+        for version in ["fixture-worker 1.2.0", "fixture-worker nightly"] {
+            let profile = echo_profile(&format!(
+                "version_args: ['{version}'], min_version: '1.2.0'"
+            ));
+            let status = probe(&profile, &BillingPolicy::default(), "full");
+            assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        }
+    }
+
+    #[test]
+    fn auth_probe_blocks_only_a_confirmed_logged_out_cli() {
+        let unauthenticated = echo_profile(
+            "auth_probe: { args: ['you are not logged in'], ready_patterns: ['logged in as'], unauthenticated_patterns: ['not logged in'] }",
+        );
+        let status = probe(&unauthenticated, &BillingPolicy::default(), "full");
+        assert_eq!(
+            status.readiness,
+            Readiness::Unauthenticated,
+            "{}",
+            status.detail
+        );
+        assert_eq!(status.readiness.label(), "unauthenticated");
+        assert_eq!(status.auth, AuthState::Unauthenticated);
+
+        let authenticated = echo_profile(
+            "auth_probe: { args: ['logged in as fixture'], ready_patterns: ['logged in as'], unauthenticated_patterns: ['not logged in'] }",
+        );
+        let status = probe(&authenticated, &BillingPolicy::default(), "full");
+        assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        assert_eq!(status.auth, AuthState::Authenticated);
+
+        // Inconclusive output is a label on a ready worker, never a block.
+        let unknown = echo_profile(
+            "auth_probe: { args: ['status unavailable'], ready_patterns: ['logged in as'], unauthenticated_patterns: ['not logged in'] }",
+        );
+        let status = probe(&unknown, &BillingPolicy::default(), "full");
+        assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        assert_eq!(status.auth, AuthState::Unknown);
+        let auth_stage = status
+            .stages(&BillingPolicy::default())
+            .into_iter()
+            .find(|stage| stage.label == "auth")
+            .unwrap();
+        assert_eq!(auth_stage.mark, StageMark::Offline);
+    }
+
+    #[test]
+    fn the_new_gates_run_in_order_and_stop_at_the_first_failure() {
+        // Identity is checked before version: a wrong product with a too-low
+        // version reports the wrong product, never the version.
+        let profile = echo_profile(
+            "version_args: ['other 0.0.1'], min_version: '9.9.9', identity_probe: { args: ['other 0.0.1'], expected_signature: 'fixture-worker' }, auth_probe: { args: ['not logged in'], unauthenticated_patterns: ['not logged in'] }",
+        );
+        let status = probe(&profile, &BillingPolicy::default(), "full");
+        assert_eq!(
+            status.readiness,
+            Readiness::WrongProduct,
+            "{}",
+            status.detail
+        );
+        assert_eq!(
+            status.auth,
+            AuthState::NotProbed,
+            "auth ran after a failed identity gate"
+        );
+
+        // Version is checked before auth: a too-low version reports the
+        // version, and the auth probe never runs.
+        let profile = echo_profile(
+            "version_args: ['fixture-worker 0.0.1'], min_version: '9.9.9', identity_probe: { args: ['fixture-worker 0.0.1'], expected_signature: 'fixture-worker' }, auth_probe: { args: ['not logged in'], unauthenticated_patterns: ['not logged in'] }",
+        );
+        let status = probe(&profile, &BillingPolicy::default(), "full");
+        assert_eq!(
+            status.readiness,
+            Readiness::UnsupportedVersion,
+            "{}",
+            status.detail
+        );
+        assert_eq!(status.identity, IdentityState::Matched);
+        assert_eq!(
+            status.auth,
+            AuthState::NotProbed,
+            "auth ran after a failed version gate"
+        );
+    }
+
+    #[test]
+    fn undeclared_probes_keep_the_existing_five_stage_checklist_unchanged() {
+        let billing = BillingPolicy::default();
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: codex\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files }\n",
+        )
+        .unwrap();
+        let status = probe(&profile, &billing, "full");
+        assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        assert_eq!(status.identity, IdentityState::NotDeclared);
+        assert_eq!(status.auth, AuthState::NotProbed);
+        let labels: Vec<&str> = status
+            .stages(&billing)
+            .iter()
+            .map(|stage| stage.label)
+            .collect();
+        assert_eq!(
+            labels,
+            ["contract", "binary", "version", "billing-env", "auth"]
+        );
+    }
+
+    #[test]
+    fn declared_gates_appear_in_the_staged_checklist_between_binary_and_version() {
+        let billing = BillingPolicy::default();
+        let profile = echo_profile(
+            "version_args: ['fixture-worker 1.2.3'], min_version: '1.0.0', identity_probe: { args: ['fixture-worker 1.2.3'], expected_signature: 'fixture-worker' }, auth_probe: { args: ['logged in as fixture'], ready_patterns: ['logged in as'] }",
+        );
+        let status = probe(&profile, &billing, "full");
+        assert_eq!(status.readiness, Readiness::Ready, "{}", status.detail);
+        let stages = status.stages(&billing);
+        let labels: Vec<&str> = stages.iter().map(|stage| stage.label).collect();
+        assert_eq!(
+            labels,
+            [
+                "contract",
+                "binary",
+                "identity",
+                "version",
+                "billing-env",
+                "auth"
+            ]
+        );
+        assert_eq!(stages[2].mark, StageMark::Pass);
+        assert_eq!(
+            stages.iter().find(|s| s.label == "auth").unwrap().mark,
+            StageMark::Pass
+        );
+    }
+
     #[test]
     fn generic_scout_sandbox_contract_fails_closed_when_missing_or_unverifiable() {
         let profile = |sandbox_args: &[&str], full_access_args: &[&str]| WorkerProfile {
@@ -1012,6 +1821,9 @@ invocation:
                 effort_args: vec![],
                 pass_env: vec![],
                 session: None,
+                identity_probe: None,
+                auth_probe: None,
+                min_version: None,
             },
             limits: crate::schemas::Limits::default(),
             provider_response_refusal_patterns: vec![],

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -2225,6 +2225,47 @@ pub struct Invocation {
     /// profiles omit this and keep ExplicitPacket answer continuation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session: Option<GenericSessionInvocation>,
+    /// Opt-in offline product-identity probe. Without it, any binary that
+    /// answers the version probe with exit 0 passes as this worker, so a
+    /// different product installed under the same command name reads as ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_probe: Option<IdentityProbe>,
+    /// Opt-in offline auth probe. Deliberately tolerant: it can only confirm
+    /// an unauthenticated CLI, never turn an unknown login into a hard stop.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_probe: Option<AuthProbe>,
+    /// Opt-in lowest supported version of the worker CLI. Compared tolerantly
+    /// (leading numeric triple on both sides); anything unparseable is unknown
+    /// and never blocks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
+}
+
+/// Offline check that the binary under `command` really is the expected
+/// product. The probe must be a local, non-interactive command.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IdentityProbe {
+    /// Arguments for the identity probe (e.g. `["--version"]`).
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Case-insensitive substring expected in the probe's first output line.
+    #[serde(default)]
+    pub expected_signature: String,
+}
+
+/// Offline, tolerant auth probe. Yardlet never makes a billed call to verify a
+/// subscription login; this only reads what a local command already prints.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AuthProbe {
+    /// Arguments for the auth probe (e.g. `["auth", "status"]`).
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Case-insensitive substrings that mean "logged in".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ready_patterns: Vec<String>,
+    /// Case-insensitive substrings that mean "not logged in". Checked first.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub unauthenticated_patterns: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -2380,6 +2421,60 @@ impl Invocation {
             )),
             _ => unreachable!("prompt transport was validated above"),
         }
+    }
+
+    /// Validate the optional readiness-probe declarations. Applies to every
+    /// worker id (built-in adapters included) because these fields are new:
+    /// nothing declares them today, and a declared-but-unusable probe must
+    /// fail closed on the static gate rather than spawn a bare command.
+    pub fn validate_probes(&self, worker_id: &str) -> Result<(), String> {
+        if let Some(identity) = &self.identity_probe {
+            if identity.args.is_empty() || identity.args.iter().any(|arg| arg.trim().is_empty()) {
+                return Err(format!(
+                    "worker '{worker_id}' identity_probe.args must contain a configured offline probe"
+                ));
+            }
+            validate_invocation_args(
+                worker_id,
+                "identity_probe.args",
+                &identity.args,
+                false,
+                false,
+                false,
+            )?;
+            if identity.expected_signature.trim().is_empty() {
+                return Err(format!(
+                    "worker '{worker_id}' identity_probe.expected_signature must not be empty"
+                ));
+            }
+        }
+        if let Some(auth) = &self.auth_probe {
+            if auth.args.is_empty() || auth.args.iter().any(|arg| arg.trim().is_empty()) {
+                return Err(format!(
+                    "worker '{worker_id}' auth_probe.args must contain a configured offline probe"
+                ));
+            }
+            validate_invocation_args(
+                worker_id,
+                "auth_probe.args",
+                &auth.args,
+                false,
+                false,
+                false,
+            )?;
+            let patterns = auth
+                .ready_patterns
+                .iter()
+                .chain(auth.unauthenticated_patterns.iter())
+                .filter(|pattern| !pattern.trim().is_empty())
+                .count();
+            if patterns == 0 {
+                return Err(format!(
+                    "worker '{worker_id}' auth_probe must declare at least one ready_patterns or unauthenticated_patterns entry"
+                ));
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -206,6 +206,10 @@ pub struct WorkerLine {
     pub billing_blocked: bool,
     /// Model this worker runs with (alias or full id); empty = the CLI default.
     pub model: String,
+    /// The profile's declared `min_version`, so the workers panel can say
+    /// "upgrade to >= X" without re-reading workers.yaml.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_version: Option<String>,
     pub detail: String,
     pub enabled: bool,
     /// Non-public cache identity for the invocation/billing inputs that produced
@@ -286,6 +290,7 @@ impl Snapshot {
                         billing_env_present: 0,
                         billing_blocked: false,
                         model: p.model.clone(),
+                        required_version: p.invocation.min_version.clone(),
                         detail: "disabled (toggle on the Home workers panel)".to_string(),
                         enabled: false,
                         readiness_cache_key,
@@ -301,6 +306,7 @@ impl Snapshot {
                     return WorkerLine {
                         enabled: true,
                         model: p.model.clone(),
+                        required_version: p.invocation.min_version.clone(),
                         billing_blocked: guard::billing_blocked(&policy, c.billing_env_present),
                         readiness_cache_key,
                         ..c.clone()
@@ -315,6 +321,7 @@ impl Snapshot {
                     billing_env_present: present,
                     billing_blocked: guard::billing_blocked(&policy, present),
                     model: p.model.clone(),
+                    required_version: s.required_version,
                     detail: s.detail,
                     enabled: true,
                     readiness_cache_key,
@@ -817,6 +824,9 @@ current_intent: ""
                 version: Some("fixture 1.0".into()),
                 billing_env_present: Vec::new(),
                 contract_error: None,
+                identity: crate::guard::IdentityState::NotDeclared,
+                auth: crate::guard::AuthState::NotProbed,
+                required_version: None,
                 readiness: crate::guard::Readiness::Ready,
                 detail: "injected readiness".into(),
             }

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -337,6 +337,17 @@ pub struct L {
     pub w_ambiguous: &'static str,
     pub w_notready: &'static str,
     pub w_disabled: &'static str,
+    /// Readiness contract states: another product answers this command name,
+    /// the CLI is older than the profile's declared minimum, and the CLI
+    /// itself reports it is not logged in.
+    pub w_wrong_product: &'static str,
+    pub w_unsupported_version: &'static str,
+    pub w_unauthenticated: &'static str,
+    /// Fix-it hints shown next to those three states. `w_hint_upgrade` is
+    /// formatted with the declared minimum version.
+    pub w_hint_wrong_product: &'static str,
+    pub w_hint_upgrade: &'static str,
+    pub w_hint_login: &'static str,
     pub worker_on: &'static str,
     pub worker_off: &'static str,
     pub worker_toggle_hint: &'static str,
@@ -630,6 +641,12 @@ pub const EN: L = L {
     w_ambiguous: "ambiguous",
     w_notready: "not ready",
     w_disabled: "off",
+    w_wrong_product: "wrong CLI",
+    w_unsupported_version: "old version",
+    w_unauthenticated: "logged out",
+    w_hint_wrong_product: "another product answers this command",
+    w_hint_upgrade: "upgrade to >=",
+    w_hint_login: "sign in with the worker CLI itself",
     worker_on: "enabled",
     worker_off: "disabled",
     worker_toggle_hint: "  Enter/Space toggle",
@@ -899,6 +916,12 @@ pub const KO: L = L {
     w_ambiguous: "모호",
     w_notready: "준비안됨",
     w_disabled: "꺼짐",
+    w_wrong_product: "다른 제품",
+    w_unsupported_version: "구버전",
+    w_unauthenticated: "미인증",
+    w_hint_wrong_product: "같은 명령 이름에 엉뚱한 CLI가 응답",
+    w_hint_upgrade: "업그레이드 필요 >=",
+    w_hint_login: "워커 CLI에서 직접 로그인",
     worker_on: "켜짐",
     worker_off: "꺼짐",
     worker_toggle_hint: "  Enter/Space 토글",
@@ -1258,6 +1281,43 @@ mod tests {
         for ((state, en), ko) in states.into_iter().zip(expected_en).zip(expected_ko) {
             assert_eq!(task_state_label(Lang::En.l(), state), en);
             assert_eq!(task_state_label(Lang::Ko.l(), state), ko);
+        }
+    }
+
+    #[test]
+    fn extended_worker_readiness_labels_stay_distinct_in_both_languages() {
+        // The workers panel renders one of these per row, and marker-based
+        // assertions elsewhere match on them, so no label may be a substring of
+        // another label or of a fix-it hint.
+        for lang in [Lang::En, Lang::Ko] {
+            let l = lang.l();
+            let labels = [
+                l.w_ready,
+                l.w_ambiguous,
+                l.w_notready,
+                l.w_disabled,
+                l.w_wrong_product,
+                l.w_unsupported_version,
+                l.w_unauthenticated,
+            ];
+            let hints = [l.w_hint_wrong_product, l.w_hint_upgrade, l.w_hint_login];
+            for field in labels.iter().chain(hints.iter()) {
+                assert!(!field.trim().is_empty(), "{lang:?} has an empty field");
+            }
+            for (index, label) in labels.iter().enumerate() {
+                for (other_index, other) in labels.iter().enumerate() {
+                    assert!(
+                        index == other_index || !other.contains(label),
+                        "{lang:?}: worker label {label:?} overlaps {other:?}"
+                    );
+                }
+                for hint in hints {
+                    assert!(
+                        !hint.contains(label),
+                        "{lang:?}: worker label {label:?} overlaps hint {hint:?}"
+                    );
+                }
+            }
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4917,6 +4917,7 @@ routing:
                 billing_env_present: 0,
                 billing_blocked: false,
                 model: worker.model,
+                required_version: worker.invocation.min_version,
                 detail: "injected".into(),
                 enabled: true,
             })

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -969,21 +969,58 @@ fn task_waiting_kind(snap: &Snapshot, id: &str, state: TaskState, l: &L) -> Opti
     }
 }
 
+/// The workers-panel row vocabulary for one readiness verdict: glyph, color,
+/// localized word, and the fix-it hint the state is only actionable with.
+///
+/// The match arms are the `guard::Readiness` labels carried on the snapshot, so
+/// this stays pure and is unit-tested against every variant rather than
+/// discovered as a silently untranslated row.
+fn worker_row_words(
+    readiness: &str,
+    enabled: bool,
+    required_version: Option<&str>,
+    l: &L,
+) -> (&'static str, Color, &'static str, Option<String>) {
+    if !enabled {
+        return ("\u{00b7}", Color::DarkGray, l.w_disabled, None);
+    }
+    match readiness {
+        "invocable" => ("\u{2713}", Color::Green, l.w_ready, None),
+        "ambiguous" => ("?", Color::Yellow, l.w_ambiguous, None),
+        "wrong product" => (
+            "\u{2715}",
+            Color::Red,
+            l.w_wrong_product,
+            Some(l.w_hint_wrong_product.to_string()),
+        ),
+        "unsupported version" => (
+            "\u{2715}",
+            Color::Red,
+            l.w_unsupported_version,
+            Some(format!(
+                "{} {}",
+                l.w_hint_upgrade,
+                required_version.unwrap_or("?")
+            )),
+        ),
+        "unauthenticated" => (
+            "\u{2715}",
+            Color::Red,
+            l.w_unauthenticated,
+            Some(l.w_hint_login.to_string()),
+        ),
+        _ => ("\u{2715}", Color::Red, l.w_notready, None),
+    }
+}
+
 fn render_workers(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L, selected: Option<usize>) {
     let items: Vec<ListItem> = snap
         .workers
         .iter()
         .enumerate()
         .map(|(i, w)| {
-            let (glyph, color, word) = if !w.enabled {
-                ("\u{00b7}", Color::DarkGray, l.w_disabled)
-            } else {
-                match w.readiness.as_str() {
-                    "invocable" => ("\u{2713}", Color::Green, l.w_ready),
-                    "ambiguous" => ("?", Color::Yellow, l.w_ambiguous),
-                    _ => ("\u{2715}", Color::Red, l.w_notready),
-                }
-            };
+            let (glyph, color, word, hint) =
+                worker_row_words(&w.readiness, w.enabled, w.required_version.as_deref(), l);
             let is_sel = selected == Some(i);
             let marker = if is_sel { "\u{25b8}" } else { " " };
             let id_style = if w.enabled {
@@ -1024,6 +1061,12 @@ fn render_workers(frame: &mut Frame, area: Rect, snap: &Snapshot, l: &L, selecte
                     Style::default().fg(Color::DarkGray),
                 ),
             ];
+            if let Some(hint) = hint {
+                spans.push(Span::styled(
+                    format!("  {hint}"),
+                    Style::default().fg(Color::Red),
+                ));
+            }
             if is_sel {
                 // The selected worker also surfaces its model alongside the
                 // toggle hint (room is tight on every row, so show it here).
@@ -1931,6 +1974,58 @@ mod tests {
         assert!(!output.contains("STALE INTENT REASON"));
 
         let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn every_readiness_verdict_reaches_the_workers_panel_with_its_own_words() {
+        use crate::guard::Readiness;
+
+        for lang in [i18n::Lang::En, i18n::Lang::Ko] {
+            let l = lang.l();
+            let mut seen: Vec<&'static str> = Vec::new();
+            for readiness in [
+                Readiness::Ready,
+                Readiness::NotReady,
+                Readiness::Ambiguous,
+                Readiness::WrongProduct,
+                Readiness::UnsupportedVersion,
+                Readiness::Unauthenticated,
+            ] {
+                let (_, _, word, hint) =
+                    worker_row_words(readiness.label(), true, Some("1.2.0"), l);
+                // A verdict that falls through to the generic "not ready" arm
+                // would silently hide what is actually wrong.
+                assert!(
+                    readiness == Readiness::NotReady || word != l.w_notready,
+                    "{lang:?}: {} has no workers-panel wording of its own",
+                    readiness.label()
+                );
+                assert!(!seen.contains(&word), "{lang:?}: {word} is used twice");
+                seen.push(word);
+
+                // The three extended states are only actionable with their fix.
+                let extended = matches!(
+                    readiness,
+                    Readiness::WrongProduct
+                        | Readiness::UnsupportedVersion
+                        | Readiness::Unauthenticated
+                );
+                assert_eq!(
+                    hint.is_some(),
+                    extended,
+                    "{lang:?}: {} hint presence is wrong",
+                    readiness.label()
+                );
+                if readiness == Readiness::UnsupportedVersion {
+                    assert!(hint.unwrap().contains("1.2.0"), "{lang:?}");
+                }
+            }
+            // A disabled worker keeps its own row wording regardless of verdict.
+            let (_, _, word, hint) =
+                worker_row_words(Readiness::Unauthenticated.label(), false, None, l);
+            assert_eq!(word, l.w_disabled);
+            assert!(hint.is_none());
+        }
     }
 
     #[test]

--- a/tests/worker_readiness_contract_process.rs
+++ b/tests/worker_readiness_contract_process.rs
@@ -1,0 +1,355 @@
+#![cfg(unix)]
+
+//! Extended readiness contract, exercised against real subprocesses.
+//!
+//! Each fixture installs a fake CLI that echoes exactly what the profile asks
+//! it to echo, so one script can play "a different product under the same
+//! command name", "an out-of-date build", and "a logged-out CLI". The three
+//! states must reach the operator (routing refusal + `worker status`) and must
+//! block the worker spawn, and every probe attempt must run with the
+//! AI-billing environment already scrubbed.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Fixture {
+    root: PathBuf,
+    capture: PathBuf,
+    binary: PathBuf,
+    worker: PathBuf,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let stem = format!(
+            "yardlet-readiness-contract-{label}-{}-{nonce}",
+            std::process::id()
+        );
+        let root = std::env::temp_dir().join(&stem);
+        let capture = std::env::temp_dir().join(format!("{stem}-capture"));
+        fs::create_dir_all(&root).unwrap();
+        fs::create_dir_all(&capture).unwrap();
+        let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+
+        must_succeed(&root, Path::new("git"), &["init", "-q"]);
+        must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["config", "user.email", "fixture@example.invalid"],
+        );
+        fs::write(root.join("README.md"), "fixture\n").unwrap();
+        must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+        must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+        must_succeed(&root, &binary, &["init"]);
+
+        let worker = root.join("fixture-worker.sh");
+        write_worker(&worker, &capture);
+        must_succeed(&root, Path::new("git"), &["add", "fixture-worker.sh"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["commit", "-qm", "fixture worker"],
+        );
+        write_task(&root);
+
+        Self {
+            root,
+            capture,
+            binary,
+            worker,
+        }
+    }
+
+    fn configure(&self, invocation: &str) {
+        fs::write(
+            self.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      args: [execute, '{{run_dir}}']\n      sandbox_args: ['--fixture-sandbox']\n{}    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n  allow_preferred_worker_failover: false\n",
+                self.worker.display(),
+                invocation
+            ),
+        )
+        .unwrap();
+        fs::write(
+            self.root.join(".agents/billing-policy.yaml"),
+            "schema_version: 1\nmode: zero_key_subscription_workers\nworker_invocation:\n  ai_billing_env_policy: scrub_or_block\nblocked_worker_env_names: [YARD_READINESS_CONTRACT_SECRET]\n",
+        )
+        .unwrap();
+    }
+
+    fn run_with_secret(&self, args: &[&str]) -> Output {
+        Command::new(&self.binary)
+            .args(args)
+            .current_dir(&self.root)
+            .env("YARD_READINESS_CONTRACT_SECRET", "must-not-reach-worker")
+            .output()
+            .unwrap()
+    }
+
+    /// The recorded billing-env posture of one probe attempt. Reading a missing
+    /// capture file panics, so the assertion cannot pass vacuously.
+    fn probe_secret(&self, branch: &str) -> String {
+        let path = self.capture.join(format!("{branch}-secret"));
+        fs::read_to_string(&path).unwrap_or_else(|error| {
+            panic!("no {branch} probe attempt recorded at {path:?}: {error}")
+        })
+    }
+
+    fn attempted(&self, branch: &str) -> bool {
+        self.capture.join(format!("{branch}-argv")).exists()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+        let _ = fs::remove_dir_all(&self.capture);
+    }
+}
+
+fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()));
+    assert!(
+        output.status.success(),
+        "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        program.display(),
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn write_task(root: &Path) {
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-readiness-contract\nsummary: readiness contract fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-readiness-contract\nintent_id: intent-readiness-contract\ntasks:\n  - id: YARD-001\n    title: readiness contract fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [worker spawns only when readiness allows it]\n",
+    )
+    .unwrap();
+}
+
+/// A fake CLI whose probe branches echo their second argument, so each test
+/// declares the exact probe output in `.agents/workers.yaml`.
+fn write_worker(path: &Path, capture: &Path) {
+    let script = format!(
+        r#"#!/bin/sh
+set -eu
+capture={capture:?}
+printf '%s\0' "$@" > "$capture/last-argv"
+if [ "${{YARD_READINESS_CONTRACT_SECRET+x}}" = x ]; then
+  printf present > "$capture/last-secret"
+else
+  printf absent > "$capture/last-secret"
+fi
+case "${{1:-}}" in
+  identity|version|auth)
+    cp "$capture/last-argv" "$capture/$1-argv"
+    cp "$capture/last-secret" "$capture/$1-secret"
+    printf '%s\n' "${{2:-}}"
+    exit 0
+    ;;
+esac
+printf invoked > "$capture/invoked"
+run_dir="$2"
+run_id="$(basename "$run_dir")"
+cat > "$capture/stdin"
+cat > "$run_dir/result.json" <<EOF
+{{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "compact_summary": "readiness fixture complete"
+}}
+EOF
+printf '# Readiness fixture handoff\n' > "$run_dir/handoff.md"
+"#,
+        capture = capture.display()
+    );
+    fs::write(path, script).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn combined(output: &Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn a_different_product_under_the_same_command_name_is_rejected_before_the_worker_spawn() {
+    let fixture = Fixture::new("wrong-product");
+    fixture.configure(
+        "      version_args: [version, 'other-product 3.1.0']\n      identity_probe:\n        args: [identity, 'other-product 3.1.0 (not the worker)']\n        expected_signature: fixture-worker\n",
+    );
+
+    let run = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(!run.status.success(), "a wrong binary unexpectedly routed");
+    let routing = combined(&run);
+    assert!(
+        routing.contains("different product is installed under the command name"),
+        "{routing}"
+    );
+    assert!(routing.contains("other-product 3.1.0"), "{routing}");
+    assert!(
+        !fixture.capture.join("invoked").exists(),
+        "a wrong binary must never be invoked as the worker"
+    );
+    // Identity is gated before the version probe, so the later gate never runs.
+    assert!(
+        fixture.attempted("identity"),
+        "the identity probe never ran"
+    );
+    assert!(
+        !fixture.attempted("version"),
+        "the version probe ran after a failed identity gate"
+    );
+    assert_eq!(
+        fixture.probe_secret("identity"),
+        "absent",
+        "identity probes must use the worker billing-env sanitation boundary"
+    );
+
+    let status = fixture.run_with_secret(&["worker", "status"]);
+    let text = combined(&status);
+    assert!(text.contains("fixture [wrong product]"), "{text}");
+    assert!(text.contains("set an explicit `command:` path"), "{text}");
+    assert!(
+        text.contains("[ FAIL] identity"),
+        "the staged checklist must name the identity gate: {text}"
+    );
+}
+
+#[test]
+fn a_logged_out_worker_cli_is_rejected_before_the_worker_spawn() {
+    let fixture = Fixture::new("unauthenticated");
+    fixture.configure(
+        "      version_args: [version, 'fixture-worker 1.4.0']\n      auth_probe:\n        args: [auth, 'account: you are not logged in']\n        ready_patterns: ['logged in as']\n        unauthenticated_patterns: ['not logged in']\n",
+    );
+
+    let run = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        !run.status.success(),
+        "a logged-out worker unexpectedly routed"
+    );
+    let routing = combined(&run);
+    assert!(routing.contains("NOT logged in"), "{routing}");
+    assert!(
+        !fixture.capture.join("invoked").exists(),
+        "a logged-out worker must never be invoked"
+    );
+    assert!(fixture.attempted("auth"), "the auth probe never ran");
+    assert_eq!(
+        fixture.probe_secret("auth"),
+        "absent",
+        "auth probes must use the worker billing-env sanitation boundary"
+    );
+
+    let status = fixture.run_with_secret(&["worker", "status"]);
+    let text = combined(&status);
+    assert!(text.contains("fixture [unauthenticated]"), "{text}");
+    assert!(text.contains("fix: sign in with"), "{text}");
+    assert!(
+        text.contains("[ FAIL] auth"),
+        "the staged checklist must fail the auth gate: {text}"
+    );
+    assert!(
+        text.contains("never asks for an API key"),
+        "a logged-out worker must be pointed at its own login, not at an API key: {text}"
+    );
+}
+
+#[test]
+fn a_worker_cli_below_min_version_is_rejected_with_upgrade_guidance() {
+    let fixture = Fixture::new("unsupported-version");
+    fixture.configure(
+        "      version_args: [version, 'fixture-worker 0.9.9']\n      min_version: '1.2.0'\n      auth_probe:\n        args: [auth, 'logged in as fixture']\n        ready_patterns: ['logged in as']\n",
+    );
+
+    let run = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        !run.status.success(),
+        "an out-of-date worker unexpectedly routed"
+    );
+    let routing = combined(&run);
+    assert!(routing.contains("upgrade to >= 1.2.0"), "{routing}");
+    assert!(routing.contains("fixture-worker 0.9.9"), "{routing}");
+    assert!(
+        !fixture.capture.join("invoked").exists(),
+        "an out-of-date worker must never be invoked"
+    );
+    // The version gate runs before auth, and stops it.
+    assert!(fixture.attempted("version"), "the version probe never ran");
+    assert!(
+        !fixture.attempted("auth"),
+        "the auth probe ran after a failed version gate"
+    );
+    assert_eq!(
+        fixture.probe_secret("version"),
+        "absent",
+        "version probes must use the worker billing-env sanitation boundary"
+    );
+
+    let status = fixture.run_with_secret(&["worker", "status"]);
+    let text = combined(&status);
+    assert!(text.contains("fixture [unsupported version]"), "{text}");
+    assert!(text.contains("fix: upgrade"), "{text}");
+    assert!(text.contains(">= 1.2.0"), "{text}");
+}
+
+#[test]
+fn a_matching_up_to_date_logged_in_worker_stays_invocable() {
+    let fixture = Fixture::new("all-gates-pass");
+    fixture.configure(
+        "      version_args: [version, 'fixture-worker 1.4.0']\n      min_version: '1.2.0'\n      identity_probe:\n        args: [identity, 'fixture-worker 1.4.0']\n        expected_signature: fixture-worker\n      auth_probe:\n        args: [auth, 'logged in as fixture']\n        ready_patterns: ['logged in as']\n        unauthenticated_patterns: ['not logged in']\n",
+    );
+
+    let run = fixture.run_with_secret(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        run.status.success(),
+        "every gate passed but the run failed:\n{}",
+        combined(&run)
+    );
+    assert!(
+        fixture.capture.join("invoked").exists(),
+        "the worker was never invoked despite passing every gate"
+    );
+    for branch in ["identity", "version", "auth"] {
+        assert!(fixture.attempted(branch), "the {branch} probe never ran");
+        assert_eq!(
+            fixture.probe_secret(branch),
+            "absent",
+            "{branch} probes must use the worker billing-env sanitation boundary"
+        );
+    }
+
+    let status = fixture.run_with_secret(&["worker", "status"]);
+    let text = combined(&status);
+    assert!(text.contains("fixture [invocable]"), "{text}");
+    assert!(text.contains("[   ok] identity"), "{text}");
+    assert!(
+        text.contains("[   ok] auth"),
+        "a declared auth probe that reports a login must show it: {text}"
+    );
+}


### PR DESCRIPTION
V010-006 readiness-contract bundle (roadmap: readiness must distinguish missing binary / wrong product under the same command name / unsupported version / unknown auth / authenticated-ready). Implemented by an Opus subagent to a fixed spec; independently reviewed, unit (26) + new process fixtures (4) re-run green before this PR.

## What

- Optional per-profile declarations on `invocation`: `identity_probe` (args + expected first-line signature, case-insensitive substring), `auth_probe` (args + ready/unauthenticated patterns, tolerant three-way verdict — only a CONFIRMED logged-out match blocks, probe failure is Unknown), `min_version` (lenient N.N.N comparison, unparseable → pass).
- `Readiness` gains `WrongProduct` / `UnsupportedVersion` / `Unauthenticated`; all three are non-invocable through the single shared `guard::probe` path (routing, planner, capability projection, spawn recheck). Auth-unknown stays a label on Ready, not a block.
- Gate order: static contract → binary → identity → version → auth; earlier failure stops later probes (asserted at subprocess level). Broken declarations (empty args/signature/patterns) fail the static contract closed before any spawn.
- All probes run with the sanitized zero-key env (`env_clear` + existing scrub); fixtures assert per-branch secret absence non-vacuously.
- Display on all three surfaces (CLI status `fix:` hints, snapshot WorkerLine, TUI workers panel) with EN/KO i18n, plus drift-guard tests (every variant gets its own localized word; no label is a substring of another).
- `readiness_cache_key` changes when a probe declaration changes (pinned by test).
- README.md / README.ko.md profile docs 1:1.

## Evidence

Agent-run gates: fmt 0 / clippy -D warnings 0 / `cargo test --all-features --no-fail-fast` 0 (737 unit + all integration targets ok). RED observed with judgement fns as `todo!()` (8 new tests failed, 18 pre-existing stayed green) and with process fixtures under forced-passing judgements (all 4 failed for the right reason). My independent re-run: guard unit 26/26, process target 4/4. Codename scan of diff: 0.