### PR TITLE
feat(workers): finish prompt transport with a file mode and gate workers.yaml schema_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@
 
 ### Added
 
+- **`prompt_transport: file` completes the generic packet-delivery matrix.** A
+  worker CLI that takes its prompt as a file, because it has no stdin mode or
+  because a full packet exceeds the platform's argv limit, declares
+  `prompt_transport: file` and exactly one `{prompt_file}` in `args` (and, for
+  native resume, in `session.resume_args`). Yardlet writes the complete packet
+  to `packet-prompt.txt` inside that run's own directory, mode `0600`, expands
+  `{prompt_file}` with its absolute path, and writes nothing to the worker's
+  stdin. The file is replaced in place for a retry or a resume, so a worker can
+  never read the previous attempt's packet, and the run directory's own
+  lifecycle removes it rather than a separate cleanup step that could fail.
+  Each transport now requires exactly its own placeholder (`stdin` neither,
+  `argument` one `{prompt}`, `file` one `{prompt_file}`), and a mixed template
+  is rejected before any probe or worker is spawned, because an unexpanded
+  placeholder would otherwise reach the worker's argv verbatim.
+
+- **`workers.yaml` `schema_version` is enforced instead of merely parsed.** The
+  field was read and then ignored, so a file written by a newer Yardlet was
+  silently interpreted under this build's rules, and the fields a newer schema
+  adds are exactly the ones that bound a worker's behavior. Any version other
+  than the supported `1` now fails closed with `this yardlet supports
+  workers.yaml schema_version 1, found N`. A file that never declared the field
+  is unaffected in kind: it has always been rejected by the parser itself,
+  because the field deliberately carries no serde default.
+
 - **Worker-declared native harness sources.** A worker profile can declare the
   harness it already loads by itself — `harness.native_rule_files` (e.g.
   `AGENTS.md`, `.cursorrules`) and `harness.native_skill_dirs` (e.g.

--- a/README.ko.md
+++ b/README.ko.md
@@ -347,6 +347,13 @@ Enter/Space). 비활성화된 워커는 라우팅과 계획에서 건너뜁니�
 
 ### 워커 추가하기
 
+`.agents/workers.yaml`은 `schema_version: 1`을 선언하며, 이 빌드는 그 버전만
+읽습니다. 다른 버전을 선언한 파일은 부분적으로 읽는 대신
+`this yardlet supports workers.yaml schema_version 1, found N`으로 거부됩니다.
+새 스키마가 추가하는 필드가 바로 워커의 동작을 제한하는 필드이므로, 최선을 다해
+읽어보는 쪽이 위험한 선택입니다. Yardlet을 업그레이드하거나 이 빌드가 지원하는
+버전으로 되돌리세요.
+
 Codex와 Claude Code는 내장 어댑터를 가집니다. 다른 모든 구독 기반 CLI는
 `.agents/workers.yaml`만으로 추가할 수 있습니다. 호출 템플릿을 주면 Yardlet이 동일한
 결과 파일 계약으로 그것을 구동합니다. 제네릭 워커는 활성 상태이고 실행 파일과 설정된
@@ -379,7 +386,7 @@ TUI는 모두 같은 판정을 사용합니다.
       args: ["auth", "status"]
       ready_patterns: ["logged in as"]
       unauthenticated_patterns: ["not logged in"]
-    prompt_transport: argument              # 기본값: stdin
+    prompt_transport: argument              # stdin(기본값) | argument | file
     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
     session:                                # 선택적 native resume 계약
       capture: {stream: stdout, prefix: "SESSION_REF="}
@@ -398,6 +405,28 @@ stdin으로 보내고, `version_args`를 생략하면 `--version`을 실행합�
 경계를 보존합니다. stdin 전달에는 `{prompt}`를 넣으면 안 됩니다. 그 밖의 호출
 플레이스홀더는 `{run_dir}`, `{model}`, `{effort}`, `{image}`입니다.
 
+프롬프트를 **파일**로 받는 CLI, 즉 stdin 모드가 없거나 전체 패킷이 플랫폼의 argv
+한도를 넘는 경우에는 `prompt_transport: file`을 설정하고 `args`에 `{prompt_file}`을
+정확히 한 번 넣으세요.
+
+```yaml
+    prompt_transport: file
+    args: ["run", "--out", "{run_dir}", "--prompt-file", "{prompt_file}"]
+    session:
+      capture: {stream: stdout, prefix: "SESSION_REF="}
+      resume_args: ["resume", "--session", "{session}", "--prompt-file", "{prompt_file}"]
+```
+
+Yardlet은 전체 패킷을 해당 run 디렉터리 안의 `packet-prompt.txt`에 `0600` 모드로
+쓰고 `{prompt_file}`을 그 절대 경로로 치환합니다. 워커의 stdin에는 아무것도 쓰지
+않습니다. 재시도나 native resume에서는 같은 자리에 새로 쓰므로 워커가 이전 attempt의
+패킷을 읽는 일이 없고, 정리는 run 디렉터리의 수명주기가 담당하므로 따로 실패할 수
+있는 cleanup 단계가 없습니다. 각 transport는 자기 플레이스홀더만 요구합니다. `stdin`은
+`{prompt}`와 `{prompt_file}` 둘 다 없어야 하고, `argument`는 `{prompt}`가 정확히 한 번,
+`file`은 `{prompt_file}`이 정확히 한 번 있어야 합니다. 섞어 쓰면 프로브나 워커를
+띄우기 전에 거부됩니다. 치환되지 않은 플레이스홀더가 그대로 워커의 argv에 도달하기
+때문입니다.
+
 제네릭 native resume은 하위 호환 opt-in입니다. `session`을 생략하면 기존
 `ExplicitPacket` 답변 continuation을 유지합니다. `session`이 있으면
 `capture.stream`은 `stdout` 또는 `stderr`여야 하고, `capture.prefix`는 비어 있지 않은
@@ -407,9 +436,10 @@ suffix가 opaque `worker_session_ref`가 됩니다. Yardlet은 전역 session �
 attempt의 참조를 추론하지 않습니다.
 
 resume template은 fresh generic invocation과 같은 `command`, access, model, effort, image,
