### PR TITLE
feat(workers): key stdout normalization on a declared output_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,30 @@
 
 ### Added
 
+- **Worker-declared stdout format, and a tolerant result fallback for the
+  workers that declare one.** Normalization used to branch on two hardcoded
+  worker ids, so every other CLI's output was read one-line-one-message no
+  matter what it actually emitted. A profile can now declare
+  `invocation.output_format`: `text` (the previous behavior, and still the
+  default when undeclared), `json` (one document per attempt), or `stream-json`
+  (one object per line). Normalization is selected by that FORMAT rather than by
+  worker id; the built-in Codex and Claude Code adapters keep their vendor
+  profiles as core-owned, byte-for-byte unchanged, and may only restate
+  `stream-json` — any other declaration on them is rejected instead of silently
+  ignored. Degradation is the rule: an unparseable `stream-json` line becomes a
+  text message and a `json` attempt with no complete document is all text, so a
+  malformed stream can never fail a run. A generic worker declaring `json` or
+  `stream-json` also gains the tolerant result fallback: with no `result.json`
+  on disk, Yardlet recovers the last complete JSON object in its captured stdout
+  that parses as the result schema and names this run and task. That identity
+  check is load-bearing — every packet carries a result schema EXAMPLE, so
+  without it a worker that echoed its own prompt would have manufactured a
+  finished run, template follow-up tasks and all. A recovery never masquerades
+  as a written file: the run record keeps a `result_recovered_from_stdout`
+  marker with the exact attempt, stream and byte range, and the run report says
+  so. Nothing recoverable means today's typed failure and raw-log preservation,
+  unchanged.
+
 - **Worker-declared native harness sources.** A worker profile can declare the
   harness it already loads by itself — `harness.native_rule_files` (e.g.
   `AGENTS.md`, `.cursorrules`) and `harness.native_skill_dirs` (e.g.

--- a/README.ko.md
+++ b/README.ko.md
@@ -370,6 +370,7 @@ TUI는 모두 같은 판정을 사용합니다.
     command: mytool
     supports_noninteractive: true
     output_contract: files
+    output_format: stream-json             # 선택: text | json | stream-json
     version_args: ["version", "--offline"] # 기본값: ["--version"]
     min_version: "1.2.0"                    # 선택: 최소 지원 버전
     identity_probe:                         # 선택: 잘못된 바이너리 검사
@@ -397,6 +398,31 @@ stdin으로 보내고, `version_args`를 생략하면 `--version`을 실행합�
 넣으세요. Yardlet은 셸 문자열을 만들지 않고 하나의 `Command` 인자로 치환하여 인자
 경계를 보존합니다. stdin 전달에는 `{prompt}`를 넣으면 안 됩니다. 그 밖의 호출
 플레이스홀더는 `{run_dir}`, `{model}`, `{effort}`, `{image}`입니다.
+
+`output_format`은 워커 stdout의 형태를 선언하고, `output_contract`는 결과가 어디서
+오는지를 계속 선언합니다. 선택 사항이며, 생략하면 지금 동작이 그대로 유지되어
+제네릭 워커 출력의 모든 줄이 하나의 공개 메시지가 됩니다.
+
+| `output_format` | Yardlet이 stdout을 읽는 방식 | 결과 fallback |
+|---|---|---|
+| (생략) / `text` | 비어 있지 않은 줄마다 공개 메시지 하나 | 없음 — 결과 파일만이 결과 |
+| `json` | attempt당 JSON 문서 하나, 나머지 줄은 text | 있음 |
+| `stream-json` | 줄마다 JSON 오브젝트 하나, 파싱 실패 줄은 text로 강등 | 있음 |
+
+강등이 원칙이고 hard failure는 없습니다. 파싱되지 않는 `stream-json` 줄은 text
+메시지가 되고, 완전한 문서가 없는 `json` attempt는 전부 text가 됩니다. `json` 또는
+`stream-json`을 선언하면 관용적 결과 fallback도 켜집니다. 워커가 `result.json`을
+쓰지 않았다면, Yardlet은 캡처된 stdout에서 결과 스키마로 파싱되고 **이 run과 task를
+가리키는** 마지막 완전한 JSON 오브젝트를 복원합니다. 이 신원 검사가, 자기 패킷을
+그대로 echo한 워커가 패킷 안의 결과 스키마 예시를 완료된 run으로 둔갑시키는 것을
+막습니다. 복원은 결코 "파일을 썼다"로 위장되지 않습니다. run 기록에 정확한 attempt,
+stream, 바이트 범위를 담은 `result_recovered_from_stdout` 마커가 남고 run 보고서도
+그 사실을 명시합니다. 복원할 결과가 없으면 기존의 typed 실패와 raw 로그가 그대로
+유지됩니다.
+
+내장 어댑터는 자신의 stream-json 프로파일을 소유하므로, `codex`와 `claude-code`
+프로필은 `stream-json`만 다시 선언할 수 있습니다. 다른 값은 조용히 무시되지 않고
+거절됩니다.
 
 제네릭 native resume은 하위 호환 opt-in입니다. `session`을 생략하면 기존
 `ExplicitPacket` 답변 continuation을 유지합니다. `session`이 있으면

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ access explicitly (`yardlet access full`).
     command: mytool
     supports_noninteractive: true
     output_contract: files
+    output_format: stream-json             # optional: text | json | stream-json
     version_args: ["version", "--offline"] # default: ["--version"]
     min_version: "1.2.0"                    # optional lowest supported version
     identity_probe:                         # optional wrong-binary check
@@ -420,6 +421,33 @@ Yardlet substitutes it as one `Command` argument, preserving argument
 boundaries without constructing a shell string. Stdin delivery must not include
 `{prompt}`. The other invocation placeholders are `{run_dir}`, `{model}`,
 `{effort}`, and `{image}`.
+
+`output_format` declares the SHAPE of the worker's stdout, while
+`output_contract` keeps declaring where its result comes from. It is optional;
+omitting it keeps today's behavior exactly, where every line of a generic
+worker's output becomes one public message.
+
+| `output_format` | Yardlet reads stdout as | Result fallback |
+|---|---|---|
+| (omitted) / `text` | one public message per non-empty line | none — the result file is the only result |
+| `json` | one JSON document per attempt; the rest of the stream stays text | yes |
+| `stream-json` | one JSON object per line; unparseable lines degrade to text | yes |
+
+Degradation is the rule, never a hard failure: a `stream-json` line that does
+not parse becomes a text message, and a `json` attempt with no complete
+document is all text. Declaring `json` or `stream-json` also enables the
+tolerant result fallback: if the worker wrote no `result.json`, Yardlet
+recovers the last complete JSON object in its captured stdout that parses as
+the result schema **and names this run and task**. The identity check is what
+keeps a worker that echoes its own packet from turning the packet's result
+schema example into a finished run. A recovery never passes as a written file:
+the run record carries a `result_recovered_from_stdout` marker with the exact
+attempt, stream and byte range, and the run report says so out loud. If no
+result can be recovered, the run keeps its usual typed failure and its raw logs.
+
+The built-in adapters own their stream-json profiles, so a `codex` or
+`claude-code` profile may only restate `stream-json`; any other value is
+rejected rather than silently ignored.
 
 Generic native resume is backward-compatible and opt-in. Omit `session` to keep
 the existing `ExplicitPacket` answer continuation. When `session` is present,

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -417,7 +417,13 @@ pub fn invocation_contract(profile: &WorkerProfile) -> Result<(), String> {
         ));
     }
     profile.invocation.validate_probes(&profile.id)?;
+    profile.invocation.validate_output_format(&profile.id)?;
     let output = profile.invocation.output_contract.trim();
