### PR TITLE
fix(ui): say when Home is frozen on a stale snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
   clean legacy state while task-bearing or provenance-bearing queues keep
   failing closed.
 
+- **A failed state reload no longer freezes Home silently.** Both TUI reload
+  paths dropped `Snapshot::load` errors, so a wedged workspace kept serving the
+  last projection that loaded: the operator saw stale-but-plausible Home state
+  plus an unrelated-sounding confirm error, with nothing saying the screen was
+  dead (issue #138). The last good projection is still kept — a blank Home is
+  worse — but Home now leads with one red row naming the failure and the `g`
+  retry key, in English and Korean, and clears it the moment a reload succeeds.
+
 ### Added
 
 - **One-command start for the unambiguous planning case.** `yardlet planning

--- a/src/ui/i18n.rs
+++ b/src/ui/i18n.rs
@@ -452,6 +452,11 @@ pub struct L {
     pub startup_failed: &'static str,
     pub background_job_failed: &'static str,
     pub no_workspace_state: &'static str,
+    /// Home banner for a screen frozen on the last projection that loaded, with
+    /// `{error}` replaced by the reload failure (issue #138). Keep the leading
+    /// phrase distinct from every other string here: the PTY tests match it as a
+    /// substring of the whole rendered frame.
+    pub snapshot_stale: &'static str,
     pub footer_startup_loading: &'static str,
     pub footer_startup_failed: &'static str,
     pub newwork_title: &'static str,
@@ -725,6 +730,8 @@ pub const EN: L = L {
     startup_failed: "Startup failed:",
     background_job_failed: "Background job ended unexpectedly; state will be recovered",
     no_workspace_state: "No workspace state loaded.",
+    snapshot_stale:
+        "! state reload failed ({error}) - showing the last good state, press g to retry",
     footer_startup_loading: "startup in progress  q quit",
     footer_startup_failed: "g retry  q quit",
     newwork_title: " New Work ",
@@ -994,6 +1001,7 @@ pub const KO: L = L {
     startup_failed: "시작 실패:",
     background_job_failed: "백그라운드 작업이 예기치 않게 종료됨; 상태를 복구합니다",
     no_workspace_state: "워크스페이스 상태를 불러오지 못했습니다.",
+    snapshot_stale: "! 상태 로드 실패 ({error}) - 마지막 정상 상태를 보여주는 중, g 키로 재시도",
     footer_startup_loading: "시작 준비 중  q 종료",
     footer_startup_failed: "g 재시도  q 종료",
     newwork_title: " 새 작업 ",

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -308,6 +308,11 @@ pub struct App {
     /// would be wasteful).
     pub ime_checked: Instant,
     pub lang: i18n::Lang,
+    /// Why the last state reload failed, when it did. `snapshot` deliberately
+    /// keeps the last projection that loaded — a blank Home is worse than a
+    /// stale one — so this is what stops the frozen screen from passing for a
+    /// live one (issue #138). `None` means the screen is current.
+    pub snapshot_stale: Option<String>,
 }
 
 #[derive(Default)]
@@ -470,6 +475,18 @@ fn lang_of(snapshot: &Option<Snapshot>) -> i18n::Lang {
         .unwrap_or(i18n::Lang::En)
 }
 
+/// The freshness marker a finished reload attempt leaves behind: `None` when
+/// the projection on screen is current, `Some(reason)` when it is frozen.
+///
+/// A failure never clears the last good snapshot — a blank Home is worse than a
+/// stale one — so this verdict is the only thing that keeps the frozen screen
+/// from passing for a live one (issue #138). The reason is flattened to a single
+/// line because the banner owns exactly one row; a failure with nothing to say
+/// still yields a marker, so silence is never mistaken for health.
+fn snapshot_freshness(load_error: Option<&str>) -> Option<String> {
+    load_error.map(|error| error.split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
 impl App {
     #[cfg(test)]
     fn new(ws: Workspace) -> App {
@@ -550,6 +567,7 @@ impl App {
             ime_saved: None,
             ime_checked: Instant::now(),
             lang,
+            snapshot_stale: None,
         }
     }
 
@@ -563,6 +581,7 @@ impl App {
 
     fn begin_startup(&mut self, rx: Receiver<StartupMsg>) {
         self.snapshot = None;
+        self.snapshot_stale = None;
         self.bootstrap = BootstrapState::Loading(StartupStage::Recovery);
         self.startup_started = Instant::now();
         self.startup_rx = Some(rx);
@@ -665,20 +684,34 @@ impl App {
             Some(w) => Snapshot::load_reusing_workers(&self.ws, w),
             None => Snapshot::load(&self.ws),
         };
-        if let Ok(s) = loaded {
-            self.lang = i18n::detect(&s.config.language, s.intent_summary());
-            self.snapshot = Some(s);
-        }
+        self.apply_reload(loaded);
         self.refresh_monitor_runs();
     }
 
     /// Full reload including a fresh worker readiness probe (g / startup).
     fn reload_full(&mut self) {
-        if let Ok(s) = Snapshot::load(&self.ws) {
-            self.lang = i18n::detect(&s.config.language, s.intent_summary());
-            self.snapshot = Some(s);
-        }
+        let loaded = Snapshot::load(&self.ws);
+        self.apply_reload(loaded);
         self.refresh_monitor_runs();
+    }
+
+    /// Adopt a reload result.
+    ///
+    /// A failure keeps the last projection that loaded, because a blank Home is
+    /// worse than a stale one — but it records why, so the Home banner can say
+    /// the screen is frozen. Dropping these errors is what let a wedged
+    /// workspace serve stale-but-plausible state with no indication at all
+    /// (issue #138).
+    fn apply_reload(&mut self, loaded: Result<Snapshot>) {
+        let error = match loaded {
+            Ok(s) => {
+                self.lang = i18n::detect(&s.config.language, s.intent_summary());
+                self.snapshot = Some(s);
+                None
+            }
+            Err(error) => Some(error.to_string()),
+        };
+        self.snapshot_stale = snapshot_freshness(error.as_deref());
     }
 
     /// Rebuild the Monitor's task→run-dir map (a runs-directory scan per
@@ -5085,6 +5118,75 @@ routing:
         assert!(app.snapshot.as_ref().unwrap().workers[0]
             .detail
             .contains("supports_noninteractive"));
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    #[test]
+    fn snapshot_freshness_marks_a_failed_reload_and_clears_on_the_next_success() {
+        assert_eq!(snapshot_freshness(None), None, "a good reload is fresh");
+        assert_eq!(
+            snapshot_freshness(Some(
+                "unconfirmed_or_inconsistent: active intent is missing"
+            )),
+            Some("unconfirmed_or_inconsistent: active intent is missing".to_string())
+        );
+        // The banner owns exactly one row, so a multi-line failure chain has to
+        // collapse into one line instead of pushing the queue off-screen.
+        assert_eq!(
+            snapshot_freshness(Some("  reading work-queue.yaml\n\ncaused by:\tbad yaml  ")),
+            Some("reading work-queue.yaml caused by: bad yaml".to_string())
+        );
+        // A failure with nothing to say is still a failure: the marker must be
+        // present so the screen is never silently frozen (issue #138).
+        assert_eq!(snapshot_freshness(Some(" \n ")), Some(String::new()));
+    }
+
+    /// Issue #138: both reload paths dropped `Snapshot::load` errors on the
+    /// floor, so a wedged workspace left the TUI showing stale-but-plausible
+    /// Home state with nothing saying the screen was dead. Keeping the last good
+    /// projection is right; keeping it silently is the defect.
+    const WEDGED_QUEUE: &str = r#"schema_version: 1
+queue_id: queue-wedged
+intent_id: int-wedged
+activation_required: true
+tasks: []
+"#;
+
+    #[test]
+    fn a_failed_reload_keeps_the_last_good_snapshot_and_marks_it_stale() {
+        let ws = workspace_with_user_config("stale-snapshot-marker");
+        let mut app = App::new(ws.clone());
+        assert!(app.snapshot.is_some(), "fixture workspace must load");
+        assert_eq!(app.snapshot_stale, None, "a good load is not stale");
+
+        std::fs::write(ws.queue_path(), WEDGED_QUEUE).unwrap();
+        app.reload_full();
+        assert!(
+            app.snapshot.is_some(),
+            "a load failure must keep the last good projection, not blank Home"
+        );
+        assert!(
+            app.snapshot_stale
+                .as_deref()
+                .is_some_and(|marker| marker.contains("active intent is missing")),
+            "explicit refresh must record why the reload failed: {:?}",
+            app.snapshot_stale
+        );
+
+        // The once-a-second cheap reload takes the same path.
+        app.snapshot_stale = None;
+        app.reload();
+        assert!(
+            app.snapshot_stale.is_some(),
+            "the cheap reload must mark the screen stale too"
+        );
+
+        std::fs::remove_file(ws.queue_path()).unwrap();
+        app.reload_full();
+        assert_eq!(
+            app.snapshot_stale, None,
+            "a reload that succeeds again must clear the marker"
+        );
         let _ = std::fs::remove_dir_all(ws.root);
     }
 

--- a/src/ui/view.rs
+++ b/src/ui/view.rs
@@ -508,22 +508,27 @@ fn render_home(frame: &mut Frame, app: &App) {
         render_bootstrap(frame, app, area);
         return;
     }
-    let chunks = Layout::vertical([
-        Constraint::Length(5),
+    // A frozen screen gets one extra row directly under the header, and only
+    // then: a healthy Home keeps the layout it always had (issue #138).
+    let stale = app.snapshot_stale.as_deref();
+    let mut constraints = vec![Constraint::Length(5)];
+    constraints.extend(stale.map(|_| Constraint::Length(1)));
+    constraints.extend([
         Constraint::Min(4),
         Constraint::Length(5),
         Constraint::Length(3),
         Constraint::Length(4),
-    ])
-    .split(area);
+    ]);
+    let chunks = Layout::vertical(constraints).split(area);
+    let body = 1 + usize::from(stale.is_some());
 
     match &app.snapshot {
         Some(snap) => {
             render_header(frame, chunks[0], snap, l);
-            render_queue(frame, chunks[1], snap, l, app.selected);
+            render_queue(frame, chunks[body], snap, l, app.selected);
             // Selection continues past the queue into the workers panel.
             let wsel = app.selected.checked_sub(snap.tasks().len());
-            render_workers(frame, chunks[2], snap, l, wsel);
+            render_workers(frame, chunks[body + 1], snap, l, wsel);
         }
         None => {
             let p =
@@ -531,7 +536,16 @@ fn render_home(frame: &mut Frame, app: &App) {
             frame.render_widget(p, chunks[0]);
         }
     }
-    render_status(frame, chunks[3], app);
+    if let Some(error) = stale {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                stale_banner(l, error, chunks[1].width),
+                Style::default().fg(Color::Red).bold(),
+            ))),
+            chunks[1],
+        );
+    }
+    render_status(frame, chunks[body + 2], app);
     // A freshly installed binary is worth shouting about — the silent
     // status-line note got missed for days. When idle, the footer turns into
     // the restart prompt in cyan so it can't be overlooked.
@@ -543,7 +557,7 @@ fn render_home(frame: &mut Frame, app: &App) {
             )))
             .block(Block::bordered())
             .wrap(Wrap { trim: true }),
-            chunks[4],
+            chunks[body + 3],
         );
         return;
     }
@@ -590,7 +604,24 @@ fn render_home(frame: &mut Frame, app: &App) {
             plan_reviewable,
         )
     };
-    render_footer(frame, chunks[4], &footer);
+    render_footer(frame, chunks[body + 3], &footer);
+}
+
+/// The one-row Home banner for a screen frozen on its last good projection.
+///
+/// The error is width-truncated so a long failure chain cannot push the retry
+/// hint off the row: the whole point of the banner is that the operator learns
+/// the screen is dead AND how to refresh it (issue #138).
+fn stale_banner(l: &L, error: &str, width: u16) -> String {
+    let error = if error.trim().is_empty() {
+        l.unknown_word
+    } else {
+        error
+    };
+    let fixed = UnicodeWidthStr::width(l.snapshot_stale.replace("{error}", "").as_str());
+    let budget = (width as usize).saturating_sub(fixed);
+    l.snapshot_stale
+        .replace("{error}", &truncate_width(error, budget))
 }
 
 fn render_bootstrap(frame: &mut Frame, app: &App, area: Rect) {
@@ -1929,6 +1960,76 @@ mod tests {
         let output = rendered_queue(&current);
         assert!(output.contains("CURRENT INTENT REASON"));
         assert!(!output.contains("STALE INTENT REASON"));
+
+        let _ = std::fs::remove_dir_all(ws.root);
+    }
+
+    /// Issue #138: a wedged workspace froze Home on its last good projection
+    /// with nothing on screen saying so. The frozen projection stays — a blank
+    /// Home is worse — but it now leads with one row that names the failure and
+    /// the retry key, and it must not push the queue, workers, or footer out.
+    #[test]
+    fn a_stale_snapshot_banner_leads_home_without_hiding_the_rest_of_it() {
+        let (ws, _, _) = crate::snapshot::reused_task_id_fixture("tui-stale-banner");
+        let mut app = App::new(ws.clone());
+
+        let fresh = rendered_home(&app);
+        assert!(
+            !fresh.contains("state reload failed"),
+            "a healthy Home must carry no stale banner:\n{fresh}"
+        );
+        assert!(fresh.contains("SHARED"), "{fresh}");
+
+        app.snapshot_stale = Some("unconfirmed_or_inconsistent: active intent is missing".into());
+        let stale = rendered_home(&app);
+        assert!(stale.contains("state reload failed"), "{stale}");
+        assert!(stale.contains("active intent is missing"), "{stale}");
+        assert!(stale.contains("press g to retry"), "{stale}");
+        // Header first, banner directly under it, then the rest of Home.
+        let rows: Vec<&str> = stale.lines().collect();
+        let banner = rows
+            .iter()
+            .position(|row| row.contains("state reload failed"))
+            .expect("banner row");
+        let queue = rows
+            .iter()
+            .position(|row| row.contains("SHARED"))
+            .expect("queue row");
+        assert!(
+            (1..queue).contains(&banner),
+            "banner must sit between the header and the queue, got row {banner} of:\n{stale}"
+        );
+        // Nothing the healthy frame showed is hidden by the extra row.
+        for kept in ["Workspace: ", "SHARED", "n new", "? keys"] {
+            assert!(
+                stale.contains(kept),
+                "stale Home dropped {kept:?}:\n{stale}"
+            );
+        }
+
+        app.lang = i18n::Lang::Ko;
+        let ko = rendered_home(&app);
+        assert!(ko.replace(' ', "").contains("상태로드실패"), "{ko}");
+        assert!(!ko.contains("state reload failed"), "{ko}");
+
+        // A failure with no message still gets a banner rather than an empty row.
+        app.lang = i18n::Lang::En;
+        app.snapshot_stale = Some(String::new());
+        let blank = rendered_home(&app);
+        assert!(blank.contains("state reload failed (unknown)"), "{blank}");
+
+        // A long failure chain loses its own tail, never the retry hint, and it
+        // stays inside one row in both languages.
+        for lang in [i18n::Lang::En, i18n::Lang::Ko] {
+            let l = lang.l();
+            let narrow = stale_banner(l, &"chain ".repeat(200), 100);
+            let hint = l.snapshot_stale.rsplit("{error}").next().unwrap();
+            assert!(narrow.ends_with(hint), "{narrow}");
+            assert!(
+                UnicodeWidthStr::width(narrow.as_str()) <= 100,
+                "banner overflowed its row: {narrow}"
+            );
+        }
 
         let _ = std::fs::remove_dir_all(ws.root);
     }

--- a/tests/tui_stale_snapshot_process.rs
+++ b/tests/tui_stale_snapshot_process.rs
@@ -1,0 +1,154 @@
+//! End-to-end PTY proof that a failed state reload is visible (issue #138).
+//!
+//! During the #138 incident the workspace wedged while the TUI kept serving the
+//! last snapshot it had loaded: `Snapshot::load` failures in the reload paths
+//! were dropped on the floor, so Home stayed stale-but-plausible and the only
+//! feedback was an unrelated-sounding confirm error. Keeping the last good
+//! projection is the right call — a blank Home is worse — so what this pins is
+//! the other half: pressing the advertised refresh key on a wedged workspace
+//! has to put the failure on screen, and leave the rest of Home readable.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+mod common;
+
+use common::{drain, open_pty, recent, resize_pty, seen, wait_for_marker};
+
+/// A queue that names an intent and demands activation, with no intent contract
+/// beside it: the shape the post-tidy scaffold wedge left behind. The shared
+/// activation gate fails closed on it, so every `Snapshot::load` errors.
+const WEDGED_QUEUE: &str = "schema_version: 1\n\
+                            queue_id: queue-wedged\n\
+                            intent_id: int-wedged\n\
+                            activation_required: true\n\
+                            tasks: []\n";
+
+const ROWS: u16 = 24;
+
+fn test_root() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("yard-tui-stale-{}-{nonce}", std::process::id()))
+}
+
+#[test]
+fn a_wedged_workspace_shows_a_stale_banner_instead_of_a_silently_frozen_home() {
+    let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+    // Removed even if an assertion below unwinds past the clean exit (issue #64).
+    let workspace = common::WorkspaceGuard::create(test_root());
+    let root = workspace.path().to_path_buf();
+
+    let init = Command::new(&binary)
+        .arg("init")
+        .current_dir(&root)
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "yardlet init failed: {}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+    let config_path = root.join(".agents/yardlet.yaml");
+    let config = fs::read_to_string(&config_path)
+        .unwrap()
+        .replace("language: auto", "language: en");
+    fs::write(&config_path, config).unwrap();
+
+    let (mut master, slave) = open_pty(ROWS, 140);
+    let stdin = Stdio::from(slave.try_clone().unwrap());
+    let stdout = Stdio::from(slave.try_clone().unwrap());
+    let stderr = Stdio::from(slave);
+    let child = Command::new(&binary)
+        .current_dir(&root)
+        .env("TERM", "xterm-256color")
+        .env("YARDLET_PROCESS_FIXTURE", "1")
+        .stdin(stdin)
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .unwrap();
+    // Killed and reaped even if an assertion below unwinds past the clean quit
+    // (issue #64).
+    let mut child = common::ChildGuard::new(child);
+
+    let mut sink: Vec<u8> = Vec::new();
+
+    // The key list is the LAST footer fragment, so seeing it means a whole idle
+    // Home frame has been drawn from a workspace that loaded cleanly.
+    wait_for_marker(&mut master, &mut sink, "? keys", Duration::from_secs(20));
+    assert!(
+        !seen(&sink, "state reload failed"),
+        "a healthy workspace must not claim a stale screen;\n{}",
+        recent(&sink)
+    );
+
+    // Wedge the canonical state under the running TUI. Home is idle, so nothing
+    // reloads on its own — the banner can only come from the refresh key.
+    fs::write(root.join(".agents/work-queue.yaml"), WEDGED_QUEUE).unwrap();
+    assert!(!root.join(".agents/intent-contract.yaml").exists());
+
+    let before_refresh = sink.len();
+    master.write_all(b"g").unwrap();
+
+    // Force a full repaint at a width the app is not already at. Ratatui writes
+    // only CHANGED cells, so a row that shares a prefix with the row it replaced
+    // is emitted in pieces and is never a contiguous byte run; a genuine size
+    // change resets the buffer so the next frame re-emits every visible cell in
+    // reading order. Resizing back to 140 would coalesce into one SIGWINCH at an
+    // unchanged size and force no repaint at all.
+    resize_pty(&master, ROWS, 139);
+
+    wait_for_marker(
+        &mut master,
+        &mut sink,
+        "state reload failed",
+        Duration::from_secs(10),
+    );
+
+    // Match only what arrived AFTER the keypress: the cumulative sink holds
+    // every marker this session ever rendered (issue #92).
+    let after_refresh = &sink[before_refresh..];
+    assert!(
+        seen(after_refresh, "active intent is missing"),
+        "the banner must name the load failure;\n{}",
+        recent(&sink)
+    );
+    assert!(
+        seen(after_refresh, "press g to retry"),
+        "the banner must name the retry key;\n{}",
+        recent(&sink)
+    );
+    // The last good projection stays on screen underneath it. The banner is
+    // above the footer in reading order, so the repaint that carried the banner
+    // has not necessarily reached the footer yet — poll to a deadline instead of
+    // judging the one partial frame the marker arrived in.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        drain(&mut master, &mut sink);
+        if seen(&sink[before_refresh..], "? keys") {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the stale frame must still be a usable Home;\n{}",
+            recent(&sink)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // Back to the contract width now that the banner has been observed.
+    resize_pty(&master, ROWS, 140);
+
+    std::thread::sleep(Duration::from_millis(200));
+    let _ = master.write_all(b"q");
+    child.shutdown(Duration::from_secs(5), || drain(&mut master, &mut sink));
+    // `workspace` removes the root on drop, on this path and on a panicking one.
+}


### PR DESCRIPTION
Follow-up recorded on #138: while the workspace gate was failing, the TUI silently kept serving the last good snapshot — stale-but-plausible Home with no indication anything was wrong. Implemented by an Opus subagent to a fixed spec; independently reviewed and re-verified.

## What

- `App.snapshot_stale: Option<String>`; `reload`/`reload_full` funnel through one `apply_reload` that keeps the last good projection on failure but records the error, clearing it on the next success.
- Home-only red/bold banner directly under the header, added to the layout only while stale (healthy Home keeps its exact previous layout): EN "! state reload failed (<error>) - showing the last good state, press g to retry" / KO "! 상태 로드 실패 (<error>) - 마지막 정상 상태를 보여주는 중, g 키로 재시도". Error text width-truncated so the retry hint never falls off the row; marker phrase verified substring-unique for PTY matching.
- Pure decision fn `snapshot_freshness` flattens multi-line anyhow chains to the banner's single row.

## Evidence

TDD: compile RED (12 errors) → scaffold-only assertion RED (3 unit + PTY "marker not seen", with the dumped frame showing the defect itself — a healthy-looking Home on a wedged workspace) → GREEN. The PTY fixture reproduces a real `unconfirmed_or_inconsistent` wedge against the actual binary and only shows the banner via the `g` path. Agent gates: fmt/clippy/unit 727 + 31 integration targets all 0. My re-runs after each train merge: stale+freshness unit green, PTY target 1/1, clippy -D warnings 0. Codename scan: 0.