-정화된 환경 계약을 사용합니다. `{prompt}`는 `prompt_transport`를 따릅니다. `stdin`이면
-`resume_args`에서 생략하고, `argument`이면 정확히 한 번 넣습니다. 각 template 항목은
-하나의 `Command` 인자가 되므로 `{session}`과 `{prompt}`의 argv 경계가 유지됩니다.
+정화된 환경 계약을 사용합니다. 패킷 플레이스홀더는 `prompt_transport`를 따릅니다.
+`stdin`이면 `resume_args`에서 둘 다 생략하고, `argument`이면 `{prompt}`를 정확히 한 번,
+`file`이면 `{prompt_file}`을 정확히 한 번 넣습니다. 각 template 항목은
+하나의 `Command` 인자가 되므로 `{session}`과 패킷의 argv 경계가 유지됩니다.
 session block이 없거나, fresh child가 비어 있지 않은 ref를 내지 않거나, answer routing이
 다른 worker를 선택하면 Yardlet은 native resume 대신 안전하게 `ExplicitPacket`을 사용합니다.
 

--- a/README.md
+++ b/README.md
@@ -367,6 +367,13 @@ planning.
 
 ### Adding a worker
 
+`.agents/workers.yaml` declares `schema_version: 1`, and this build reads that
+version only. A file that declares any other version is refused with
+`this yardlet supports workers.yaml schema_version 1, found N` instead of being
+read partially: the fields a newer schema adds are exactly the ones that would
+bound a worker's behavior, so a best-effort read is the unsafe option. Upgrade
+Yardlet, or set the version back to what this build supports.
+
 Codex and Claude Code have built-in adapters. Any other subscription-backed
 CLI can be added in `.agents/workers.yaml` alone: give it an invocation
 template and Yardlet drives it through the same result-file contract. Generic
@@ -400,7 +407,7 @@ access explicitly (`yardlet access full`).
       args: ["auth", "status"]
       ready_patterns: ["logged in as"]
       unauthenticated_patterns: ["not logged in"]
-    prompt_transport: argument              # default: stdin
+    prompt_transport: argument              # stdin (default) | argument | file
     args: ["run", "--out", "{run_dir}", "--prompt", "{prompt}"]
     session:                                # optional native resume contract
       capture: {stream: stdout, prefix: "SESSION_REF="}
@@ -421,6 +428,29 @@ boundaries without constructing a shell string. Stdin delivery must not include
 `{prompt}`. The other invocation placeholders are `{run_dir}`, `{model}`,
 `{effort}`, and `{image}`.
 
+For a CLI that takes its prompt as a **file**, because it has no stdin mode or
+because a full packet is larger than the platform's argv limit, set
+`prompt_transport: file` and put `{prompt_file}` exactly once in `args`:
+
+```yaml
+    prompt_transport: file
+    args: ["run", "--out", "{run_dir}", "--prompt-file", "{prompt_file}"]
+    session:
+      capture: {stream: stdout, prefix: "SESSION_REF="}
+      resume_args: ["resume", "--session", "{session}", "--prompt-file", "{prompt_file}"]
+```
+
+Yardlet writes the complete packet to `packet-prompt.txt` inside that run's own
+directory, mode `0600`, and expands `{prompt_file}` with its absolute path.
+Nothing is written to the worker's stdin. The file is replaced in place for a
+retry or a native resume, so a worker never reads the previous attempt's packet,
+and the run directory's own lifecycle removes it, so there is no separate
+cleanup step to fail. Each transport requires exactly its own placeholder:
+`stdin` must contain neither `{prompt}` nor `{prompt_file}`, `argument` needs
+exactly one `{prompt}`, and `file` needs exactly one `{prompt_file}`. Mixing
+them is rejected before any worker or probe is spawned, because an unexpanded
+placeholder would otherwise reach the worker's argv verbatim.
+
 Generic native resume is backward-compatible and opt-in. Omit `session` to keep
 the existing `ExplicitPacket` answer continuation. When `session` is present,
 `capture.stream` must be `stdout` or `stderr`, `capture.prefix` must be a
@@ -430,10 +460,11 @@ child's selected raw stream becomes the opaque `worker_session_ref`. Yardlet
 does not inspect global session files or infer a reference from another attempt.
 
 The resume template uses the same `command`, access, model, effort, image, and