+    // `output_contract` answers "where does the RESULT come from"; the newer
+    // `output_format` answers "what shape is stdout". They must not read as
+    // rival knobs: `json_or_files` stays the built-in adapters' core-owned
+    // result contract, and a generic worker keeps the `files` contract plus the
+    // tolerant stdout fallback its `output_format` declaration authorizes.
     match profile.id.as_str() {
         "codex" | "claude-code" if matches!(output, "files" | "json_or_files") => Ok(()),
         "codex" | "claude-code" => Err(format!(
@@ -425,7 +431,8 @@ pub fn invocation_contract(profile: &WorkerProfile) -> Result<(), String> {
             profile.id, output
         )),
         _ if output != "files" => Err(format!(
-            "worker '{}' generic invocation has unsupported output_contract '{}'; expected files",
+            "worker '{}' generic invocation has unsupported output_contract '{}'; expected files \
+             (declare structured stdout with output_format, not output_contract)",
             profile.id, output
         )),
         _ => profile.invocation.validate_generic(&profile.id),
@@ -1339,6 +1346,70 @@ invocation:
         assert_eq!(projection[0].capabilities, vec!["Shell Tool"]);
     }
 
+    // V010-006: `output_format` declares the STDOUT shape while
+    // `output_contract` keeps declaring where the result comes from. An
+    // undeclared format must leave every existing verdict untouched, an
+    // unsupported value must be rejected instead of guessed at, and a built-in
+    // adapter must not be able to claim a shape its core-owned normalizer will
+    // not honor.
+    #[test]
+    fn declared_output_format_is_gated_without_moving_existing_verdicts() {
+        for (label, yaml, expected) in [
+            (
+                "generic-unsupported",
+                "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, output_format: ndjson, sandbox_args: ['--restricted'] }\n",
+                Some("unsupported output_format 'ndjson'"),
+            ),
+            (
+                "generic-stream-json",
+                "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, output_format: stream-json, sandbox_args: ['--restricted'] }\n",
+                None,
+            ),
+            (
+                "generic-json",
+                "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, output_format: json, sandbox_args: ['--restricted'] }\n",
+                None,
+            ),
+            (
+                "generic-undeclared",
+                "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: files, sandbox_args: ['--restricted'] }\n",
+                None,
+            ),
+            (
+                "builtin-restates-vendor-profile",
+                "id: codex\ninvocation: { command: bash, supports_noninteractive: true, output_contract: json_or_files, output_format: stream-json }\n",
+                None,
+            ),
+            (
+                "builtin-contradicts-vendor-profile",
+                "id: codex\ninvocation: { command: bash, supports_noninteractive: true, output_contract: json_or_files, output_format: text }\n",
+                Some("core-owned stream-json output_format"),
+            ),
+        ] {
+            let profile: WorkerProfile = crate::yaml::from_str(yaml).unwrap();
+            match (invocation_contract(&profile), expected) {
+                (Ok(()), None) => {}
+                (Err(error), Some(expected)) => {
+                    assert!(error.contains(expected), "{label}: {error}")
+                }
+                (result, expected) => panic!("{label}: got {result:?}, expected {expected:?}"),
+            }
+        }
+    }
+
+    // The two knobs must not read as rivals: a generic worker still cannot
+    // widen its RESULT contract, and the rejection says which knob to use.
+    #[test]
+    fn generic_result_contract_rejection_points_at_output_format() {
+        let profile: WorkerProfile = crate::yaml::from_str(
+            "id: generic-fixture\ninvocation: { command: bash, supports_noninteractive: true, output_contract: json_or_files, sandbox_args: ['--restricted'] }\n",
+        )
+        .unwrap();
+        let error = invocation_contract(&profile).unwrap_err();
+        assert!(error.contains("expected files"), "{error}");
+        assert!(error.contains("output_format"), "{error}");
+    }
+
     #[test]
     fn built_in_adapters_keep_their_existing_file_contracts_invocable() {
         for (id, output_contract) in [("codex", "files"), ("claude-code", "json_or_files")] {
@@ -1811,6 +1882,7 @@ invocation:
                 command: "bash".into(),
                 supports_noninteractive: true,
                 output_contract: "files".into(),
+                output_format: None,
                 args: vec!["{run_dir}".into()],
                 prompt_transport: "stdin".into(),
                 version_args: vec!["--version".into()],

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1935,6 +1935,7 @@ mod tests {
                 command: id.to_string(),
                 supports_noninteractive: true,
                 output_contract: "files".to_string(),
+                output_format: None,
                 args: vec!["{run_dir}".to_string()],
                 prompt_transport: "stdin".to_string(),
                 version_args: vec!["--version".to_string()],

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -696,6 +696,7 @@ pub fn run_batch<F: FnMut(&str)>(
                 integration_cleanup_complete: false,
                 owned_oids: Vec::new(),
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )?;
         ok.push(p);

--- a/src/run.rs
+++ b/src/run.rs
@@ -20,8 +20,9 @@ use crate::packet::{self, PacketInputs};
 use crate::schemas::{
     AnswerActionRequest, AttemptState, ChannelEvent, ChannelEventType, ContinuationMode,
     ConversationTurn, EventActor, EventActorKind, OutputContractCause, OutputContractIncident,
-    Question, QuestionState, RunResult, TaskState, TransitionActor, TransitionCause, TurnRole,
-    WorkQueue, WorkerAttempt, WorkerOutputLogSpan, WorkerProfile, WorkersFile,
+    Question, QuestionState, ResultRecoveredFromStdout, RunResult, TaskState, TransitionActor,
+    TransitionCause, TurnRole, WorkQueue, WorkerAttempt, WorkerOutputLogSpan, WorkerProfile,
+    WorkersFile,
 };
 use crate::state::{self, append_str, write_str, PlanningLock, Workspace};
 use crate::ui::i18n::{self, Lang};
@@ -1251,6 +1252,11 @@ pub(crate) struct RunRecord {
     /// third attempt.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_contract_incident: Option<OutputContractIncident>,
+    /// Set when a result was recovered from a worker's captured stdout instead
+    /// of read from the result file it was asked to write. Recorded so the run
+    /// can never present a tolerant recovery as a written-file success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result_recovered_from_stdout: Option<ResultRecoveredFromStdout>,
 }
 
 impl RunRecord {
@@ -1835,6 +1841,88 @@ fn worker_attempt_result(
     "failed"
 }
 
+/// The stdout shape this attempt's worker is normalized against.
+///
+/// Resolution must match what the live publisher used during the attempt: the
+/// end-of-attempt replay dedupes against the events that publisher already
+/// recorded, and two different normalizers over the same bytes would record
+/// two different answers for one raw span. An unreadable workers file falls
+/// back to the core-owned resolution, which is what every profile without a
+/// declaration gets anyway.
+fn declared_output_format(ws: &Workspace, worker_id: &str) -> workers::WorkerOutputFormat {
+    let declared = ws.load_workers().ok().and_then(|workers| {
+        workers
+            .workers
+            .iter()
+            .find(|profile| profile.id == worker_id)
+            .and_then(|profile| profile.invocation.output_format.clone())
+    });
+    workers::resolve_output_format(worker_id, declared.as_deref())
+}
+
+/// Recover a missing result from the attempt's captured stdout when — and only
+/// when — the profile declared structured stdout (`json`/`stream-json`).
+///
+/// Deliberate limits: the built-in adapters never reach this (their format is
+/// a core-owned vendor profile, not a declaration), an existing result file
+/// always wins, and the recovery is abandoned unless its provenance marker can
+/// be written first. A run record that cannot hold the marker must not gain a
+/// result.json that reads as worker-written.
+fn recover_declared_result_from_stdout(
+    run_dir: &std::path::Path,
+    attempt: &WorkerAttempt,
+    capture: &workers::AttemptCapture,
+    format: workers::WorkerOutputFormat,
+) -> Result<Option<ResultRecoveredFromStdout>> {
+    use workers::WorkerOutputFormat;
+
+    let declared = match format {
+        WorkerOutputFormat::Json => "json",
+        WorkerOutputFormat::StreamJson => "stream-json",
+        _ => return Ok(None),
+    };
+    let result_path = run_dir.join("result.json");
+    if result_path.exists() {
+        return Ok(None);
+    }
+    // The run receipt is read BEFORE the stream: it names the run and task the
+    // recovered result has to identify, and a receipt that cannot hold the
+    // provenance marker forfeits the recovery outright.
+    let record_path = run_dir.join("run.yaml");
+    let Ok(mut record) = state::load_yaml::<RunRecord>(&record_path) else {
+        return Ok(None);
+    };
+    let Ok(raw) = std::fs::read(&capture.stdout_log) else {
+        return Ok(None);
+    };
+    let Some(recovered) =
+        workers::recover_result_from_output(&raw, &record.run_id, &record.task_id)
+    else {
+        return Ok(None);
+    };
+    let marker = ResultRecoveredFromStdout {
+        schema_version: 1,
+        attempt_id: attempt.attempt_id.clone(),
+        worker_id: attempt.worker_id.clone(),
+        output_format: declared.to_string(),
+        stream: "stdout".to_string(),
+        byte_start: recovered.byte_start as u64,
+        byte_end: recovered.byte_end as u64,
+    };
+    record.result_recovered_from_stdout = Some(marker.clone());
+    state::save_yaml_atomic(&record_path, &record)?;
+    // The worker's exact bytes, never a re-serialization: a recovered result
+    // stays worker-authored content that Yardlet only relocated.
+    state::write_str_atomic(&result_path, &recovered.json)?;
+    Ok(Some(marker))
+}
+
+fn load_result_recovery_marker(run_dir: &std::path::Path) -> Option<ResultRecoveredFromStdout> {
+    state::load_yaml::<RunRecord>(&run_dir.join("run.yaml"))
+        .ok()
+        .and_then(|record| record.result_recovered_from_stdout)
+}
+
 pub(crate) fn finish_worker_attempt(
     ws: &Workspace,
     lock: Option<&PlanningLock>,
@@ -1844,6 +1932,13 @@ pub(crate) fn finish_worker_attempt(
     capture: &workers::AttemptCapture,
     outcome: &workers::WorkerOutcome,
 ) -> Result<()> {
+    let output_format = declared_output_format(ws, &attempt.worker_id);
+    // Before the attempt is judged: a worker that DECLARES structured stdout
+    // may have put its result there instead of in the result file. Recovering
+    // it here keeps the tolerant fallback on the one seam the serial and
+    // parallel paths already share, and the marker it writes is what stops a
+    // recovery from reading back as "the worker wrote result.json".
+    recover_declared_result_from_stdout(run_dir, attempt, capture, output_format)?;
     let mut channel = ws.load_task_channel(&context.intent_id, &context.task_id)?;
     let mut causation_id = channel
         .events
@@ -1872,9 +1967,12 @@ pub(crate) fn finish_worker_attempt(
         ] {
             let raw = std::fs::read(path)
                 .with_context(|| format!("reading attempt raw stream {}", path.display()))?;
-            for normalized in
-                workers::normalize_worker_output(&attempt.worker_id, stream, &raw, &artifact_id)
-            {
+            for normalized in workers::normalize_worker_output_with_format(
+                output_format,
+                stream,
+                &raw,
+                &artifact_id,
+            ) {
                 let existing = channel.events.iter().find(|event| {
                     event.attempt_id.as_deref() == Some(&attempt.attempt_id)
                         && event.event_type == normalized.event_type
@@ -2718,6 +2816,7 @@ pub fn run_next(ws: &Workspace, opts: &RunOptions) -> Result<RunReport> {
         integration_cleanup_complete: false,
         owned_oids: Vec::new(),
         output_contract_incident: None,
+        result_recovered_from_stdout: None,
     };
     state::save_yaml_atomic(&run_dir.join("run.yaml"), &record)?;
     if serial_worktree.is_some() {
@@ -7453,6 +7552,19 @@ pub(crate) fn finalize_run(input: FinalizeInput) -> Result<FinalizeReport> {
     let result: Option<RunResult> = std::fs::read_to_string(run_dir.join("result.json"))
         .ok()
         .and_then(|t| serde_json::from_str(&t).ok());
+    // Say it out loud in the run report: this result was read out of the
+    // worker's stdout, not out of the file the worker was asked to write.
+    if let Some(marker) = load_result_recovery_marker(run_dir) {
+        lines.push(format!(
+            "result_recovered_from_stdout: attempt {} wrote no result.json; recovered the last \
+             result object from its {} bytes {}..{} (declared output_format {})",
+            marker.attempt_id,
+            marker.stream,
+            marker.byte_start,
+            marker.byte_end,
+            marker.output_format
+        ));
+    }
     let output_contract_incident = load_output_contract_incident(run_dir);
     let output_contract_classification_skips =
         state::load_yaml::<OutputContractClassificationSkips>(
@@ -8522,6 +8634,7 @@ fn seal_run_record(
         integration_cleanup_complete: false,
         owned_oids: Vec::new(),
         output_contract_incident: None,
+        result_recovered_from_stdout: None,
     });
     // Never preserve identity or worktree-location fields from the
     // worker-writable projection. These values are all known by the core at
@@ -15681,6 +15794,7 @@ exit 1
                 integration_cleanup_complete: false,
                 owned_oids: vec![worker_oid.clone(), integration_oid.clone()],
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )
         .unwrap();
@@ -16642,6 +16756,7 @@ exit 1
                 integration_cleanup_complete: false,
                 owned_oids: vec![],
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )
         .unwrap();
@@ -16796,6 +16911,7 @@ exit 1
                 integration_cleanup_complete: false,
                 owned_oids: vec![],
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )
         .unwrap();
@@ -16931,6 +17047,7 @@ exit 1
                 integration_cleanup_complete: false,
                 owned_oids: vec![],
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )
         .unwrap();
@@ -17079,6 +17196,7 @@ exit 1
                 integration_cleanup_complete: false,
                 owned_oids: vec![],
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )
         .unwrap();
@@ -17296,6 +17414,7 @@ exit 1
                 integration_cleanup_complete: false,
                 owned_oids: vec![],
                 output_contract_incident: None,
+                result_recovered_from_stdout: None,
             },
         )
         .unwrap();

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -2183,6 +2183,23 @@ pub struct OutputContractIncident {
     pub terminal_attempt_id: Option<String>,
 }
 
+/// Provenance for a result Yardlet had to recover from a worker's captured
+/// stdout because the declared result FILE was absent. Recorded so a tolerant
+/// recovery can never read back as "the worker wrote result.json" (V010-006).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResultRecoveredFromStdout {
+    #[serde(default)]
+    pub schema_version: u32,
+    pub attempt_id: String,
+    pub worker_id: String,
+    /// The `invocation.output_format` declaration that authorized the recovery.
+    pub output_format: String,
+    /// Raw attempt stream the bytes came from (always `stdout` today).
+    pub stream: String,
+    pub byte_start: u64,
+    pub byte_end: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Billing {
     #[serde(default)]
@@ -2204,6 +2221,15 @@ pub struct Invocation {
     pub supports_noninteractive: bool,
     #[serde(default)]
     pub output_contract: String,
+    /// Shape of this worker's stdout: `text` (one event per line, the default
+    /// when undeclared), `json` (one JSON document per attempt), or
+    /// `stream-json` (one JSON object per line). It selects the stdout
+    /// normalizer and, for a generic worker declaring `json`/`stream-json`,
+    /// authorizes the tolerant result fallback when the result FILE is absent.
+    /// The built-in adapters own their vendor stream-json profile, so they may
+    /// only restate it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_format: Option<String>,
     /// Generic adapter template for workers without a built-in adapter
     /// (codex and claude-code have first-class ones; any other id uses these).
     /// Placeholders: `{run_dir}`, `{model}`, `{effort}`, `{image}`, and, for
@@ -2317,6 +2343,9 @@ pub struct GenericSessionCapture {
     pub prefix: String,
 }
 
+/// The declarable stdout shapes, in the order the guard names them.
+pub const OUTPUT_FORMATS: [&str; 3] = ["text", "json", "stream-json"];
+
 fn default_prompt_transport() -> String {
     "stdin".to_string()
 }
@@ -2336,6 +2365,31 @@ fn is_default_version_args(args: &Vec<String>) -> bool {
 impl Invocation {
     pub fn prompt_on_stdin(&self) -> bool {
         self.prompt_transport.trim() == "stdin"
+    }
+
+    /// Validate the optional `output_format` declaration.
+    ///
+    /// Undeclared keeps today's behavior for every profile. A built-in adapter
+    /// carries a CORE-OWNED vendor stream-json normalizer, so a declaration
+    /// that disagrees with it is rejected rather than silently ignored: a
+    /// profile must never claim a stdout shape Yardlet will not honor.
+    pub fn validate_output_format(&self, worker_id: &str) -> Result<(), String> {
+        let Some(declared) = self.output_format.as_deref().map(str::trim) else {
+            return Ok(());
+        };
+        if !OUTPUT_FORMATS.contains(&declared) {
+            return Err(format!(
+                "worker '{worker_id}' has unsupported output_format '{declared}'; expected {}",
+                OUTPUT_FORMATS.join(", ")
+            ));
+        }
+        if matches!(worker_id, "codex" | "claude-code") && declared != "stream-json" {
+            return Err(format!(
+                "worker '{worker_id}' has a core-owned stream-json output_format; \
+                 remove the declaration or set stream-json (declared '{declared}')"
+            ));
+        }
+        Ok(())
     }
 
     /// Validate only the generic adapter's structural template. Runtime

--- a/src/workers/mod.rs
+++ b/src/workers/mod.rs
@@ -351,14 +351,260 @@ fn normalize_claude_json(
     out
 }
 
+/// The stdout shape a worker's output is normalized against.
+///
+/// The two built-in adapters keep their own vendor profiles: those normalizers
+/// are core-owned, so a profile cannot redefine them. Everything else is a
+/// user declaration (`invocation.output_format`), defaulting to line-per-event
+/// text — exactly the fallback every non-built-in worker had before.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerOutputFormat {
+    /// Codex CLI's stream-json profile.
+    CodexStreamJson,
+    /// Claude Code CLI's stream-json profile.
+    ClaudeStreamJson,
+    /// One public message per non-empty line, verbatim.
+    Text,
+    /// One JSON document per attempt; the rest of the stream is text.
+    Json,
+    /// One JSON object per line; unparseable lines degrade to text.
+    StreamJson,
+}
+
+impl WorkerOutputFormat {
+    /// Whether the streaming publisher can normalize this format line by line.
+    ///
+    /// A `json` worker emits ONE document that may span many lines, so its
+    /// events can only be derived once the whole attempt stream is on disk.
+    /// Publishing per line there would record a different event for the same
+    /// bytes than the end-of-attempt replay does, and those two must agree.
+    pub fn streams_line_by_line(self) -> bool {
+        !matches!(self, Self::Json)
+    }
+}
+
+/// Parse a declared `output_format`. Unknown values are rejected by the guard,
+/// never guessed at.
+pub fn parse_output_format(declared: &str) -> Option<WorkerOutputFormat> {
+    match declared.trim() {
+        "text" => Some(WorkerOutputFormat::Text),
+        "json" => Some(WorkerOutputFormat::Json),
+        "stream-json" => Some(WorkerOutputFormat::StreamJson),
+        _ => None,
+    }
+}
+
+/// Deterministic normalizer selection: a built-in adapter's vendor profile is
+/// core-owned and wins over any declaration; a generic worker uses its own
+/// declaration and falls back to text when it has none.
+pub fn resolve_output_format(worker_id: &str, declared: Option<&str>) -> WorkerOutputFormat {
+    match worker_id {
+        "codex" => WorkerOutputFormat::CodexStreamJson,
+        "claude-code" => WorkerOutputFormat::ClaudeStreamJson,
+        _ => declared
+            .and_then(parse_output_format)
+            .unwrap_or(WorkerOutputFormat::Text),
+    }
+}
+
+/// A structured event from a generic worker's JSON. `text` keeps the payload
+/// renderable by the same consumers that read vendor messages; `json` keeps
+/// the exact parsed object so nothing structural is lost to prose.
+fn generic_json_event(
+    value: &serde_json::Value,
+    artifact_id: &str,
+    stream: RawStreamKind,
+    start: usize,
+    end: usize,
+) -> Option<NormalizedWorkerEvent> {
+    let rendered = value
+        .get("text")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string());
+    (!rendered.is_empty()).then(|| {
+        normalized_event(
+            ChannelEventType::WorkerMessage,
+            serde_json::json!({"text": rendered, "json": value}),
+            artifact_id,
+            stream,
+            start,
+            end,
+        )
+    })
+}
+
+/// Byte spans of every balanced `{...}` region, in the order they CLOSE, so
+/// reversing yields the latest-finishing candidate first and, at equal ends,
+/// the outermost before the fragment nested inside it.
+///
+/// Nested regions are kept on purpose: a worker's prose can leave a stray brace
+/// open, and dropping everything after it would silently lose a result that is
+/// sitting right there in the stream. Quoted text is only tracked inside an
+/// object, where JSON strings actually live; unbalanced quotes in prose must
+/// not swallow the rest of the stream.
+///
+/// This is a scanner, not a parser: callers still parse the spans they want.
+fn balanced_object_spans(raw: &[u8]) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut open = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+    for (index, byte) in raw.iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if *byte == b'\\' {
+                escaped = true;
+            } else if *byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' if !open.is_empty() => in_string = true,
+            b'{' => open.push(index),
+            b'}' => {
+                if let Some(start) = open.pop() {
+                    spans.push((start, index + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+    spans
+}
+
+/// The last balanced region that actually parses as a JSON object.
+/// Tolerant by design: unparseable candidates are skipped, never fatal.
+pub fn last_complete_json_object(raw: &[u8]) -> Option<(usize, usize, serde_json::Value)> {
+    balanced_object_spans(raw)
+        .into_iter()
+        .rev()
+        .find_map(|(start, end)| {
+            serde_json::from_slice::<serde_json::Value>(&raw[start..end])
+                .ok()
+                .filter(serde_json::Value::is_object)
+                .map(|value| (start, end, value))
+        })
+}
+
+/// A result Yardlet recovered from captured stdout instead of the result file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoveredResult {
+    pub byte_start: usize,
+    pub byte_end: usize,
+    /// The worker's exact bytes, so the recovered result stays worker-authored.
+    pub json: String,
+}
+
+/// Tolerantly recover a worker result from captured stdout: the LAST balanced
+/// JSON object that parses as the result schema AND identifies this exact run.
+/// Returns None when the stream holds no such object, which keeps the typed
+/// failure path exactly as it was.
+///
+/// The identity check is not a formality. Every task packet carries a result
+/// SCHEMA EXAMPLE, so a worker that echoes its own prompt prints a
+/// result-shaped object; without this, echoing the packet would manufacture a
+/// finished run — placeholder status, template follow-up tasks and all. A
+/// result that does not name this run and task is not this run's result.
+pub fn recover_result_from_output(
+    raw: &[u8],
+    run_id: &str,
+    task_id: &str,
+) -> Option<RecoveredResult> {
+    if run_id.trim().is_empty() || task_id.trim().is_empty() {
+        return None;
+    }
+    balanced_object_spans(raw)
+        .into_iter()
+        .rev()
+        .find(|(start, end)| {
+            serde_json::from_slice::<crate::schemas::RunResult>(&raw[*start..*end])
+                .is_ok_and(|result| result.run_id == run_id && result.task_id == task_id)
+        })
+        .and_then(|(start, end)| {
+            Some(RecoveredResult {
+                byte_start: start,
+                byte_end: end,
+                json: String::from_utf8(raw[start..end].to_vec()).ok()?,
+            })
+        })
+}
+
+/// One JSON document per attempt: the last complete object becomes a structured
+/// event; every line outside it degrades to text.
+fn normalize_json_document(
+    raw: &[u8],
+    artifact_id: &str,
+    stream: RawStreamKind,
+) -> Vec<NormalizedWorkerEvent> {
+    let document = last_complete_json_object(raw);
+    let mut events = Vec::new();
+    let mut start = 0_usize;
+    while start < raw.len() {
+        let end = raw[start..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(raw.len(), |offset| start + offset + 1);
+        match &document {
+            Some((doc_start, doc_end, value)) if start < *doc_end && end > *doc_start => {
+                if start <= *doc_start {
+                    events.extend(generic_json_event(
+                        value,
+                        artifact_id,
+                        stream,
+                        *doc_start,
+                        *doc_end,
+                    ));
+                }
+            }
+            _ => {
+                let line = String::from_utf8_lossy(&raw[start..end]);
+                if let Some(event) = text_event(line.trim(), artifact_id, stream, start, end) {
+                    events.push(event);
+                }
+            }
+        }
+        start = end;
+    }
+    events
+}
+
 /// Normalize only provider-exposed public messages/tool activity. Raw bytes
 /// remain the source of truth and every emitted event points at its exact line.
+///
+/// Id-keyed entry, kept as the oracle for the two core-owned vendor profiles:
+/// production always resolves a profile's DECLARED format first, so nothing
+/// outside tests reaches a normalizer through a worker id any more.
+#[cfg(test)]
 pub fn normalize_worker_output(
     worker_id: &str,
     stream: RawStreamKind,
     raw: &[u8],
     artifact_id: &str,
 ) -> Vec<NormalizedWorkerEvent> {
+    normalize_worker_output_with_format(
+        resolve_output_format(worker_id, None),
+        stream,
+        raw,
+        artifact_id,
+    )
+}
+
+/// Format-keyed normalization. Every worker reaches its normalizer through the
+/// declared (or core-owned) stdout shape, never through an id comparison.
+pub fn normalize_worker_output_with_format(
+    format: WorkerOutputFormat,
+    stream: RawStreamKind,
+    raw: &[u8],
+    artifact_id: &str,
+) -> Vec<NormalizedWorkerEvent> {
+    if format == WorkerOutputFormat::Json {
+        return normalize_json_document(raw, artifact_id, stream);
+    }
     let mut events = Vec::new();
     let mut start = 0_usize;
     while start < raw.len() {
@@ -369,30 +615,27 @@ pub fn normalize_worker_output(
         let line = String::from_utf8_lossy(&raw[start..end]);
         let trimmed = line.trim();
         if !trimmed.is_empty() {
-            match serde_json::from_str::<serde_json::Value>(trimmed) {
-                Ok(value) if worker_id == "codex" => {
-                    events.extend(normalize_codex_json(
-                        &value,
-                        artifact_id,
-                        stream,
-                        start,
-                        end,
-                    ));
-                }
-                Ok(value) if worker_id == "claude-code" => {
-                    events.extend(normalize_claude_json(
-                        &value,
-                        artifact_id,
-                        stream,
-                        start,
-                        end,
-                    ));
-                }
-                Ok(_) | Err(_) => {
-                    if let Some(event) = text_event(trimmed, artifact_id, stream, start, end) {
-                        events.push(event);
+            let parsed = serde_json::from_str::<serde_json::Value>(trimmed).ok();
+            let structured =
+                match (format, parsed.as_ref()) {
+                    (WorkerOutputFormat::CodexStreamJson, Some(value)) => {
+                        Some(normalize_codex_json(value, artifact_id, stream, start, end))
                     }
-                }
+                    (WorkerOutputFormat::ClaudeStreamJson, Some(value)) => Some(
+                        normalize_claude_json(value, artifact_id, stream, start, end),
+                    ),
+                    (WorkerOutputFormat::StreamJson, Some(value)) => Some(
+                        generic_json_event(value, artifact_id, stream, start, end)
+                            .into_iter()
+                            .collect(),
+                    ),
+                    // Text, and any line the declared format could not parse:
+                    // degrade to a message event instead of failing the stream.
+                    _ => None,
+                };
+            match structured {
+                Some(structured) => events.extend(structured),
+                None => events.extend(text_event(trimmed, artifact_id, stream, start, end)),
             }
         }
         start = end;
@@ -401,7 +644,7 @@ pub fn normalize_worker_output(
 }
 
 fn publish_complete_public_lines(
-    worker_id: &str,
+    format: WorkerOutputFormat,
     stream: RawStreamKind,
     artifact_id: &str,
     pending: &mut Vec<u8>,
@@ -419,10 +662,13 @@ fn publish_complete_public_lines(
             break;
         };
         let line = pending.drain(..line_len).collect::<Vec<_>>();
-        for mut event in normalize_worker_output(worker_id, stream, &line, artifact_id) {
-            event.raw_ref.byte_start += *consumed;
-            event.raw_ref.byte_end += *consumed;
-            sink(event).map_err(std::io::Error::other)?;
+        if format.streams_line_by_line() {
+            for mut event in normalize_worker_output_with_format(format, stream, &line, artifact_id)
+            {
+                event.raw_ref.byte_start += *consumed;
+                event.raw_ref.byte_end += *consumed;
+                sink(event).map_err(std::io::Error::other)?;
+            }
         }
         *consumed += line_len as u64;
     }
@@ -1567,6 +1813,8 @@ fn spawn_internal(
                 let log = std::sync::Arc::clone(&log_file);
                 let captured = std::sync::Arc::clone(&captured_session);
                 let worker_id = profile.id.clone();
+                let output_format =
+                    resolve_output_format(&profile.id, profile.invocation.output_format.as_deref());
                 let event_sink = reader_event_sink.clone();
                 thread::spawn(move || -> std::io::Result<()> {
                     let mut buf = [0u8; 4096];
@@ -1595,7 +1843,7 @@ fn spawn_internal(
                                 }
                                 if let Some(sink) = &event_sink {
                                     publish_complete_public_lines(
-                                        &worker_id,
+                                        output_format,
                                         stream,
                                         &artifact_id,
                                         &mut public_pending,
@@ -1651,7 +1899,7 @@ fn spawn_internal(
                                 if let Some(sink) = &event_sink {
                                     public_pending.extend_from_slice(&buf[..n]);
                                     publish_complete_public_lines(
-                                        &worker_id,
+                                        output_format,
                                         stream,
                                         &artifact_id,
                                         &mut public_pending,
@@ -3078,6 +3326,245 @@ printf '%s\n' '{"type":"thread.started","thread_id":"aaaaaaaa-bbbb-4ccc-8ddd-eee
         }
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    // V010-006: normalization is selected by FORMAT. The two built-in adapters
+    // own theirs, so a declaration cannot move them; every other worker gets
+    // the shape it declared, and text when it declared nothing.
+    #[test]
+    fn output_format_resolution_is_core_owned_for_built_ins_and_declared_for_the_rest() {
+        for declared in [None, Some("text"), Some("json"), Some("stream-json")] {
+            assert_eq!(
+                resolve_output_format("codex", declared),
+                WorkerOutputFormat::CodexStreamJson,
+                "codex profile moved by {declared:?}"
+            );
+            assert_eq!(
+                resolve_output_format("claude-code", declared),
+                WorkerOutputFormat::ClaudeStreamJson,
+                "claude-code profile moved by {declared:?}"
+            );
+        }
+        for (declared, expected) in [
+            (None, WorkerOutputFormat::Text),
+            (Some("text"), WorkerOutputFormat::Text),
+            (Some("json"), WorkerOutputFormat::Json),
+            (Some("stream-json"), WorkerOutputFormat::StreamJson),
+            // Unsupported values are the guard's business; resolution must not
+            // invent a shape for one that slipped through.
+            (Some("ndjson"), WorkerOutputFormat::Text),
+        ] {
+            assert_eq!(
+                resolve_output_format("generic-fixture", declared),
+                expected,
+                "generic profile for {declared:?}"
+            );
+        }
+        assert_eq!(
+            parse_output_format("stream-json"),
+            Some(WorkerOutputFormat::StreamJson)
+        );
+        assert_eq!(parse_output_format("ndjson"), None);
+    }
+
+    // A `json` worker emits ONE document, so its events can only be derived
+    // once the whole stream is captured; every other format streams per line.
+    #[test]
+    fn only_the_json_document_format_defers_normalization_off_the_line_publisher() {
+        for format in [
+            WorkerOutputFormat::CodexStreamJson,
+            WorkerOutputFormat::ClaudeStreamJson,
+            WorkerOutputFormat::Text,
+            WorkerOutputFormat::StreamJson,
+        ] {
+            assert!(format.streams_line_by_line(), "{format:?}");
+        }
+        assert!(!WorkerOutputFormat::Json.streams_line_by_line());
+    }
+
+    #[test]
+    fn declared_stream_json_structures_json_lines_and_degrades_the_rest_to_text() {
+        let raw = concat!(
+            "warming up\n",
+            "{\"text\":\"public update\",\"phase\":\"build\"}\n",
+            "{not json at all\n",
+            "{\"phase\":\"done\"}\n"
+        );
+        let events = normalize_worker_output_with_format(
+            WorkerOutputFormat::StreamJson,
+            RawStreamKind::Stdout,
+            raw.as_bytes(),
+            "raw_att_1_stdout",
+        );
+
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].payload["text"], "warming up");
+        assert!(events[0].payload.get("json").is_none());
+        assert_eq!(events[1].payload["text"], "public update");
+        assert_eq!(events[1].payload["json"]["phase"], "build");
+        // A line the declared format cannot parse degrades; it never fails.
+        assert_eq!(events[2].payload["text"], "{not json at all");
+        // No `text` field to render: keep the object and say so verbatim.
+        assert_eq!(events[3].payload["json"]["phase"], "done");
+        assert_eq!(events[3].payload["text"], "{\"phase\":\"done\"}");
+        for event in &events {
+            assert_eq!(
+                event.event_type,
+                crate::schemas::ChannelEventType::WorkerMessage
+            );
+            let start = event.raw_ref.byte_start as usize;
+            let end = event.raw_ref.byte_end as usize;
+            assert!(start < end && end <= raw.len());
+        }
+    }
+
+    #[test]
+    fn declared_json_normalizes_the_last_complete_document_and_leaves_the_rest_text() {
+        let raw = concat!(
+            "starting\n",
+            "{\"text\":\"superseded\"}\n",
+            "note between documents\n",
+            "{\n  \"text\": \"final answer\",\n  \"nested\": {\"brace\": \"} not a close\"}\n}\n",
+            "trailing note\n"
+        );
+        let events = normalize_worker_output_with_format(
+            WorkerOutputFormat::Json,
+            RawStreamKind::Stdout,
+            raw.as_bytes(),
+            "raw_att_1_stdout",
+        );
+
+        let texts = events
+            .iter()
+            .map(|event| event.payload["text"].as_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            texts,
+            vec![
+                "starting",
+                "{\"text\":\"superseded\"}",
+                "note between documents",
+                "final answer",
+                "trailing note",
+            ]
+        );
+        let document = &events[3];
+        assert_eq!(document.payload["json"]["nested"]["brace"], "} not a close");
+        // The structured event spans the WHOLE document, not just its first line.
+        let start = document.raw_ref.byte_start as usize;
+        let end = document.raw_ref.byte_end as usize;
+        assert_eq!(&raw[start..=start], "{");
+        assert!(raw[start..end].contains("final answer"));
+        assert!(raw[start..end].lines().count() > 1);
+    }
+
+    #[test]
+    fn result_recovery_takes_the_last_result_shaped_object_from_captured_stdout() {
+        let raw = concat!(
+            "{\"schema_version\":1,\"run_id\":\"r1\",\"task_id\":\"YARD-001\",\"status\":\"failed\"}\n",
+            "still working\n",
+            "{\"type\":\"progress\",\"done\":true}\n",
+            "{\"schema_version\":1,\"run_id\":\"r1\",\"task_id\":\"YARD-001\",\"status\":\"done\",\"compact_summary\":\"last\"}\n",
+        );
+        let recovered =
+            recover_result_from_output(raw.as_bytes(), "r1", "YARD-001").expect("result recovered");
+        assert!(recovered.json.contains("\"compact_summary\":\"last\""));
+        assert_eq!(
+            &raw[recovered.byte_start..recovered.byte_end],
+            recovered.json
+        );
+        let parsed: crate::schemas::RunResult = serde_json::from_str(&recovered.json).unwrap();
+        assert_eq!(parsed.status, "done");
+    }
+
+    // A stray brace in a worker's prose must not hide the result sitting after
+    // it: the scanner keeps nested candidates precisely so recovery survives an
+    // unbalanced stream.
+    #[test]
+    fn result_recovery_survives_an_unbalanced_brace_earlier_in_the_stream() {
+        let raw = concat!(
+            "writing { and never closing it\n",
+            "{\"schema_version\":1,\"run_id\":\"r1\",\"task_id\":\"YARD-001\",\"status\":\"done\"}\n",
+        );
+        let recovered =
+            recover_result_from_output(raw.as_bytes(), "r1", "YARD-001").expect("result recovered");
+        assert!(recovered.json.starts_with("{\"schema_version\":1"));
+    }
+
+    // Every task packet carries a result SCHEMA EXAMPLE, so a worker that
+    // echoes its own prompt prints a result-shaped object. Recovering that
+    // would manufacture a finished run out of a template.
+    #[test]
+    fn result_recovery_refuses_the_result_schema_example_a_worker_echoed_back() {
+        let task: crate::schemas::Task =
+            crate::yaml::from_str("id: YARD-001\ntitle: echo the packet\n").unwrap();
+        let echoed = format!(
+            "here is my packet:\n{}\n",
+            crate::packet::compile(&crate::packet::PacketInputs {
+                worker_id: "generic-fixture",
+                task: &task,
+                intent: None,
+                repo: &Default::default(),
+                run_dir_rel: ".agents/runs/run-1",
+                conversation: &[],
+                continuation: None,
+                chained_from: None,
+                language: "en",
+                images: &[],
+                role_notes: "",
+                harness: &Default::default(),
+                approved: false,
+                pre_push_checks: &[],
+            })
+        );
+        assert!(
+            echoed.contains("\"run_id\": \"<run-id>\""),
+            "the packet no longer carries the template this guards against"
+        );
+        assert_eq!(
+            recover_result_from_output(echoed.as_bytes(), "run-1", "YARD-001"),
+            None,
+            "the packet's own schema example was recovered as a result"
+        );
+    }
+
+    #[test]
+    fn result_recovery_declines_broken_non_result_and_foreign_output() {
+        for (label, raw) in [
+            // Truncated: no balanced object at all.
+            (
+                "truncated",
+                "{\"schema_version\":1,\"run_id\":\"r1\",\"task_id\":\"YARD-001\",\"status\":\"done\"",
+            ),
+            // Balanced but not the result schema.
+            ("not a result", "{\"type\":\"progress\",\"done\":true}\n"),
+            // Balanced, result-ish, but missing required fields.
+            ("partial schema", "{\"status\":\"done\"}\n"),
+            // A complete result that belongs to a DIFFERENT run or task.
+            (
+                "foreign run",
+                "{\"schema_version\":1,\"run_id\":\"r0\",\"task_id\":\"YARD-001\",\"status\":\"done\"}\n",
+            ),
+            (
+                "foreign task",
+                "{\"schema_version\":1,\"run_id\":\"r1\",\"task_id\":\"YARD-999\",\"status\":\"done\"}\n",
+            ),
+            ("empty", ""),
+        ] {
+            assert_eq!(
+                recover_result_from_output(raw.as_bytes(), "r1", "YARD-001"),
+                None,
+                "{label}: recovered a result from {raw:?}"
+            );
+        }
+        // An unidentifiable run cannot claim any result as its own.
+        let mine =
+            "{\"schema_version\":1,\"run_id\":\"r1\",\"task_id\":\"YARD-001\",\"status\":\"done\"}";
+        assert_eq!(
+            recover_result_from_output(mine.as_bytes(), "", "YARD-001"),
+            None
+        );
+        assert_eq!(recover_result_from_output(mine.as_bytes(), "r1", ""), None);
     }
 
     #[test]

--- a/templates/agents/workers.yaml
+++ b/templates/agents/workers.yaml
@@ -120,6 +120,12 @@ workers:
   #     command: mytool
   #     supports_noninteractive: true
   #     output_contract: files
+  #     # Shape of this CLI's stdout: text (default when omitted; one message
+  #     # per line), json (one document per attempt), or stream-json (one
+  #     # object per line). json/stream-json also let Yardlet tolerantly
+  #     # recover a missing result from stdout, marked as recovered in the run
+  #     # record so it never reads as a written result file.
+  #     output_format: stream-json
   #     version_args: ["version", "--offline"]
   #     prompt_transport: argument
   #     # {prompt} is exactly one argv item. Yardlet never builds a shell string.

--- a/tests/generic_output_normalization_process.rs
+++ b/tests/generic_output_normalization_process.rs
@@ -1,0 +1,455 @@
+//! V010-006: a generic worker declares the SHAPE of its stdout
+//! (`invocation.output_format`) and Yardlet normalizes against that
+//! declaration instead of a hard-coded worker id.
+//!
+//! What only a real process can prove, and what this file is for:
+//!
+//! * a `json` worker that wrote no result FILE still gets its result read out
+//!   of captured stdout, and the recovery is stamped with its provenance so it
+//!   can never read back as "the worker wrote result.json";
+//! * the same worker with a BROKEN document keeps today's typed failure and
+//!   its exact raw evidence;
+//! * a `stream-json` worker's mixed stream normalizes tolerantly, and the live
+//!   publisher and the end-of-attempt replay agree on every raw span (they
+//!   record into the same channel, so disagreement is a run-failing error).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Fixture {
+    root: PathBuf,
+    binary: PathBuf,
+    worker: PathBuf,
+}
+
+impl Fixture {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "yardlet-output-format-{label}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let binary = PathBuf::from(env!("CARGO_BIN_EXE_yardlet"));
+
+        must_succeed(&root, Path::new("git"), &["init", "-q"]);
+        must_succeed(&root, Path::new("git"), &["config", "user.name", "fixture"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["config", "user.email", "fixture@example.invalid"],
+        );
+        fs::write(root.join("README.md"), "fixture\n").unwrap();
+        must_succeed(&root, Path::new("git"), &["add", "README.md"]);
+        must_succeed(&root, Path::new("git"), &["commit", "-qm", "fixture"]);
+        must_succeed(&root, &binary, &["init"]);
+
+        let worker = root.join("fixture-worker.sh");
+        write_worker(&worker);
+        must_succeed(&root, Path::new("git"), &["add", "fixture-worker.sh"]);
+        must_succeed(
+            &root,
+            Path::new("git"),
+            &["commit", "-qm", "fixture worker"],
+        );
+        write_task(&root);
+
+        Self {
+            root,
+            binary,
+            worker,
+        }
+    }
+
+    fn configure(&self, mode: &str, output_format: &str) {
+        fs::write(
+            self.root.join(".agents/workers.yaml"),
+            format!(
+                "schema_version: 1\nworkers:\n  - id: fixture\n    invocation:\n      command: {}\n      supports_noninteractive: true\n      output_contract: files\n      output_format: {output_format}\n      version_args: [probe, offline]\n      args: [{mode}, '{{run_dir}}']\n      sandbox_args: ['--fixture-sandbox']\n    limits:\n      max_wall_minutes: 1\n      max_retries: 0\nrouting:\n  default_worker: fixture\n  fallback_order: [fixture]\n  allow_preferred_worker_failover: false\n",
+                self.worker.display()
+            ),
+        )
+        .unwrap();
+    }
+
+    fn run(&self) -> Output {
+        Command::new(&self.binary)
+            .args(["run", "--task", "YARD-001", "--execute"])
+            .current_dir(&self.root)
+            .output()
+            .unwrap()
+    }
+
+    fn latest_run(&self) -> PathBuf {
+        let mut runs = fs::read_dir(self.root.join(".agents/runs"))
+            .unwrap()
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.join("task-packet.md").is_file())
+            .collect::<Vec<_>>();
+        runs.sort();
+        runs.pop().expect("fixture run exists")
+    }
+
+    fn run_record(&self) -> serde_yaml_ng::Value {
+        serde_yaml_ng::from_str(&fs::read_to_string(self.latest_run().join("run.yaml")).unwrap())
+            .unwrap()
+    }
+
+    fn attempt_stdout(&self) -> Vec<u8> {
+        let run = self.latest_run();
+        let attempt = fs::read_to_string(run.join("latest-attempt")).unwrap();
+        fs::read(run.join("attempts").join(attempt.trim()).join("stdout.log")).unwrap()
+    }
+
+    fn channel_events(&self) -> Vec<serde_yaml_ng::Value> {
+        files_below(&self.root.join(".agents/task-channels"), ".yaml")
+            .into_iter()
+            .filter(|path| path.to_string_lossy().contains("/events/"))
+            .filter_map(|path| {
+                serde_yaml_ng::from_str::<serde_yaml_ng::Value>(&fs::read_to_string(path).ok()?)
+                    .ok()
+            })
+            .collect()
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn must_succeed(root: &Path, program: &Path, args: &[&str]) -> Output {
+    let output = Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", program.display()));
+    assert!(
+        output.status.success(),
+        "{} {:?} failed\nstdout:\n{}\nstderr:\n{}",
+        program.display(),
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn files_below(root: &Path, suffix: &str) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    if let Ok(entries) = fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                files.extend(files_below(&path, suffix));
+            } else if path.to_string_lossy().ends_with(suffix) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+fn write_task(root: &Path) {
+    fs::write(
+        root.join(".agents/intent-contract.yaml"),
+        "schema_version: 1\nid: intent-output-format\nsummary: declared output format fixture\nstatus: accepted\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join(".agents/work-queue.yaml"),
+        "schema_version: 1\nqueue_id: queue-output-format\nintent_id: intent-output-format\ntasks:\n  - id: YARD-001\n    title: declared output format fixture\n    state: queued\n    priority: 10\n    risk: low\n    kind: implementation\n    preferred_worker: fixture\n    acceptance: [result reaches the core]\n",
+    )
+    .unwrap();
+}
+
+/// The fixture worker. Each mode writes a different STDOUT shape; only the
+/// stream-json mode writes the result file the packet asks for.
+fn write_worker(path: &Path) {
+    let script = r#"#!/bin/sh
+set -eu
+if [ "${1:-}" = probe ] && [ "${2:-}" = offline ]; then
+  printf 'fixture-worker 1.0\n'
+  exit 0
+fi
+run_dir="$2"
+run_id="$(basename "$run_dir")"
+if [ "${1:-}" = json-result ]; then
+  cat
+  printf 'reading the packet {\n'
+  printf 'superseded run: {"schema_version": 1, "run_id": "stale", "task_id": "YARD-001", "status": "failed"}\n'
+  cat <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {"drift_detected": false, "notes": "on scope"},
+  "changes": {"files_modified": [], "files_created": [], "files_deleted": []},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "compact_summary": "document worker answered on stdout"
+}
+EOF
+  printf '# Generic json worker handoff\n' > "$run_dir/handoff.md"
+  exit 0
+fi
+if [ "${1:-}" = json-broken ]; then
+  cat
+  printf 'starting the document\n'
+  printf '{\n  "schema_version": 1,\n  "run_id": "%s",\n  "task_id": "YARD-001",\n  "status": "do\n' "$run_id"
+  printf 'stream ended mid-document\n' >&2
+  exit 0
+fi
+if [ "${1:-}" = stream-json ]; then
+  cat
+  printf 'plain progress line\n'
+  printf '{"text":"structured public update","phase":"build"}\n'
+  printf '{"phase":"verify","checks":2}\n'
+  printf 'not { valid } json\n'
+  cat > "$run_dir/result.json" <<EOF
+{
+  "schema_version": 1,
+  "run_id": "$run_id",
+  "task_id": "YARD-001",
+  "status": "done",
+  "intent_adherence": {"drift_detected": false, "notes": ""},
+  "changes": {"files_modified": [], "files_created": [], "files_deleted": []},
+  "validation": {"commands_run": [], "passed": true, "failures": []},
+  "compact_summary": "stream worker wrote its own result file"
+}
+EOF
+  printf '# Generic stream-json worker handoff\n' > "$run_dir/handoff.md"
+  exit 0
+fi
+printf 'unknown mode %s\n' "${1:-}" >&2
+exit 64
+"#;
+    fs::write(path, script).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+/// (a) A declared `json` worker that never wrote result.json: Yardlet recovers
+/// the LAST result-shaped document from its captured stdout, keeps the worker's
+/// exact bytes, and stamps the recovery everywhere the run is read.
+#[test]
+fn declared_json_worker_result_is_recovered_from_stdout_with_its_provenance() {
+    let fixture = Fixture::new("json-recovered");
+    fixture.configure("json-result", "json");
+
+    let output = fixture.run();
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(output.status.success(), "{combined}");
+
+    let run = fixture.latest_run();
+    let stdout = fixture.attempt_stdout();
+    let result = fs::read_to_string(run.join("result.json")).unwrap();
+    assert!(
+        result.contains("document worker answered on stdout"),
+        "{result}"
+    );
+    // The LAST result-shaped document wins: the superseded one printed earlier
+    // in the same stream must not be the one that reaches the core.
+    assert!(!result.contains("\"run_id\": \"stale\""), "{result}");
+
+    let record = fixture.run_record();
+    let marker = record
+        .get("result_recovered_from_stdout")
+        .unwrap_or_else(|| panic!("run.yaml carries no recovery marker: {record:#?}"));
+    assert_eq!(
+        marker.get("stream").and_then(serde_yaml_ng::Value::as_str),
+        Some("stdout")
+    );
+    assert_eq!(
+        marker
+            .get("output_format")
+            .and_then(serde_yaml_ng::Value::as_str),
+        Some("json")
+    );
+    assert_eq!(
+        marker
+            .get("attempt_id")
+            .and_then(serde_yaml_ng::Value::as_str),
+        Some(
+            fs::read_to_string(run.join("latest-attempt"))
+                .unwrap()
+                .trim()
+        )
+    );
+    // The marker points at the exact bytes it took, and those bytes ARE the
+    // result file: a recovery relocates the worker's own output, never a
+    // re-serialization of it.
+    let start = marker
+        .get("byte_start")
+        .and_then(serde_yaml_ng::Value::as_u64)
+        .unwrap() as usize;
+    let end = marker
+        .get("byte_end")
+        .and_then(serde_yaml_ng::Value::as_u64)
+        .unwrap() as usize;
+    assert_eq!(String::from_utf8_lossy(&stdout[start..end]), result);
+
+    assert!(
+        combined.contains("result_recovered_from_stdout"),
+        "the run report must say the result did not come from the file: {combined}"
+    );
+    // Raw evidence is untouched by the recovery.
+    assert!(String::from_utf8_lossy(&stdout).contains("reading the packet {"));
+}
+
+/// (b) The same declared worker with a BROKEN document: no result is invented,
+/// today's typed failure stands, and the raw stream survives intact.
+#[test]
+fn declared_json_worker_with_a_broken_document_keeps_the_typed_failure_and_raw_log() {
+    let fixture = Fixture::new("json-broken");
+    fixture.configure("json-broken", "json");
+
+    let output = fixture.run();
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("result_recovered_from_stdout"),
+        "an unparseable stream must not report a recovery: {combined}"
+    );
+    assert!(
+        !combined.contains("next task state: ✓ done"),
+        "a broken document must not finish the task: {combined}"
+    );
+
+    let run = fixture.latest_run();
+    assert!(
+        !run.join("result.json").exists(),
+        "an unparseable stream must not produce a result file"
+    );
+    let record = fixture.run_record();
+    assert!(
+        record.get("result_recovered_from_stdout").is_none(),
+        "a failed recovery must leave no provenance marker: {record:#?}"
+    );
+
+    let stdout = String::from_utf8(fixture.attempt_stdout()).unwrap();
+    assert!(stdout.contains("starting the document"), "{stdout}");
+    assert!(stdout.contains("\"status\": \"do"), "{stdout}");
+    let attempt_id = fs::read_to_string(run.join("latest-attempt")).unwrap();
+    let stderr = fs::read_to_string(
+        run.join("attempts")
+            .join(attempt_id.trim())
+            .join("stderr.log"),
+    )
+    .unwrap();
+    assert_eq!(stderr, "stream ended mid-document\n");
+
+    let completed = fixture
+        .channel_events()
+        .into_iter()
+        .find(|event| {
+            event.get("type").and_then(serde_yaml_ng::Value::as_str) == Some("worker.completed")
+        })
+        .expect("worker.completed recorded");
+    assert_eq!(
+        completed
+            .get("payload")
+            .and_then(|payload| payload.get("result"))
+            .and_then(serde_yaml_ng::Value::as_str),
+        Some("failed")
+    );
+}
+
+/// (c) A declared `stream-json` worker's mixed stream: JSON lines become
+/// structured events, unparseable lines degrade to text, and nothing in the
+/// stream can fail the run.
+#[test]
+fn declared_stream_json_worker_normalizes_a_mixed_stream_tolerantly() {
+    let fixture = Fixture::new("stream-json");
+    fixture.configure("stream-json", "stream-json");
+
+    let output = fixture.run();
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let run = fixture.latest_run();
+    assert!(fs::read_to_string(run.join("result.json"))
+        .unwrap()
+        .contains("stream worker wrote its own result file"));
+    let record = fixture.run_record();
+    assert!(
+        record.get("result_recovered_from_stdout").is_none(),
+        "a worker that wrote its own result must not be marked as recovered"
+    );
+
+    let messages = fixture
+        .channel_events()
+        .into_iter()
+        .filter(|event| {
+            event.get("type").and_then(serde_yaml_ng::Value::as_str) == Some("worker.message")
+        })
+        .map(|event| event.get("payload").cloned().unwrap_or_default())
+        .collect::<Vec<_>>();
+    let text_of = |payload: &serde_yaml_ng::Value| {
+        payload
+            .get("text")
+            .and_then(serde_yaml_ng::Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    let structured = messages
+        .iter()
+        .find(|payload| text_of(payload) == "structured public update")
+        .unwrap_or_else(|| panic!("no structured message event: {messages:#?}"));
+    assert_eq!(
+        structured
+            .get("json")
+            .and_then(|json| json.get("phase"))
+            .and_then(serde_yaml_ng::Value::as_str),
+        Some("build"),
+        "a structured event must keep the parsed object, not only its prose"
+    );
+    // An object with no renderable text keeps its structure and says so verbatim.
+    assert!(
+        messages.iter().any(|payload| {
+            payload
+                .get("json")
+                .and_then(|json| json.get("checks"))
+                .and_then(serde_yaml_ng::Value::as_u64)
+                == Some(2)
+        }),
+        "{messages:#?}"
+    );
+    // The unparseable line degrades to text instead of failing the stream.
+    assert!(
+        messages
+            .iter()
+            .any(|payload| text_of(payload) == "not { valid } json"),
+        "{messages:#?}"
+    );
+    assert!(
+        messages
+            .iter()
+            .any(|payload| text_of(payload) == "plain progress line"),
+        "{messages:#?}"
+    );
+}


### PR DESCRIPTION
V010-006 output-normalization bundle — the last of the gap-map bundles. Implemented by an Opus subagent to a fixed spec; independently reviewed and re-verified, including on the merge with the file-transport PR.

## What

- `Invocation.output_format: Option<String>` (`text` | `json` | `stream-json`). Undeclared keeps today's behavior exactly; built-in codex/claude-code carry a core-owned vendor stream-json normalizer and reject a disagreeing declaration instead of ignoring it.
- `normalize_worker_output` dispatches by format, not worker id (the id-keyed signature survives as a test-only shim; production paths are format-keyed). stream-json degrades unparseable lines to text; json reads one document per attempt; degradation is never a hard failure. AttemptCapture raw-log preservation untouched.
- Tolerant result fallback: a generic worker declaring json/stream-json whose `result.json` is missing gets its result recovered from the LAST parseable result object in captured stdout — recorded with a durable `result_recovered_from_stdout` provenance marker (recovery is abandoned unless the marker persists first), writing the worker's exact bytes.
- **Fabrication defense found by the process fixture:** every packet embeds a result schema example that parses as a result; an echoing worker got a fabricated outcome in the first draft. Recovery now requires the object to name THIS run_id and task_id, unit-tested against a real compiled packet.

## Evidence

Agent gates: fmt/clippy/all-features all exit 0 (34 targets, 947 passed). RED evidence via six behavior toggles, each restored (validators, dispatch, identity gate, recovery seam, replay parity). Existing codex/claude tests pass unmodified (diff removes only the id-keyed dispatch lines). My re-runs: bundle units 59/59 pre-merge; after merging the file-transport train: union 61 units + 15 process tests across three generic targets green, clippy -D warnings 0, fmt 0. Codename scan: 0.