-sanitized environment contract as the fresh generic invocation. `{prompt}`
-follows `prompt_transport`: omit it from `resume_args` for `stdin`, or include it
-exactly once for `argument`. Each template item becomes one `Command` argument,
-so `{session}` and `{prompt}` retain their argv boundaries. If the session block
+sanitized environment contract as the fresh generic invocation. The packet
+placeholder follows `prompt_transport`: omit both from `resume_args` for
+`stdin`, include exactly one `{prompt}` for `argument`, or exactly one
+`{prompt_file}` for `file`. Each template item becomes one `Command` argument,
+so `{session}` and the packet retain their argv boundaries. If the session block
 is absent, the fresh child emits no non-empty ref, or answer routing selects a
 different worker, Yardlet safely uses `ExplicitPacket` instead of native resume.
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -961,6 +961,10 @@ pub(crate) fn capture_serial_input_overlays(
 const PROVIDER_REFUSAL_CLASSIFICATION_SKIPS_FILE: &str =
     "provider-refusal-classification-skips.yaml";
 
+// NOTE: the file prompt transport's `packet-prompt.txt` is deliberately NOT
+// listed. It is written into the staging run directory the worker actually
+// reads, and importing it back is what leaves the exact packet the worker was
+// handed in the canonical run's evidence.
 const MAIN_OWNED_RUN_ARTIFACT_NAMES: [&str; 19] = [
     "run.yaml",
     "task-packet.md",

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1946,6 +1946,11 @@ impl WorkQueue {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkersFile {
+    /// Deliberately has NO serde default: a `workers.yaml` that never declared
+    /// a version is rejected by the parser (`missing field schema_version`)
+    /// before `validate` runs, so defaulting it here would start silently
+    /// reading an unversioned file as version 1. `validate` therefore only has
+    /// to judge versions that are actually present.
     pub schema_version: u32,
     #[serde(default)]
     pub workers: Vec<WorkerProfile>,
@@ -1956,8 +1961,19 @@ pub struct WorkersFile {
 pub const MAX_PROVIDER_RESPONSE_REFUSAL_PATTERNS: usize = 16;
 pub const MAX_PROVIDER_RESPONSE_REFUSAL_PATTERN_BYTES: usize = 256;
 
+/// The only `workers.yaml` schema this build understands. A newer file is a
+/// hard stop rather than a best-effort read: the fields this build ignores are
+/// exactly the ones a future version would use to bound a worker's behavior.
+pub const SUPPORTED_WORKERS_SCHEMA_VERSION: u32 = 1;
+
 impl WorkersFile {
     pub fn validate(&self) -> Result<(), String> {
+        if self.schema_version != SUPPORTED_WORKERS_SCHEMA_VERSION {
+            return Err(format!(
+                "this yardlet supports workers.yaml schema_version {SUPPORTED_WORKERS_SCHEMA_VERSION}, found {}",
+                self.schema_version
+            ));
+        }
         for worker in &self.workers {
             if !matches!(worker.id.as_str(), "codex" | "claude-code") {
                 worker.invocation.validate_generic(&worker.id)?;
@@ -2206,14 +2222,18 @@ pub struct Invocation {
     pub output_contract: String,
     /// Generic adapter template for workers without a built-in adapter
     /// (codex and claude-code have first-class ones; any other id uses these).
-    /// Placeholders: `{run_dir}`, `{model}`, `{effort}`, `{image}`, and, for
-    /// argument prompt transport, exactly one `{prompt}`. The binary must be
-    /// able to write result files in the workspace.
+    /// Placeholders: `{run_dir}`, `{model}`, `{effort}`, `{image}`, and, per
+    /// prompt transport, exactly one `{prompt}` (argument) or one
+    /// `{prompt_file}` (file). The binary must be able to write result files in
+    /// the workspace.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub args: Vec<String>,
     /// How a generic adapter receives the compiled task packet: `stdin`
-    /// (legacy/default) or `argument` (`arg` is accepted as an alias). Argument
-    /// transport expands exactly one `{prompt}` in `args` without a shell.
+    /// (legacy/default), `argument` (`arg` is accepted as an alias), or `file`.
+    /// Argument transport expands exactly one `{prompt}` in `args` without a
+    /// shell; file transport writes the packet into the run directory and
+    /// expands exactly one `{prompt_file}` with its absolute path, for CLIs
+    /// that take a prompt file instead of stdin or an argv-sized prompt.
     #[serde(
         default = "default_prompt_transport",
         skip_serializing_if = "is_default_prompt_transport"
@@ -2338,6 +2358,11 @@ impl Invocation {
         self.prompt_transport.trim() == "stdin"
     }
 
+    /// Does this worker read the packet from a file Yardlet writes for it?
+    pub fn prompt_in_file(&self) -> bool {
+        self.prompt_transport.trim() == "file"
+    }
+
     /// Validate only the generic adapter's structural template. Runtime
     /// invocability (`supports_noninteractive`, output contract, binary,
     /// offline probe, billing policy) belongs to the shared guard so status,
@@ -2372,27 +2397,30 @@ impl Invocation {
             validate_invocation_args(worker_id, label, args, true, false, false)?;
         }
 
-        let prompt_count = self
-            .args
-            .iter()
-            .map(|arg| arg.matches("{prompt}").count())
-            .sum::<usize>();
+        let prompt_count = placeholder_count(&self.args, "{prompt}");
+        let prompt_file_count = placeholder_count(&self.args, "{prompt_file}");
         match self.prompt_transport.trim() {
-            "stdin" if prompt_count == 0 => {}
+            "stdin" if prompt_count == 0 && prompt_file_count == 0 => {}
             "stdin" => {
                 return Err(format!(
-                "worker '{worker_id}' uses prompt_transport stdin, so args must not contain {{prompt}}"
+                "worker '{worker_id}' uses prompt_transport stdin, so args must not contain {{prompt}} or {{prompt_file}}"
             ))
             }
-            "argument" | "arg" if prompt_count == 1 => {}
+            "argument" | "arg" if prompt_count == 1 && prompt_file_count == 0 => {}
             "argument" | "arg" => {
                 return Err(format!(
-                "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in args"
+                "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in args and no {{prompt_file}}"
+            ))
+            }
+            "file" if prompt_file_count == 1 && prompt_count == 0 => {}
+            "file" => {
+                return Err(format!(
+                "worker '{worker_id}' file prompt transport requires exactly one {{prompt_file}} placeholder in args and no {{prompt}}"
             ))
             }
             other => {
                 return Err(format!(
-                "worker '{worker_id}' has unsupported prompt_transport '{other}'; expected stdin or argument"
+                "worker '{worker_id}' has unsupported prompt_transport '{other}'; expected stdin, argument, or file"
             ))
             }
         }
@@ -2432,19 +2460,22 @@ impl Invocation {
                 "worker '{worker_id}' generic session resume_args require exactly one {{session}} placeholder"
             ));
         }
-        let resume_prompt_count = session
-            .resume_args
-            .iter()
-            .map(|arg| arg.matches("{prompt}").count())
-            .sum::<usize>();
+        let resume_prompt_count = placeholder_count(&session.resume_args, "{prompt}");
+        let resume_prompt_file_count = placeholder_count(&session.resume_args, "{prompt_file}");
         match self.prompt_transport.trim() {
-            "stdin" if resume_prompt_count == 0 => Ok(()),
+            "stdin" if resume_prompt_count == 0 && resume_prompt_file_count == 0 => Ok(()),
             "stdin" => Err(format!(
-                "worker '{worker_id}' uses prompt_transport stdin, so session.resume_args must not contain {{prompt}}"
+                "worker '{worker_id}' uses prompt_transport stdin, so session.resume_args must not contain {{prompt}} or {{prompt_file}}"
             )),
-            "argument" | "arg" if resume_prompt_count == 1 => Ok(()),
+            "argument" | "arg" if resume_prompt_count == 1 && resume_prompt_file_count == 0 => {
+                Ok(())
+            }
             "argument" | "arg" => Err(format!(
-                "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in session.resume_args"
+                "worker '{worker_id}' argument prompt transport requires exactly one {{prompt}} placeholder in session.resume_args and no {{prompt_file}}"
+            )),
+            "file" if resume_prompt_file_count == 1 && resume_prompt_count == 0 => Ok(()),
+            "file" => Err(format!(
+                "worker '{worker_id}' file prompt transport requires exactly one {{prompt_file}} placeholder in session.resume_args and no {{prompt}}"
             )),
             _ => unreachable!("prompt transport was validated above"),
         }
@@ -2505,6 +2536,13 @@ impl Invocation {
     }
 }
 
+/// How many times `placeholder` appears across an argv template.
+fn placeholder_count(args: &[String], placeholder: &str) -> usize {
+    args.iter()
+        .map(|arg| arg.matches(placeholder).count())
+        .sum()
+}
+
 fn validate_invocation_args(
     worker_id: &str,
     label: &str,
@@ -2521,6 +2559,10 @@ fn validate_invocation_args(
             }
         }
         if allow_prompt {
+            // Both packet placeholders are structurally legal wherever the
+            // packet may be delivered; which ONE is required is decided per
+            // transport in `validate_generic`.
+            remainder = remainder.replace("{prompt_file}", "");
             remainder = remainder.replace("{prompt}", "");
         }
         if allow_session {
@@ -4139,6 +4181,105 @@ delivery: auto
                 .expect_err("ambiguous generic prompt transport must fail validation");
             assert!(error.contains(expected), "{error:?} does not contain {expected:?}");
         }
+    }
+
+    #[test]
+    fn generic_file_prompt_transport_requires_exactly_one_prompt_file_placeholder() {
+        let valid: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      supports_noninteractive: true\n      output_contract: files\n      prompt_transport: file\n      args: [run, '--packet', '{prompt_file}']\n",
+        )
+        .unwrap();
+        valid.validate().unwrap();
+        assert!(!valid.workers[0].invocation.prompt_on_stdin());
+        assert!(valid.workers[0].invocation.prompt_in_file());
+
+        let valid_resume: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: file\n      args: [run, '{prompt_file}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: [resume, '{session}', '{prompt_file}']\n",
+        )
+        .unwrap();
+        valid_resume.validate().unwrap();
+
+        for (yaml, expected) in [
+            // File transport without the placeholder has nowhere to deliver.
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: file\n      args: [run]\n",
+                "exactly one {prompt_file}",
+            ),
+            // Twice would hand the worker two contradictory packet paths.
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: file\n      args: [run, '{prompt_file}', '{prompt_file}']\n",
+                "exactly one {prompt_file}",
+            ),
+            // Both placeholders would deliver the same packet twice.
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: file\n      args: [run, '{prompt_file}', '{prompt}']\n",
+                "exactly one {prompt_file}",
+            ),
+            // The other transports never expand {prompt_file}, so a literal
+            // placeholder would reach the worker's argv verbatim.
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      args: [run, '{prompt_file}']\n",
+                "stdin",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: argument\n      args: [run, '{prompt}', '{prompt_file}']\n",
+                "exactly one {prompt}",
+            ),
+            (
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: file\n      args: [run, '{prompt_file}']\n      session:\n        capture: {stream: stdout, prefix: 'SESSION_REF='}\n        resume_args: [resume, '{session}']\n",
+                "exactly one {prompt_file}",
+            ),
+        ] {
+            let workers: WorkersFile = crate::yaml::from_str(yaml).unwrap();
+            let error = workers
+                .validate()
+                .expect_err("ambiguous file prompt transport must fail validation");
+            assert!(
+                error.contains(expected),
+                "{error:?} does not contain {expected:?}"
+            );
+        }
+
+        let unsupported: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: fixture\n      prompt_transport: shell\n      args: [run]\n",
+        )
+        .unwrap();
+        let error = unsupported.validate().unwrap_err();
+        assert!(error.contains("stdin, argument, or file"), "{error}");
+    }
+
+    #[test]
+    fn workers_schema_version_gate_fails_closed_on_unsupported_versions() {
+        let supported: WorkersFile = crate::yaml::from_str(
+            "schema_version: 1\nworkers:\n  - id: fixture\n    invocation: {command: fixture}\n",
+        )
+        .unwrap();
+        assert_eq!(supported.schema_version, SUPPORTED_WORKERS_SCHEMA_VERSION);
+        supported.validate().unwrap();
+
+        for version in [0_u32, 2, 7] {
+            let workers: WorkersFile = crate::yaml::from_str(&format!(
+                "schema_version: {version}\nworkers:\n  - id: fixture\n    invocation: {{command: fixture}}\n"
+            ))
+            .unwrap();
+            let error = workers
+                .validate()
+                .expect_err("an unsupported workers.yaml schema_version must fail closed");
+            assert_eq!(
+                error,
+                format!("this yardlet supports workers.yaml schema_version 1, found {version}")
+            );
+        }
+
+        // The field has no serde default, so a workers.yaml that never carried
+        // it is rejected by the parser before the gate is ever reached. The gate
+        // therefore only has to judge values that are actually present.
+        let missing = crate::yaml::from_str::<WorkersFile>("workers: []\n")
+            .expect_err("workers.yaml without schema_version does not parse");
+        assert!(
+            missing.to_string().contains("schema_version"),
+            "{missing:?}"
+        );
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -6458,7 +6458,7 @@ fn write_bytes_atomic(path: &Path, contents: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn write_private_str_atomic(path: &Path, contents: &str) -> Result<()> {
+pub(crate) fn write_private_str_atomic(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
     }

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -625,10 +625,49 @@ pub fn build_command(
     cmd
 }
 
+/// The file a `prompt_transport: file` worker reads its packet from.
+///
+/// Fixed by convention and written INTO the run directory Yardlet already owns,
+/// so the run's own lifecycle (retention/gc) is what removes it and no separate
+/// cleanup path can leak a packet after the run.
+pub const PROMPT_FILE_NAME: &str = "packet-prompt.txt";
+
+/// Where the file prompt transport materializes the packet for a run.
+pub fn prompt_file_path(run_dir: &Path) -> PathBuf {
+    run_dir.join(PROMPT_FILE_NAME)
+}
+
+/// Materialize the packet for a `prompt_transport: file` worker and return the
+/// absolute path to hand it. `Ok(None)` for every other transport.
+///
+/// Written 0600 and replaced in place: a retry, a hot chain, or a native resume
+/// inside the same run directory must never leave the worker reading the
+/// previous attempt's packet.
+fn materialize_prompt_file(
+    inv: &Invocation,
+    packet: &str,
+    run_dir: &Path,
+    cwd: &Path,
+) -> Result<Option<String>> {
+    if !inv.prompt_in_file() {
+        return Ok(None);
+    }
+    let path = prompt_file_path(run_dir);
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    };
+    crate::state::write_private_str_atomic(&absolute, packet)
+        .with_context(|| format!("writing worker packet file {}", absolute.display()))?;
+    Ok(Some(absolute.display().to_string()))
+}
+
 /// Build the command for a worker WITHOUT a built-in adapter, from the
 /// invocation template in its workers.yaml profile. This is what makes a
-/// third worker a pure-config addition: packet on stdin or in one argument,
-/// args from the template, placeholders expanded without a shell.
+/// third worker a pure-config addition: packet on stdin, in one argument, or in
+/// a run-directory file; args from the template, placeholders expanded without
+/// a shell.
 #[allow(clippy::too_many_arguments)]
 pub fn build_generic_command(
     inv: &Invocation,
@@ -643,11 +682,17 @@ pub fn build_generic_command(
 ) -> Result<Command> {
     inv.validate_generic("generic worker")
         .map_err(anyhow::Error::msg)?;
+    let prompt_file = materialize_prompt_file(inv, packet, run_dir, cwd)?;
+    let prompt_file = prompt_file.as_deref().unwrap_or_default();
+    // `{prompt_file}` is expanded BEFORE `{prompt}` for the same reason
+    // `{prompt}` comes last overall: once packet text is in the string, nothing
+    // may rescan it for placeholders.
     let expand = |arg: &str, image: &str| -> String {
         arg.replace("{run_dir}", &run_dir.display().to_string())
             .replace("{model}", model)
             .replace("{effort}", effort)
             .replace("{image}", image)
+            .replace("{prompt_file}", prompt_file)
             .replace("{prompt}", packet)
     };
     let mut cmd = Command::new(bin);
@@ -708,12 +753,15 @@ fn build_generic_resume_command(
         .session
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("generic worker has no native session contract"))?;
+    let prompt_file = materialize_prompt_file(inv, packet, run_dir, cwd)?;
+    let prompt_file = prompt_file.as_deref().unwrap_or_default();
     let expand = |arg: &str, image: &str| -> String {
         arg.replace("{run_dir}", &run_dir.display().to_string())
             .replace("{model}", model)
             .replace("{effort}", effort)
             .replace("{image}", image)
             .replace("{session}", session_ref)
+            .replace("{prompt_file}", prompt_file)
             .replace("{prompt}", packet)
     };
     let mut cmd = Command::new(bin);
@@ -2264,6 +2312,110 @@ image_args: ["-i", "{image}"]
             &build_generic_command(&inv, bin, "packet", run, cwd, true, "auto", "", &[]).unwrap(),
         );
         assert_eq!(full, vec!["run", "--json", "--out", "/tmp/r", "--yolo"]);
+    }
+
+    #[test]
+    fn generic_file_transport_materializes_the_packet_and_passes_its_absolute_path() {
+        let inv: Invocation = crate::yaml::from_str(
+            r#"
+command: mytool
+supports_noninteractive: true
+output_contract: files
+prompt_transport: file
+args: ["run", "--packet", "{prompt_file}", "--out", "{run_dir}"]
+sandbox_args: ["--sandbox"]
+session:
+  capture: {stream: stdout, prefix: "SESSION_REF="}
+  resume_args: ["resume", "--session", "{session}", "--packet", "{prompt_file}"]
+"#,
+        )
+        .unwrap();
+        let root = std::env::temp_dir().join(format!(
+            "yard-file-transport-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let run = root.join("run-1");
+        std::fs::create_dir_all(&run).unwrap();
+
+        let fresh = args_of(
+            &build_generic_command(
+                &inv,
+                Path::new("mytool"),
+                "fresh packet body",
+                &run,
+                &root,
+                false,
+                "auto",
+                "",
+                &[],
+            )
+            .unwrap(),
+        );
+        let expected = prompt_file_path(&run).display().to_string();
+        assert_eq!(
+            fresh,
+            vec![
+                "run",
+                "--packet",
+                &expected,
+                "--out",
+                &run.display().to_string(),
+                "--sandbox",
+            ]
+        );
+        assert!(Path::new(&expected).is_absolute());
+        assert_eq!(
+            std::fs::read_to_string(&expected).unwrap(),
+            "fresh packet body"
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&expected).unwrap().permissions().mode() & 0o777,
+                0o600,
+                "the packet file must not be world readable"
+            );
+        }
+
+        // A resume in the same run directory replaces the packet in place, so
+        // the worker never reads a stale continuation.
+        let resumed = args_of(
+            &build_generic_resume_command(
+                &inv,
+                Path::new("mytool"),
+                "resume packet body",
+                "session-ref",
+                &run,
+                &root,
+                false,
+                "auto",
+                "",
+                &[],
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            resumed,
+            vec![
+                "resume",
+                "--session",
+                "session-ref",
+                "--packet",
+                &expected,
+                "--sandbox",
+            ]
+        );
+        assert_eq!(
+            std::fs::read_to_string(&expected).unwrap(),
+            "resume packet body"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/tests/fixtures/generic_transport_matrix/worker.sh
+++ b/tests/fixtures/generic_transport_matrix/worker.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# Fake generic worker for the prompt-transport fixture matrix.
+#
+# Every mode writes its evidence INTO the run directory it was handed, because
+# the worker environment is sanitized: nothing the test exports would survive to
+# this process. Modes:
+#
+#   probe                 offline readiness probe (version_args)
+#   stdin | file          fresh attempt that asks a question and emits a session
+#                         ref; the packet arrives on stdin or in a file
+#   stdin-resume |
+#   file-resume           native resume that completes the task
+#   ignored-stdin         declares stdin transport but closes stdin unread
+#   broken-result         exits 0 after writing an unparseable result.json
+set -eu
+
+mode="${1:-}"
+
+if [ "$mode" = probe ]; then
+  printf 'transport-matrix-worker 1.0\n'
+  exit 0
+fi
+
+run_dir="${2:-}"
+run_id="$(basename "$run_dir")"
+session_ref=''
+
+case "$mode" in
+  stdin)
+    cat > "$run_dir/seen-packet-body"
+    ;;
+  file)
+    packet_file="${3:-}"
+    printf '%s' "$packet_file" > "$run_dir/seen-packet-path"
+    cp "$packet_file" "$run_dir/seen-packet-body"
+    cat > "$run_dir/seen-stdin"
+    ;;
+  stdin-resume)
+    session_ref="${3:-}"
+    cat > "$run_dir/seen-resume-packet-body"
+    ;;
+  file-resume)
+    packet_file="${3:-}"
+    session_ref="${4:-}"
+    printf '%s' "$packet_file" > "$run_dir/seen-resume-packet-path"
+    cp "$packet_file" "$run_dir/seen-resume-packet-body"
+    cat > "$run_dir/seen-resume-stdin"
+    ;;
+  ignored-stdin)
+    # Close the inherited read end without draining it, so the orchestrator's
+    # best-effort packet write fails with EPIPE instead of being consumed.
+    exec 0<&-
+    ;;
+  broken-result)
+    ;;
+  *)
+    printf 'unknown fixture mode: %s\n' "$mode" >&2
+    exit 64
+    ;;
+esac
+
+case "$mode" in
+  stdin | file)
+    printf 'SESSION_REF=transport-matrix session\n'
+    cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "needs_user",
+  "intent_adherence": {"drift_detected": false, "notes": ""},
+  "changes": {"files_modified": [], "files_created": [], "files_deleted": []},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "question_for_user": "Continue in the same transport-matrix session?",
+  "compact_summary": "transport matrix fixture needs an answer",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+    printf '# Transport matrix question\n' > "$run_dir/handoff.md"
+    ;;
+  stdin-resume | file-resume)
+    if [ "$session_ref" != 'transport-matrix session' ]; then
+      printf 'wrong session ref: %s\n' "$session_ref" >&2
+      exit 64
+    fi
+    cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {"drift_detected": false, "notes": ""},
+  "changes": {"files_modified": [], "files_created": [], "files_deleted": []},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "question_for_user": null,
+  "compact_summary": "transport matrix native resume complete",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+    printf '# Transport matrix resumed\n' > "$run_dir/handoff.md"
+    ;;
+  ignored-stdin)
+    cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {"drift_detected": false, "notes": ""},
+  "changes": {"files_modified": [], "files_created": [], "files_deleted": []},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "question_for_user": null,
+  "compact_summary": "transport matrix ignored stdin and still delivered files",
+  "verdict": [],
+  "harness_suggestions": [],
+  "follow_up_tasks": []
+}
+EOF
+    printf '# Transport matrix ignored stdin\n' > "$run_dir/handoff.md"
+    ;;
+  broken-result)
+    printf 'transport matrix broken-result stdout\n'
+    printf 'transport matrix broken-result stderr\n' >&2
+    # Exit 0 with a truncated object: a worker claiming success it cannot prove.
+    printf '{"schema_version": 1, "run_id": "%s", "status": "done"' "$run_id" \
+      > "$run_dir/result.json"
+    printf '# Transport matrix broken result\n' > "$run_dir/handoff.md"
+    ;;
+esac
+
+exit 0

--- a/tests/generic_transport_matrix_process.rs
+++ b/tests/generic_transport_matrix_process.rs
@@ -1,0 +1,458 @@
+//! Prompt-transport fixture matrix for the generic worker adapter.
+//!
+//! Closes the three gaps the existing generic contract fixtures leave open:
+//!   (a) `prompt_transport: file` must carry a real task through the same
+//!       task -> result -> continuation path a stdin worker takes;
+//!   (b) a stdin worker that never reads the packet must still complete from
+//!       its result files, because packet delivery is best-effort by contract;
+//!   (c) a worker that exits 0 with an unparseable `result.json` must be
+//!       recorded as a typed failure whose raw attempt streams survive.
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SESSION_CONTRACT: &str =
+    "      session:\n        capture:\n          stream: stdout\n          prefix: 'SESSION_REF='\n";
+
+struct Fixture {
+    root: PathBuf,
+    binary: PathBuf,
+    worker: PathBuf,
+}
+
+impl Fixture {
+    fn new(label: &str, acceptance: &str) -> Self {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "yardlet-transport-matrix-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        must_succeed(&root, Path::new("git"), &["init", "-q"]);
+        must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["config", "user.email", "fixture@example.invalid"],
+        );
+        fs::write(root.join("README.md"), "fixture\n").unwrap();
+        must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+        must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+        must_succeed(&root, &binary, &["init"]);
+
+        let worker = root.join("fixture-worker.sh");
+        fs::copy(
+            manifest.join("tests/fixtures/generic_transport_matrix/worker.sh"),
+            &worker,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&worker).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&worker, permissions).unwrap();
+
+        fs::write(
+            root.join(".agents/intent-contract.yaml"),
+            "schema_version: 1\nid: intent-transport-matrix\nsummary: transport matrix fixture\nstatus: accepted\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join(".agents/work-queue.yaml"),
+            format!(
+                "schema_version: 1\nqueue_id: queue-transport-matrix\nintent_id: intent-transport-matrix\ntasks:\n  - id: YARD-001\n    title: transport matrix fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    fallback_enabled: false\n    acceptance: ['{acceptance}']\n"
+            ),
+        )
+        .unwrap();
+
+        Self {
+            root,
+            binary,
+            worker,
+        }
+    }
+
+    fn configure(&self, invocation: &str) {
+        fs::write(
+            self.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n{}    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n  allow_preferred_worker_failover: false\n",
+                self.worker.display(),
+                invocation
+            ),
+        )
+        .unwrap();
+    }
+
+    fn yardlet(&self, args: &[&str]) -> Output {
+        command(&self.root, &self.binary, args)
+    }
+
+    fn latest_run(&self) -> PathBuf {
+        let mut runs = fs::read_dir(self.root.join(".agents/runs"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.join("task-packet.md").is_file())
+            .collect::<Vec<_>>();
+        runs.sort();
+        runs.pop().expect("fixture run exists")
+    }
+
+    fn task_state(&self) -> String {
+        yaml(&self.root.join(".agents/work-queue.yaml"))["tasks"][0]["state"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    }
+
+    fn channel_records(&self, segment: &str) -> Vec<serde_yaml_ng::Value> {
+        let mut records = files_below(&self.root.join(".agents/task-channels"), ".yaml")
+            .into_iter()
+            .filter(|path| path.to_string_lossy().contains(segment))
+            .map(|path| yaml(&path))
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| {
+            record
+                .get("attempt_id")
+                .and_then(serde_yaml_ng::Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        });
+        records
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn command(root: &Path, program: &Path, args: &[&str]) -> Output {
+    Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()))
+}
+
+fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+    let output = command(root, program, args);
+    assert!(
+        output.status.success(),
+        "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        program.display(),
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn yaml(path: &Path) -> serde_yaml_ng::Value {
+    serde_yaml_ng::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn files_below(root: &Path, suffix: &str) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                files.extend(files_below(&path, suffix));
+            } else if path.to_string_lossy().ends_with(suffix) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+/// The transport-independent shape of a full question -> answer cycle. Two
+/// transports that produce the same value delivered the same work.
+#[derive(Debug, PartialEq, Eq)]
+struct Cycle {
+    first_state: String,
+    final_state: String,
+    continuations: Vec<String>,
+    session_refs: Vec<String>,
+    summaries: Vec<String>,
+}
+
+fn drive_question_and_answer(fixture: &Fixture, action_id: &str) -> (PathBuf, PathBuf, Cycle) {
+    must_succeed(
+        &fixture.root,
+        &fixture.binary,
+        &["run", "--task", "YARD-001", "--execute"],
+    );
+    let first_run = fixture.latest_run();
+    let first_state = fixture.task_state();
+
+    must_succeed(
+        &fixture.root,
+        &fixture.binary,
+        &[
+            "answer",
+            "transport matrix answer",
+            "--task",
+            "YARD-001",
+            "--action-id",
+            action_id,
+        ],
+    );
+    let resume_run = fixture.latest_run();
+    assert_ne!(
+        first_run, resume_run,
+        "the answer must run in its own run directory"
+    );
+
+    let attempts = fixture.channel_records("/attempts/");
+    // Attempt ids are not chronologically ordered across run directories, so
+    // compare the multiset of what each transport produced, not its order.
+    let mut continuations = attempts
+        .iter()
+        .map(|attempt| attempt["continuation"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    continuations.sort();
+    let mut session_refs = attempts
+        .iter()
+        .filter_map(|attempt| attempt.get("worker_session_ref"))
+        .filter_map(|value| value.as_str().map(str::to_string))
+        .collect::<Vec<_>>();
+    session_refs.sort();
+    let cycle = Cycle {
+        first_state,
+        final_state: fixture.task_state(),
+        continuations,
+        session_refs,
+        summaries: [&first_run, &resume_run]
+            .into_iter()
+            .map(|run| {
+                let result: serde_json::Value =
+                    serde_json::from_str(&fs::read_to_string(run.join("result.json")).unwrap())
+                        .unwrap();
+                result["compact_summary"].as_str().unwrap().to_string()
+            })
+            .collect(),
+    };
+    (first_run, resume_run, cycle)
+}
+
+// (a) Dogfood proof: a file-transport profile must be interchangeable with a
+// stdin one for a real task, not merely valid on paper.
+#[test]
+fn file_prompt_transport_matches_stdin_transport_across_task_result_and_continuation() {
+    let on_stdin = Fixture::new("stdin", "packet delivered exactly once");
+    on_stdin.configure(&format!(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe]\n      sandbox_args: ['--fixture-sandbox']\n      args: [stdin, '{{run_dir}}']\n{SESSION_CONTRACT}        resume_args: [stdin-resume, '{{run_dir}}', '{{session}}']\n"
+    ));
+    let (stdin_first, stdin_resume, stdin_cycle) =
+        drive_question_and_answer(&on_stdin, "act-transport-matrix-stdin");
+
+    let in_file = Fixture::new("file", "packet delivered exactly once");
+    in_file.configure(&format!(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe]\n      sandbox_args: ['--fixture-sandbox']\n      prompt_transport: file\n      args: [file, '{{run_dir}}', '{{prompt_file}}']\n{SESSION_CONTRACT}        resume_args: [file-resume, '{{run_dir}}', '{{prompt_file}}', '{{session}}']\n"
+    ));
+    let (file_first, file_resume, file_cycle) =
+        drive_question_and_answer(&in_file, "act-transport-matrix-file");
+
+    assert_eq!(
+        file_cycle, stdin_cycle,
+        "file transport must deliver the same task, result, and continuation as stdin"
+    );
+    assert_eq!(file_cycle.first_state, "needs_user");
+    assert_eq!(file_cycle.final_state, "done");
+    assert_eq!(file_cycle.continuations, ["fresh", "native_resume"]);
+    assert_eq!(
+        stdin_first.join("seen-packet-body").is_file(),
+        file_first.join("seen-packet-body").is_file()
+    );
+
+    // The packet lives in the run directory Yardlet already owns, so nothing
+    // else has to clean it up, and the worker read exactly that file.
+    for (run, seen_path, seen_body, seen_stdin) in [
+        (
+            &file_first,
+            "seen-packet-path",
+            "seen-packet-body",
+            "seen-stdin",
+        ),
+        (
+            &file_resume,
+            "seen-resume-packet-path",
+            "seen-resume-packet-body",
+            "seen-resume-stdin",
+        ),
+    ] {
+        let packet = fs::read_to_string(run.join("task-packet.md")).unwrap();
+        let prompt_file = run.join("packet-prompt.txt");
+        assert!(
+            prompt_file.is_file(),
+            "the packet file must stay inside {}",
+            run.display()
+        );
+        assert_eq!(fs::read_to_string(&prompt_file).unwrap(), packet);
+        assert_eq!(
+            fs::metadata(&prompt_file).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "the packet file must not be readable by other users"
+        );
+        // The worker is handed the packet inside the run directory it was given
+        // (an execute run stages that directory inside its serial worktree, so
+        // the path is that run's staged copy, never a temp file elsewhere).
+        let received = fs::read_to_string(run.join(seen_path)).unwrap();
+        let received = Path::new(&received);
+        assert!(
+            received.is_absolute(),
+            "the worker must be handed an absolute packet path, got {}",
+            received.display()
+        );
+        assert_eq!(received.file_name().unwrap(), "packet-prompt.txt");
+        assert_eq!(
+            received.parent().unwrap().file_name().unwrap(),
+            run.file_name().unwrap(),
+            "the packet must live in this run's directory"
+        );
+        assert_eq!(fs::read_to_string(run.join(seen_body)).unwrap(), packet);
+        assert!(
+            fs::read(run.join(seen_stdin)).unwrap().is_empty(),
+            "file transport must not also write the packet to stdin"
+        );
+    }
+
+    // The continuation packet is a different document, so the file transport
+    // must have replaced it rather than left the fresh packet behind.
+    assert_ne!(
+        fs::read_to_string(file_first.join("packet-prompt.txt")).unwrap(),
+        fs::read_to_string(file_resume.join("packet-prompt.txt")).unwrap()
+    );
+    assert!(!stdin_first.join("packet-prompt.txt").exists());
+    assert!(!stdin_resume.join("packet-prompt.txt").exists());
+}
+
+// (b) The packet write is best-effort by contract (`let _ = write_all`). A
+// worker that closes stdin unread makes that write fail with EPIPE, and the run
+// must still converge on the worker's result files.
+#[test]
+fn stdin_transport_tolerates_a_worker_that_closes_stdin_unread() {
+    // Large enough that the packet cannot be absorbed by any pipe buffer, so
+    // the orchestrator provably hits the closed read end instead of silently
+    // fitting the whole packet into the kernel.
+    let bulk = "packet body that cannot fit in a pipe buffer ".repeat(8_000);
+    let fixture = Fixture::new("ignored-stdin", &bulk);
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe]\n      sandbox_args: ['--fixture-sandbox']\n      args: [ignored-stdin, '{run_dir}']\n",
+    );
+
+    let output = fixture.yardlet(&["run", "--task", "YARD-001", "--execute"]);
+    assert!(
+        output.status.success(),
+        "an unread stdin must not fail the run\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let run = fixture.latest_run();
+    let packet = fs::read_to_string(run.join("task-packet.md")).unwrap();
+    assert!(
+        packet.len() > 256 * 1024,
+        "packet is only {} bytes, so a buffered write could have succeeded",
+        packet.len()
+    );
+    assert_eq!(fixture.task_state(), "done");
+    assert!(run.join("result.json").is_file());
+    assert!(!run.join("seen-packet-body").exists());
+
+    let completed = fixture
+        .channel_records("/events/")
+        .into_iter()
+        .find(|event| event["type"].as_str() == Some("worker.completed"))
+        .expect("the attempt completed");
+    assert_eq!(completed["payload"]["result"].as_str(), Some("succeeded"));
+    assert_eq!(completed["payload"]["exit_code"].as_i64(), Some(0));
+}
+
+// (c) Exit 0 plus an unparseable result.json is a failure, not a success. The
+// typed record must say so and the raw attempt streams must survive as the
+// evidence for it.
+#[test]
+fn unparseable_result_is_recorded_as_a_typed_failure_with_raw_streams_preserved() {
+    let fixture = Fixture::new("broken-result", "result parses against the schema");
+    fixture.configure(
+        "      supports_noninteractive: true\n      output_contract: files\n      version_args: [probe]\n      sandbox_args: ['--fixture-sandbox']\n      args: [broken-result, '{run_dir}']\n",
+    );
+
+    let _ = fixture.yardlet(&["run", "--task", "YARD-001", "--execute"]);
+    let run = fixture.latest_run();
+
+    assert_ne!(
+        fixture.task_state(),
+        "done",
+        "an unparseable result must never reach done"
+    );
+    assert!(
+        serde_json::from_str::<serde_json::Value>(
+            &fs::read_to_string(run.join("result.json")).unwrap()
+        )
+        .is_err(),
+        "the fixture must have written an unparseable result"
+    );
+
+    let evaluation: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(run.join("evaluation.json")).unwrap()).unwrap();
+    let schema_check = evaluation["checks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|check| check["name"] == "result_schema_valid")
+        .expect("the evaluator judges the result schema");
+    assert_eq!(schema_check["passed"], false);
+    assert_eq!(schema_check["fatal"], true);
+
+    let attempts = fixture.channel_records("/attempts/");
+    assert_eq!(attempts.len(), 1);
+    let attempt = &attempts[0];
+    let attempt_id = attempt["attempt_id"].as_str().unwrap();
+    let stdout_ref = attempt["raw_stdout_ref"].as_str().unwrap();
+    let stderr_ref = attempt["raw_stderr_ref"].as_str().unwrap();
+    assert_eq!(
+        fs::canonicalize(stdout_ref).unwrap(),
+        fs::canonicalize(run.join("attempts").join(attempt_id).join("stdout.log")).unwrap()
+    );
+    assert_eq!(
+        fs::read_to_string(stdout_ref).unwrap(),
+        "transport matrix broken-result stdout\n"
+    );
+    assert_eq!(
+        fs::read_to_string(stderr_ref).unwrap(),
+        "transport matrix broken-result stderr\n"
+    );
+
+    let completed = fixture
+        .channel_records("/events/")
+        .into_iter()
+        .find(|event| {
+            event["type"].as_str() == Some("worker.completed")
+                && event["attempt_id"].as_str() == Some(attempt_id)
+        })
+        .expect("the attempt completed");
+    let payload = &completed["payload"];
+    assert_eq!(
+        payload["result"].as_str(),
+        Some("failed"),
+        "a zero exit must not launder an unreadable result into success"
+    );
+    assert_eq!(payload["exit_code"].as_i64(), Some(0));
+    assert_eq!(payload["exit_ok"].as_bool(), Some(true));
+    assert_eq!(payload["raw_stdout_ref"].as_str(), Some(stdout_ref));
+    assert_eq!(payload["raw_stderr_ref"].as_str(), Some(stderr_ref));
+}


### PR DESCRIPTION
V010-006 transport-completion bundle. Implemented by an Opus subagent to a fixed spec; independently reviewed and re-verified (unit 4/4 new, process 3/3) before this PR.

## What

- `prompt_transport: file`: the packet is written inside the run dir (`packet-prompt.txt`, 0600, via a state.rs atomic private writer), `{prompt_file}` must appear exactly once and expands to that path; nothing goes to stdin. Cross-placeholder misuse is rejected both ways (`{prompt_file}` under stdin/argument, `{prompt}` under file) so no literal placeholder can reach argv. `{prompt_file}` expands before `{prompt}` so packet text is never rescanned.
- `WorkersFile.schema_version` is now gated against a supported-version constant (1) with an exact fail-closed message. No serde default on purpose: unversioned files were already parse-rejected, so nothing silently loosens.
- Fixture matrix closed in new `tests/generic_transport_matrix_process.rs`: (a) file-prompt fake worker passes the same task/result/continuation scenario as the stdin worker (roadmap dogfood proof) with packet bytes + 0600 asserted through the staged-run import; (b) ignored-stdin tolerance lock; (c) exit-0 + unparseable result.json stays a typed failure with raw streams preserved. The agent flagged honestly that (b)/(c) were green-before regression locks over already-held contracts, not new REDs.

## Evidence

Agent gates: fmt/clippy/all-features all exit 0 (34 targets, 770 unit, 0 failed). RED observed for the file-transport leg (unknown placeholder rejection) and unit compile REDs. My re-run: transport/schema units 4/4, process target 3/3, codename scan 0. Clean merge over the banner PR.